### PR TITLE
feat: add magic link login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -18,4 +18,8 @@ router.get('/signup-form', (req, res) => {
   res.render('partials/signup-form', { layout: false });
 });
 
+router.get('/update-password-form', (req, res) => {
+  res.render('partials/update-password-form', { layout: false });
+});
+
 module.exports = router;

--- a/views/partials/signin-form.handlebars
+++ b/views/partials/signin-form.handlebars
@@ -21,6 +21,9 @@
         <button class="button is-link" type="button" hx-on:click="App.sendSignInLink(event)">Send Magic Link</button>
       </div>
     </div>
+    <p class="mt-2">
+      <a hx-on:click="App.sendPasswordReset(event)">Forgot password?</a>
+    </p>
   </form>
   <p class="mt-4">
     Don't have an account?

--- a/views/partials/update-password-form.handlebars
+++ b/views/partials/update-password-form.handlebars
@@ -1,0 +1,16 @@
+<div id="auth-form">
+  <h2 class="title is-4">Reset Password</h2>
+  <form id="update-password" method="POST" hx-on:submit="htmx.trigger('#update-password', 'htmx:abort'); App.updatePassword(event);">
+    <div class="field">
+      <label class="label">New Password</label>
+      <div class="control">
+        <input class="input" type="password" name="password" placeholder="New Password" required>
+      </div>
+    </div>
+    <div class="field">
+      <div class="control">
+        <button class="button is-primary" type="submit">Update Password</button>
+      </div>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- keep password-based sign-in and sign-up while adding optional magic link buttons
- add helpers to send Supabase magic links without removing existing password flows
- introduce password reset via email and in-app update form

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689159352868832e8ba1175fc6e142d7