### PR TITLE
Fix header call for LFG route

### DIFF
--- a/routes/lfg.js
+++ b/routes/lfg.js
@@ -206,7 +206,7 @@ router.delete('/:id/join', isAuthenticated, async (req, res) => {
       res.status(400).send(updatePostError.message);
       return;
     }
-    res.headers('HX-Location', `/lfg`).send();
+    res.header('HX-Location', `/lfg`).send();
     return;
   }
 


### PR DESCRIPTION
## Summary
- fix incorrect method `res.headers` in LFG delete join route

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687985d69880832ea7e132d0a018518c