### PR TITLE
Implement Discord OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Agent Resources
 
 Agent Resources is a web application for managing Enclave characters, finding
-games, and more!
+games, and more! Users can log in with email/password or use their Discord
+account via Supabase OAuth integration.
 
 ## Table of Contents
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -194,6 +194,17 @@ const App = (function (document, supabase, htmx, FullCalendar) {
     }
   };
 
+  const signInWithDiscord = async () => {
+    try {
+      const { error } = await supabaseClient.auth.signInWithOAuth({
+        provider: 'discord'
+      });
+      if (error) throw error;
+    } catch (error) {
+      _displayError(error.message);
+    }
+  };
+
   const renderCalendar = () => {
     const calendarEl = htmx.find('#calendar');
     if (calendarEl) {
@@ -235,6 +246,7 @@ const App = (function (document, supabase, htmx, FullCalendar) {
     init,
     signIn,
     signUp,
+    signInWithDiscord,
     signOut,
     renderCalendar
   };

--- a/views/partials/signin-form.handlebars
+++ b/views/partials/signin-form.handlebars
@@ -18,6 +18,11 @@
         <button class="button is-primary" type="submit">Sign In</button>
       </div>
     </div>
+    <div class="field mt-2">
+      <div class="control">
+        <button class="button is-link" type="button" onclick="App.signInWithDiscord()">Login with Discord</button>
+      </div>
+    </div>
   </form>
   <p class="mt-4">
     Don't have an account?


### PR DESCRIPTION
## Summary
- allow signing in with Discord by using Supabase's OAuth
- add button on sign-in form to trigger Discord login
- mention Discord login option in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b1d3e1d1c832e9e52d520a0af8c44