### PR TITLE
Fix Unicode characters in names

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const exphbs = require('express-handlebars');
 const helpers = require('handlebars-helpers')();
-const { times, date_tz, calendar_link, getTotalV1MissionsNeeded, getTotalV2MissionsNeeded } = require('./util/handlebars');
+const { times, date_tz, calendar_link, encodeURIComponentH, getTotalV1MissionsNeeded, getTotalV2MissionsNeeded } = require('./util/handlebars');
 const range = require('handlebars-helper-range');
 const path = require('path');
 require('dotenv').config();
@@ -31,6 +31,7 @@ app.engine('handlebars', exphbs.engine({
       range,
       date_tz,
       calendar_link,
+      encodeURIComponentH,
       getTotalV1MissionsNeeded,
       getTotalV2MissionsNeeded
   }

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -79,7 +79,7 @@ router.post('/import', isAuthenticated, async (req, res) => {
   const { inputText } = req.body;
   try {
     const character = await processCharacterImport(inputText, profile);
-    res.header('HX-Location', `/characters/${character.id}/${character.name}`).send();
+    res.header('HX-Location', `/characters/${character.id}/${encodeURIComponent(character.name)}`).send();
   } catch (error) {
     res.status(400).send(error.message);
   }
@@ -160,6 +160,7 @@ router.get('/:id/:name?', authOptional, async (req, res) => {
     } else {
       const { data: recentMissions } = await getCharacterRecentMissions(id);
       res.render('character', {
+        title: character.name,
         profile,
         character,
         recentMissions,
@@ -181,7 +182,7 @@ router.put('/:id/:name?', isAuthenticated, async (req, res) => {
   if (error) {
     res.status(400).send(error.message);
   } else {
-    res.header('HX-Location', `/characters/${id}/${data.name}`).send();
+    res.header('HX-Location', `/characters/${id}/${encodeURIComponent(data.name)}`).send();
   }
 });
 

--- a/util/handlebars.js
+++ b/util/handlebars.js
@@ -21,6 +21,10 @@ const date_tz = function (datetime, format, timezone) {
   return moment.utc(datetime).tz(timezone).format(format);
 }
 
+const encodeURIComponentH = function (str) {
+  return encodeURIComponent(str);
+}
+
 const calendar_link = function (platform, start, title, description) {
   const end = moment(start).add(3, 'hour').toDate();
   const eventData = {
@@ -59,6 +63,7 @@ module.exports = {
   times,
   date_tz,
   calendar_link,
+  encodeURIComponentH,
   getTotalV1MissionsNeeded,
   getTotalV2MissionsNeeded
 }

--- a/views/character-form.handlebars
+++ b/views/character-form.handlebars
@@ -1,7 +1,7 @@
 <h2 class="title is-3">{{#if isNew}}Create New Character{{else}}Edit Character{{/if}}</h2>
 {{#unless isNew}}
 <div class="buttons">
-  <a href="/characters/{{character.id}}/{{character.name}}" class="button is-primary">View Character</a>
+  <a href="/characters/{{character.id}}/{{encodeURIComponentH character.name}}" class="button is-primary">View Character</a>
 </div>
 {{/unless}}
 

--- a/views/character-list.handlebars
+++ b/views/character-list.handlebars
@@ -23,7 +23,7 @@
             <td><span class="title is-4">{{this.name}}</span></td>
             <td>
               <div class="buttons are-small">
-                <a href="/characters/{{this.id}}/{{this.name}}" class="button is-secondary">View</a>
+                <a href="/characters/{{this.id}}/{{encodeURIComponentH this.name}}" class="button is-secondary">View</a>
                 <a href="/characters/{{this.id}}/edit" class="button is-warning">Edit</a>
                 <button class="button is-danger" hx-delete="/characters/{{this.id}}" hx-target="closest tr"
                   hx-swap="outerHTML" hx-confirm="Are you sure you want to delete this character?">Delete</button>

--- a/views/lfg-post.handlebars
+++ b/views/lfg-post.handlebars
@@ -71,7 +71,7 @@
           {{#if this.characters}}
           <tr>
             <td>
-              <a href="/characters/{{this.characters.id}}/{{this.characters.name}}">{{this.characters.name}}</a>
+              <a href="/characters/{{this.characters.id}}/{{encodeURIComponentH this.characters.name}}">{{this.characters.name}}</a>
             </td>
             <td>{{this.characters.class}}</td>
             <td>{{this.characters.level}}</td>

--- a/views/partials/character-search-results.handlebars
+++ b/views/partials/character-search-results.handlebars
@@ -14,7 +14,7 @@
         <div class="container mt-4">
           <p class="title is-4">{{this.name}}</p>
           <div class="content">
-            <a href="/characters/{{this.id}}/{{this.name}}" class="button is-primary is-fullwidth">
+            <a href="/characters/{{this.id}}/{{encodeURIComponentH this.name}}" class="button is-primary is-fullwidth">
               View Character
             </a>
           </div>

--- a/views/partials/head.handlebars
+++ b/views/partials/head.handlebars
@@ -2,7 +2,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="htmx-config" content='{"includeIndicatorStyles": false}'>
-  <title>Agent Resources</title>
+  <title>{{#if title}}{{title}} - Agent Resources{{else}}Agent Resources{{/if}}</title>
   <link rel="icon" type="image/x-icon" href="/img/favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
   <link rel="stylesheet" href="https://jenil.github.io/bulmaswatch/lux/bulmaswatch.min.css">


### PR DESCRIPTION
## Summary
- add encodeURIComponentH helper for safe URL generation
- use dynamic page titles
- encode character names in links and redirects
- pass character name to page titles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b835ea694832eaeb662d84857bfff