### PR TITLE
Refactor character writes into transactional service

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+Describe the user-visible or maintenance outcome.
+
+## Validation
+
+- [ ] `bun run check`
+- [ ] `bun run test`
+- [ ] `bun run test:http` (when routes changed)
+- [ ] `bun run test:integration` (when database writes or migrations changed)
+
+## Database and risk
+
+- [ ] No migration required
+- [ ] Migration added and local rollback/repair considerations documented
+- [ ] Authorization, sensitive data, and compatibility impacts reviewed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run check
+      - run: bun run test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,22 @@
+name: Local Supabase integration
+
+on:
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: supabase/setup-cli@v1
+      - run: bun install --frozen-lockfile
+      - run: supabase start
+      - run: |
+          eval "$(supabase status -o env)"
+          SUPABASE_URL="$API_URL" \
+          SUPABASE_PUBLISHABLE_KEY="$ANON_KEY" \
+          SUPABASE_SECRET_KEY="$SERVICE_ROLE_KEY" \
+          SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY" \
+          SUPABASE_DB_URL="$DB_URL" \
+          bun run test:integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Local workflow
+
+Use Bun for the application and test commands. Install dependencies with
+`bun install`, copy `.env.dist` to `.env`, then run `bun run setup`.
+
+Run `bun run check` and `bun run test` before opening a pull request. HTTP tests are separate:
+`bun run test:http`. Database integration tests require a local Supabase stack
+and are opt-in: `supabase start` followed by `bun run test:integration`.
+
+## Change checklist
+
+- Keep route URLs, response shapes, and templates stable unless the change
+  explicitly includes a product/API change.
+- Add or update focused tests for changed behavior.
+- Put schema changes in a new timestamped `supabase/migrations/` file. Do not
+  edit an applied migration or add a parallel schema file.
+- Run the relevant test tier. Run local integration tests for database writes.
+- Document migrations, rollback considerations, and user-visible effects in
+  the pull request.
+
+## Ownership and review
+
+Changes to `models/character.js`, `services/character/`, Supabase migrations,
+authentication, or authorization need review from a maintainer familiar with
+that domain. Keep cross-domain refactors incremental and independently
+revertible.
+
+## Security
+
+Do not report vulnerabilities in public issues. Follow [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security policy
+
+Report suspected vulnerabilities privately to the project maintainers. Include
+reproduction steps, impact, and any suggested mitigation. Do not include
+secrets, access tokens, or production user data in the report.
+
+Please allow maintainers time to investigate and deploy a fix before public
+disclosure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,19 @@
+# Architecture overview
+
+The application is an Express server using CommonJS modules and Supabase for
+persistence. Routes translate HTTP requests into model/service calls and keep
+the established page and API response contracts.
+
+`models/` owns Supabase queries and persistence adapters. Domain services own
+application rules and orchestration. `services/character/` is the reference
+boundary: pure input normalization lives alongside a `CharacterService`, while
+`models/character.js` supplies the current Supabase adapter for compatibility.
+
+Tests are tiered:
+
+- `bun run test`: isolated unit and model tests; no database or HTTP listener.
+- `bun run test:http`: route tests that bind localhost only.
+- `bun run test:integration`: opt-in tests against local Supabase only.
+
+Schema changes belong exclusively in `supabase/migrations/`. Each migration
+must be independently reviewable and have a local-Supabase verification path.

--- a/models/character-atomic.integration.test.js
+++ b/models/character-atomic.integration.test.js
@@ -1,0 +1,83 @@
+// Local-Supabase integration coverage for the transactional character RPC.
+const { test, expect, afterAll } = require('bun:test');
+const { Client } = require('pg');
+const { supabaseAdmin } = require('./_base');
+const { createCharacter } = require('./character');
+
+const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const email = `character-atomic-${suffix}@example.test`;
+let authUserId;
+let profile;
+let characterClass;
+const db = new Client({
+  connectionString: process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+});
+
+const stats = {
+  vitality: 1, might: 1, resilience: 1, spirit: 1, arcane: 1, will: 1,
+  sensory: 1, reflex: 1, vigor: 1, skill: 1, intelligence: 1, luck: 1,
+  level: 1, completed_missions: 0, commissary_reward: 0
+};
+
+const setup = async () => {
+  if (profile) return;
+  await db.connect();
+  const { rows } = await db.query(
+    `insert into auth.users (id, aud, role, email, email_confirmed_at, created_at, updated_at, raw_app_meta_data, raw_user_meta_data)
+     values (gen_random_uuid(), 'authenticated', 'authenticated', $1, now(), now(), now(), '{}'::jsonb, '{}'::jsonb)
+     returning id`,
+    [email]
+  );
+  authUserId = rows[0].id;
+  ({ data: profile } = await supabaseAdmin.from('profiles')
+    .insert({ user_id: authUserId, name: `Atomic ${suffix}`, is_public: true, timezone: 'UTC' })
+    .select()
+    .single());
+  ({ data: characterClass } = await supabaseAdmin.from('classes')
+    .insert({ name: `Atomic Class ${suffix}`, rules_version: 'v1', is_public: true, gear: [], abilities: [] })
+    .select()
+    .single());
+};
+
+afterAll(async () => {
+  if (profile?.id) await db.query('delete from characters where creator_id = $1', [profile.id]);
+  if (profile?.id) await db.query('delete from profiles where id = $1', [profile.id]);
+  if (characterClass?.id) await db.query('delete from classes where id = $1', [characterClass.id]);
+  if (authUserId) await db.query('delete from auth.users where id = $1', [authUserId]);
+  await db.end();
+});
+
+const input = (name, gearClassId = characterClass.id) => ({
+  ...stats,
+  name,
+  class: characterClass.name,
+  class_id: characterClass.id,
+  trait0: 'Brave',
+  gear: [{ name: 'Atomic Gear', class_id: gearClassId }],
+  abilities: [{ name: 'Atomic Ability', class_id: characterClass.id }]
+});
+
+test('atomic character create writes parent and children together', async () => {
+  await setup();
+  const { data, error } = await createCharacter(input(`Atomic success ${suffix}`), profile);
+  expect(error).toBeNull();
+  expect(data.id).toBeTruthy();
+
+  const [{ data: traits }, { data: gear }, { data: abilities }] = await Promise.all([
+    supabaseAdmin.from('traits').select('*').eq('character_id', data.id),
+    supabaseAdmin.from('class_gear').select('*').eq('character_id', data.id),
+    supabaseAdmin.from('class_abilities').select('*').eq('character_id', data.id)
+  ]);
+  expect(traits).toHaveLength(1);
+  expect(gear).toHaveLength(1);
+  expect(abilities).toHaveLength(1);
+});
+
+test('atomic character create rolls back the parent when a child write fails', async () => {
+  await setup();
+  const name = `Atomic rollback ${suffix}`;
+  const { error } = await createCharacter(input(name, '00000000-0000-4000-8000-000000000001'), profile);
+  expect(error).toBeTruthy();
+  const { data } = await supabaseAdmin.from('characters').select('id').eq('name', name);
+  expect(data).toHaveLength(0);
+});

--- a/models/character.js
+++ b/models/character.js
@@ -1,12 +1,19 @@
 const { supabase, supabaseAdmin } = require('./_base');
 const { getClasses, getClass, buildClassContentLookupMaps } = require('./class');
-const { sanitizeUrlFields } = require('../util/url');
-const { escapeLikePattern, validateAbilityPerks } = require('../util/validate');
+const { escapeLikePattern } = require('../util/validate');
 const { statList } = require('../util/enclave-consts');
 const { deriveCharacterTotals } = require('../util/character-derived');
 const { remapPerkAbilityIds, remapPerkAbilityIdsByName } = require('../util/ability-perks');
 const { diffChildRows, resolveCompoundLinks } = require('../util/reconcile');
 const { listOffscreenMissions } = require('./offscreen-mission');
+const {
+  cloneInput,
+  normalizeCharacterInput,
+  normalizeGearItems,
+  normalizeAbilityItems,
+  normalizeAbilityPerks
+} = require('../services/character/input');
+const { CharacterService } = require('../services/character/service');
 
 // Resolve the rules version a character should be rendered/validated against.
 // Inherits from the linked class; falls back to 'v1' when no class is linked
@@ -19,6 +26,32 @@ const effectiveRulesVersion = async (classId, client = supabase) => {
   } catch (_) {
     return 'v1';
   }
+};
+
+// This remains the database-facing part of class preparation. The pure input
+// module receives the resulting rules version and never needs Supabase.
+const resolveCharacterClassReference = async (input) => {
+  const data = cloneInput(input);
+  if (!data.class_id && data.class) {
+    try {
+      let lookup = await getClasses({ name: data.class });
+      if (!lookup || !Array.isArray(lookup.data) || lookup.data.length === 0) {
+        lookup = await getClasses({ name: data.class, is_public: true });
+      }
+      if (lookup && Array.isArray(lookup.data) && lookup.data.length > 0) data.class_id = lookup.data[0].id;
+    } catch (_) {
+      // Class lookup is intentionally non-fatal for the existing create/edit flow.
+    }
+  }
+  if (data.class_id && !data.class) {
+    try {
+      const { data: cls } = await getClass(data.class_id);
+      if (cls && cls.name) data.class = cls.name;
+    } catch (_) {
+      // Keep the submitted reference when a catalog lookup is unavailable.
+    }
+  }
+  return data;
 };
 
 const findUpgradeTargetsFor = async (classId, client = supabase) => {
@@ -120,114 +153,18 @@ const getCharacter = async (id, client = supabase) => {
   return { data, error };
 }
 
-const createCharacter = async (characterReq, profile) => {
-  characterReq.creator_id = profile.id;
-
-  const v2OnlyFields = ['quirks', 'accessories', 'ability_perks'];
-  const v1OnlyFields = ['perks', 'additional_gear'];
+const createCharacterPersistenceFlow = async (characterReq, profile) => {
+  // Preserve the historical ordering: create determines the version before a
+  // class-name lookup. All mutations below apply only to this local copy.
   const linkedVersion = await effectiveRulesVersion(characterReq.class_id);
-  if (linkedVersion !== 'v2') {
-    for (const k of v2OnlyFields) delete characterReq[k];
-  } else {
-    for (const k of v1OnlyFields) delete characterReq[k];
-  }
-
-  // Ensure class_id is populated from the class name when missing
-  if (!characterReq.class_id && characterReq.class) {
-    try {
-      let lookup = await getClasses({ name: characterReq.class });
-      if ((!lookup || !Array.isArray(lookup.data) || lookup.data.length === 0)) {
-        lookup = await getClasses({ name: characterReq.class, is_public: true });
-      }
-      if (lookup && Array.isArray(lookup.data) && lookup.data.length > 0) {
-        characterReq.class_id = lookup.data[0].id;
-      }
-    } catch (_) {
-      // Non-fatal: if lookup fails, proceed without blocking character creation
-    }
-  }
-
-  // Ensure class name is populated from class_id when missing
-  if (characterReq.class_id && !characterReq.class) {
-    try {
-      const { data: cls } = await getClass(characterReq.class_id);
-      if (cls && cls.name) {
-        characterReq.class = cls.name;
-      }
-    } catch (_) {
-      // ignore
-    }
-  }
-
-  // handle personality traits
-  const traitFields = [characterReq.trait0, characterReq.trait1, characterReq.trait2];
-  ['trait0', 'trait1', 'trait2'].forEach(trait => delete characterReq[trait]);
-  
-  // Extract v2 ability_perks before insert; we persist them after the row exists.
-  const abilityPerks = characterReq.ability_perks;
-  delete characterReq.ability_perks;
-
-  if (linkedVersion === 'v2') {
-    const v = validateAbilityPerks(normalizeAbilityPerks(abilityPerks));
-    if (!v.ok) {
-      return { data: null, error: v.errors.join(' ') };
-    }
-  }
-
-  // handle class gear
-  const classGear = characterReq.gear;
-  delete characterReq.gear;
-
-  // handle class abilities
-  const classAbilities = characterReq.abilities;
-  delete characterReq.abilities;
-
-  // handle common items - normalize to array of non-empty strings
-  if (characterReq.common_items) {
-    const items = Array.isArray(characterReq.common_items)
-      ? characterReq.common_items
-      : [characterReq.common_items];
-    characterReq.common_items = items
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(item => item.length > 0);
-  } else {
-    characterReq.common_items = [];
-  }
-
-  // handle is_public
-  if (characterReq.is_public == 'on') {
-    characterReq.is_public = true;
-  } else {
-    characterReq.is_public = false;
-  }
-
-  // handle hide_from_search
-  if (characterReq.hide_from_search == 'on') {
-    characterReq.hide_from_search = true;
-  } else {
-    characterReq.hide_from_search = false;
-  }
-
-  // handle creator_mode (wizard mode label). Reject anything outside the
-  // allowed set; treat empty/missing as NULL (Expert-Mode-built characters).
-  const allowedModes = ['advent', 'aspiring', 'aspirant'];
-  if (characterReq.creator_mode == null || characterReq.creator_mode === '') {
-    characterReq.creator_mode = null;
-  } else if (!allowedModes.includes(characterReq.creator_mode)) {
-    return { data: null, error: `Invalid creator_mode: ${characterReq.creator_mode}` };
-  }
-
-  // normalize v2 JSONB fields before insert
-  if (linkedVersion === 'v2') {
-    characterReq.quirks = normalizeNamedJsonbList(characterReq.quirks);
-    characterReq.accessories = normalizeNamedJsonbList(characterReq.accessories);
-  }
-
-  // sanitize URL fields before insert
-  sanitizeUrlFields(characterReq, ['image_url']);
+  const resolvedInput = await resolveCharacterClassReference(characterReq);
+  const normalized = normalizeCharacterInput(resolvedInput, { rulesVersion: linkedVersion, creatorId: profile.id });
+  if (normalized.error) return { data: null, error: normalized.error };
+  const { data: characterInput, childData } = normalized;
+  const { traits: traitFields, abilityPerks, classGear, classAbilities } = childData;
 
   // create character (authz: creator_id is set server-side to profile.id above)
-  const { data, error } = await supabaseAdmin.from('characters').insert(characterReq).select();
+  const { data, error } = await supabaseAdmin.from('characters').insert(characterInput).select();
   if (error) {
     console.error(error);
     return { data, error };
@@ -281,7 +218,7 @@ const createCharacter = async (characterReq, profile) => {
   return { data: character, error };
 }
 
-const updateCharacter = async (id, characterReq, profile) => {
+const updateCharacterPersistenceFlow = async (id, characterReq, profile) => {
   // Use admin to read for the ownership probe: the anon client can't see
   // private rows under RLS, which would 404 a user trying to edit their own
   // private character (PGRST116). Authz is enforced by the creator_id check
@@ -290,119 +227,39 @@ const updateCharacter = async (id, characterReq, profile) => {
   if (characterError) return { data: null, error: characterError };
   if (characterData.creator_id != profile.id) return { data: null, error: 'Unauthorized' };
 
-  const v2OnlyFields = ['quirks', 'accessories', 'ability_perks'];
   // Pre-normalization strip: remove v2-only fields early if the submitted class_id
   // is already non-v2. linkedVersion is recomputed below after class_id is finalized.
   let linkedVersion = await effectiveRulesVersion(characterReq.class_id);
+  let preparedInput = cloneInput(characterReq);
   if (linkedVersion !== 'v2') {
-    for (const k of v2OnlyFields) delete characterReq[k];
+    for (const k of ['quirks', 'accessories', 'ability_perks']) delete preparedInput[k];
   }
-
-  // Ensure class_id is populated from the class name when missing or when class changed
-  if (!characterReq.class_id && characterReq.class) {
-    try {
-      let lookup = await getClasses({ name: characterReq.class });
-      if ((!lookup || !Array.isArray(lookup.data) || lookup.data.length === 0)) {
-        lookup = await getClasses({ name: characterReq.class, is_public: true });
-      }
-      if (lookup && Array.isArray(lookup.data) && lookup.data.length > 0) {
-        characterReq.class_id = lookup.data[0].id;
-      }
-    } catch (_) {
-      // Non-fatal: if lookup fails, proceed with remaining updates
-    }
-  }
-
-  // Ensure class name is populated from class_id when missing
-  if (characterReq.class_id && !characterReq.class) {
-    try {
-      const { data: cls } = await getClass(characterReq.class_id);
-      if (cls && cls.name) {
-        characterReq.class = cls.name;
-      }
-    } catch (_) {
-      // ignore
-    }
-  }
+  preparedInput = await resolveCharacterClassReference(preparedInput);
 
   // Recompute linkedVersion now that class_id is fully resolved — the name→id
   // lookup above can change class_id, which changes the effective rules version.
-  linkedVersion = await effectiveRulesVersion(characterReq.class_id);
-
-  // handle personality traits
-  const traitFields = [characterReq.trait0, characterReq.trait1, characterReq.trait2];
-  ['trait0', 'trait1', 'trait2'].forEach(trait => delete characterReq[trait]);
+  linkedVersion = await effectiveRulesVersion(preparedInput.class_id);
+  const normalized = normalizeCharacterInput(preparedInput, {
+    rulesVersion: linkedVersion,
+    normalizeAutoCalculate: true
+  });
+  if (normalized.error) return { data: null, error: normalized.error };
+  const { data: characterInput, childData } = normalized;
+  const { traits: traitFields, abilityPerks, classGear, classAbilities } = childData;
   delete characterData.traits;
-
-  // Extract v2 ability_perks before update; we persist them after the row exists.
-  const abilityPerks = characterReq.ability_perks;
-  delete characterReq.ability_perks;
-
-  if (linkedVersion === 'v2') {
-    const v = validateAbilityPerks(normalizeAbilityPerks(abilityPerks));
-    if (!v.ok) {
-      return { data: null, error: v.errors.join(' ') };
-    }
-  }
-
-  // handle class gear
-  const classGear = characterReq.gear;
-  delete characterReq.gear;
   delete characterData.gear;
-
-  // handle class abilities
-  const classAbilities = characterReq.abilities;
   // Snapshot existing ability rows: setCharacterAbilities replaces them with
   // fresh UUIDs, but submitted ability_perks reference the old row ids (the
   // form bakes them into hidden inputs at render time). We remap old→new by
   // name+class_id below before persisting perks.
   const previousAbilities = Array.isArray(characterData.abilities) ? characterData.abilities : [];
-  delete characterReq.abilities;
   delete characterData.abilities;
-
-  // handle common items - normalize to array of non-empty strings
-  if (characterReq.common_items) {
-    const items = Array.isArray(characterReq.common_items)
-      ? characterReq.common_items
-      : [characterReq.common_items];
-    characterReq.common_items = items
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(item => item.length > 0);
-  } else {
-    characterReq.common_items = [];
-  }
-
-  // handle is_public
-  if (characterReq.is_public == 'on') {
-    characterReq.is_public = true;
-  } else {
-    characterReq.is_public = false;
-  }
-
-  // handle hide_from_search
-  if (characterReq.hide_from_search == 'on') {
-    characterReq.hide_from_search = true;
-  } else {
-    characterReq.hide_from_search = false;
-  }
-
-  // handle creator_mode (wizard mode label). Reject anything outside the
-  // allowed set; treat empty/missing as NULL.
-  const allowedModes = ['advent', 'aspiring', 'aspirant'];
-  if (characterReq.creator_mode == null || characterReq.creator_mode === '') {
-    characterReq.creator_mode = null;
-  } else if (!allowedModes.includes(characterReq.creator_mode)) {
-    return { data: null, error: `Invalid creator_mode: ${characterReq.creator_mode}` };
-  }
-
-  // handle auto_calculate
-  characterReq.auto_calculate = characterReq.auto_calculate === 'on' || characterReq.auto_calculate === true;
 
   // Auto-calculate: when enabled, recompute level/completed_missions/commissary_reward
   // from the submitted in-flight payload (gear, common_items, class_id) and the
   // character's mission history. Server is authoritative — submitted values for
   // these three fields are ignored when the flag is on.
-  if (characterReq.auto_calculate) {
+  if (characterInput.auto_calculate) {
     // Resolve gear strings ("ClassName::GearName") to objects with class_id so
     // on-class/off-class classification matches the persisted shape.
     const submittedGear = Array.isArray(classGear) ? classGear : (classGear ? [classGear] : []);
@@ -438,31 +295,22 @@ const updateCharacter = async (id, characterReq, profile) => {
 
     const derived = deriveCharacterTotals({
       character: {
-        class_id: characterReq.class_id,
+        class_id: characterInput.class_id,
         gear: resolvedGear,
-        common_items: characterReq.common_items
+        common_items: characterInput.common_items
       },
       realMissions: realMissions || [],
       offscreenMissions: offscreenMissions || [],
       rulesVersion: linkedVersion
     });
 
-    characterReq.level = derived.level;
-    characterReq.completed_missions = derived.completed_missions;
-    characterReq.commissary_reward = derived.commissary_reward;
+    characterInput.level = derived.level;
+    characterInput.completed_missions = derived.completed_missions;
+    characterInput.commissary_reward = derived.commissary_reward;
   }
-
-  // normalize v2 JSONB fields before update
-  if (linkedVersion === 'v2') {
-    characterReq.quirks = normalizeNamedJsonbList(characterReq.quirks);
-    characterReq.accessories = normalizeNamedJsonbList(characterReq.accessories);
-  }
-
-  // sanitize URL fields before update
-  sanitizeUrlFields(characterReq, ['image_url']);
 
   // update character (authz: creator_id check above + filter below)
-  const { data, error } = await supabaseAdmin.from('characters').update(characterReq).eq('id', id).eq('creator_id', profile.id).select();
+  const { data, error } = await supabaseAdmin.from('characters').update(characterInput).eq('id', id).eq('creator_id', profile.id).select();
   if (error) {
     console.error(error);
     return { data, error };
@@ -635,59 +483,6 @@ const getCharacterGear = async (id, client = supabase) => {
   return { data: mergedGear, error: null };
 }
 
-const normalizeNamedJsonbList = (input) => {
-  if (!Array.isArray(input)) return [];
-  return input
-    .map(item => {
-      if (!item) return null;
-      if (typeof item === 'string') {
-        const trimmed = item.trim();
-        return trimmed ? { name: trimmed } : null;
-      }
-      if (typeof item === 'object' && typeof item.name === 'string') {
-        const name = item.name.trim();
-        if (!name) return null;
-        const out = { name };
-        if (typeof item.description === 'string' && item.description.trim()) {
-          out.description = item.description.trim();
-        }
-        return out;
-      }
-      return null;
-    })
-    .filter(Boolean);
-};
-
-const normalizeGearItems = (gear) => {
-  if (!Array.isArray(gear)) {
-    return [];
-  }
-  return gear
-    .map(item => {
-      if (!item) return null;
-      if (typeof item === 'string') {
-        const trimmed = item.trim();
-        if (!trimmed) return null;
-        // Handle "ClassName::GearName" format from searchable selects
-        if (trimmed.includes('::')) {
-          const [, gearName] = trimmed.split('::');
-          return gearName ? { name: gearName.trim() } : null;
-        }
-        return { name: trimmed };
-      }
-      if (typeof item === 'object' && typeof item.name === 'string') {
-        const trimmed = item.name.trim();
-        if (!trimmed) return null;
-        return {
-          ...item,
-          name: trimmed
-        };
-      }
-      return null;
-    })
-    .filter(Boolean);
-};
-
 const setCharacterGear = async (id, gear) => {
   const normalizedGear = normalizeGearItems(gear);
 
@@ -777,56 +572,6 @@ const getCharacterAbilityPerks = async (id) => {
     .order('position', { ascending: true });
   if (error) return { data: null, error };
   return { data: Array.isArray(data) ? data : [], error: null };
-};
-
-const normalizeAbilityItems = (abilities) => {
-  if (!Array.isArray(abilities)) {
-    return [];
-  }
-  return abilities
-    .map(item => {
-      if (!item) return null;
-      if (typeof item === 'string') {
-        const trimmed = item.trim();
-        if (!trimmed) return null;
-        // Handle "ClassName::AbilityName" format from searchable selects
-        if (trimmed.includes('::')) {
-          const [, abilityName] = trimmed.split('::');
-          return abilityName ? { name: abilityName.trim() } : null;
-        }
-        return { name: trimmed };
-      }
-      if (typeof item === 'object' && typeof item.name === 'string') {
-        const trimmed = item.name.trim();
-        if (!trimmed) return null;
-        return {
-          ...item,
-          name: trimmed
-        };
-      }
-      return null;
-    })
-    .filter(Boolean);
-};
-
-const normalizeAbilityPerks = (perks) => {
-  if (!Array.isArray(perks)) return [];
-  return perks
-    .map((p, i) => {
-      if (!p || typeof p !== 'object') return null;
-      const text = typeof p.text === 'string' ? p.text.trim() : '';
-      const classAbilityId = p.class_ability_id || null;
-      if (!text || !classAbilityId) return null;
-      const position = Number.isFinite(Number(p.position)) ? Number(p.position) : i;
-      const compoundsWith = p.compounds_with_id || p.compounds_with || null;
-      return {
-        class_ability_id: classAbilityId,
-        text,
-        position,
-        compounds_with: compoundsWith
-      };
-    })
-    .filter(Boolean);
 };
 
 const setCharacterPerks = async (characterId, perks) => {
@@ -1267,6 +1012,18 @@ const getCharacterForAgent = async (id, actor = {}) => {
   );
   return { data: serialized, error: null };
 };
+
+// Compatibility adapter: routes and importers continue using this model's
+// public functions while all character writes now cross the service boundary.
+// The adapter can be replaced by an RPC-backed implementation without changing
+// those callers or the service contract.
+const characterService = new CharacterService({
+  createCharacter: createCharacterPersistenceFlow,
+  updateCharacter: updateCharacterPersistenceFlow
+});
+
+const createCharacter = (input, actor) => characterService.createCharacter(input, actor);
+const updateCharacter = (id, input, actor) => characterService.updateCharacter(id, input, actor);
 
 module.exports = {
   getOwnCharacters,

--- a/models/character.js
+++ b/models/character.js
@@ -2,17 +2,8 @@ const { supabase, supabaseAdmin } = require('./_base');
 const { getClasses, getClass, buildClassContentLookupMaps } = require('./class');
 const { escapeLikePattern } = require('../util/validate');
 const { statList } = require('../util/enclave-consts');
-const { deriveCharacterTotals } = require('../util/character-derived');
-const { remapPerkAbilityIds, remapPerkAbilityIdsByName } = require('../util/ability-perks');
-const { diffChildRows, resolveCompoundLinks } = require('../util/reconcile');
 const { listOffscreenMissions } = require('./offscreen-mission');
-const {
-  cloneInput,
-  normalizeCharacterInput,
-  normalizeGearItems,
-  normalizeAbilityItems,
-  normalizeAbilityPerks
-} = require('../services/character/input');
+const { cloneInput } = require('../services/character/input');
 const { CharacterService } = require('../services/character/service');
 
 // Resolve the rules version a character should be rendered/validated against.
@@ -153,223 +144,6 @@ const getCharacter = async (id, client = supabase) => {
   return { data, error };
 }
 
-const createCharacterPersistenceFlow = async (characterReq, profile) => {
-  // Preserve the historical ordering: create determines the version before a
-  // class-name lookup. All mutations below apply only to this local copy.
-  const linkedVersion = await effectiveRulesVersion(characterReq.class_id);
-  const resolvedInput = await resolveCharacterClassReference(characterReq);
-  const normalized = normalizeCharacterInput(resolvedInput, { rulesVersion: linkedVersion, creatorId: profile.id });
-  if (normalized.error) return { data: null, error: normalized.error };
-  const { data: characterInput, childData } = normalized;
-  const { traits: traitFields, abilityPerks, classGear, classAbilities } = childData;
-
-  // create character (authz: creator_id is set server-side to profile.id above)
-  const { data, error } = await supabaseAdmin.from('characters').insert(characterInput).select();
-  if (error) {
-    console.error(error);
-    return { data, error };
-  }
-  if (!data || data.length === 0) {
-    return { data: null, error: 'Character creation returned no rows' };
-  }
-  const character = data[0];
-
-  // set personality traits
-  const { data: traitsSet, error: traitsSetError } = await setCharacterTraits(character.id, traitFields);
-  if (traitsSetError) {
-    console.error(traitsSetError);
-    return { data: null, error: traitsSetError };
-  }
-
-  // set class gear
-  if (classGear) {
-    const { data: gearSet, error: gearSetError } = await setCharacterGear(
-      character.id,
-      classGear
-    );
-    if (gearSetError) {
-      console.error(gearSetError);
-      return { data: null, error: gearSetError };
-    }
-  }
-
-  // set class abilities
-  let newAbilityRows = null;
-  if (classAbilities) {
-    const { data: abilitiesSet, error: abilitiesSetError } = await setCharacterAbilities(character.id, classAbilities);
-    if (abilitiesSetError) {
-      console.error(abilitiesSetError);
-      return { data: null, error: abilitiesSetError };
-    }
-    newAbilityRows = abilitiesSet;
-  }
-
-  if (linkedVersion === 'v2') {
-    // The create form references each perk's ability by NAME (no row ids exist
-    // until the abilities are inserted just above). Remap name -> new row id;
-    // perks whose ability isn't present are dropped.
-    const perksToSave = remapPerkAbilityIdsByName(abilityPerks, newAbilityRows || []);
-    const { error: perksError } = await setCharacterPerks(character.id, perksToSave);
-    if (perksError) {
-      return { data: null, error: perksError };
-    }
-  }
-
-  return { data: character, error };
-}
-
-const updateCharacterPersistenceFlow = async (id, characterReq, profile) => {
-  // Use admin to read for the ownership probe: the anon client can't see
-  // private rows under RLS, which would 404 a user trying to edit their own
-  // private character (PGRST116). Authz is enforced by the creator_id check
-  // immediately below + the .eq('creator_id', ...) filter on the UPDATE.
-  const { data: characterData, error: characterError } = await getCharacter(id, supabaseAdmin);
-  if (characterError) return { data: null, error: characterError };
-  if (characterData.creator_id != profile.id) return { data: null, error: 'Unauthorized' };
-
-  // Pre-normalization strip: remove v2-only fields early if the submitted class_id
-  // is already non-v2. linkedVersion is recomputed below after class_id is finalized.
-  let linkedVersion = await effectiveRulesVersion(characterReq.class_id);
-  let preparedInput = cloneInput(characterReq);
-  if (linkedVersion !== 'v2') {
-    for (const k of ['quirks', 'accessories', 'ability_perks']) delete preparedInput[k];
-  }
-  preparedInput = await resolveCharacterClassReference(preparedInput);
-
-  // Recompute linkedVersion now that class_id is fully resolved — the name→id
-  // lookup above can change class_id, which changes the effective rules version.
-  linkedVersion = await effectiveRulesVersion(preparedInput.class_id);
-  const normalized = normalizeCharacterInput(preparedInput, {
-    rulesVersion: linkedVersion,
-    normalizeAutoCalculate: true
-  });
-  if (normalized.error) return { data: null, error: normalized.error };
-  const { data: characterInput, childData } = normalized;
-  const { traits: traitFields, abilityPerks, classGear, classAbilities } = childData;
-  delete characterData.traits;
-  delete characterData.gear;
-  // Snapshot existing ability rows: setCharacterAbilities replaces them with
-  // fresh UUIDs, but submitted ability_perks reference the old row ids (the
-  // form bakes them into hidden inputs at render time). We remap old→new by
-  // name+class_id below before persisting perks.
-  const previousAbilities = Array.isArray(characterData.abilities) ? characterData.abilities : [];
-  delete characterData.abilities;
-
-  // Auto-calculate: when enabled, recompute level/completed_missions/commissary_reward
-  // from the submitted in-flight payload (gear, common_items, class_id) and the
-  // character's mission history. Server is authoritative — submitted values for
-  // these three fields are ignored when the flag is on.
-  if (characterInput.auto_calculate) {
-    // Resolve gear strings ("ClassName::GearName") to objects with class_id so
-    // on-class/off-class classification matches the persisted shape.
-    const submittedGear = Array.isArray(classGear) ? classGear : (classGear ? [classGear] : []);
-    let resolvedGear = [];
-    if (submittedGear.length > 0) {
-      const { gearNameToClassId } = await buildClassContentLookupMaps();
-      resolvedGear = submittedGear
-        .map(item => {
-          if (!item) return null;
-          if (typeof item === 'string') {
-            const trimmed = item.trim();
-            if (!trimmed) return null;
-            const name = trimmed.includes('::') ? trimmed.split('::')[1].trim() : trimmed;
-            return name ? { name, class_id: gearNameToClassId.get(name) || null } : null;
-          }
-          if (typeof item === 'object' && item.name) {
-            return { name: item.name, class_id: item.class_id || gearNameToClassId.get(item.name) || null };
-          }
-          return null;
-        })
-        .filter(Boolean);
-    }
-
-    const [missionsRes, offscreenRes] = await Promise.all([
-      getCharacterRealMissionsForDerivation(id, supabaseAdmin),
-      listOffscreenMissions({ characterId: id, supabase: supabaseAdmin })
-    ]);
-    if (missionsRes.error || offscreenRes.error) {
-      return { data: null, error: missionsRes.error || offscreenRes.error };
-    }
-    const realMissions = missionsRes.data || [];
-    const offscreenMissions = offscreenRes.data || [];
-
-    const derived = deriveCharacterTotals({
-      character: {
-        class_id: characterInput.class_id,
-        gear: resolvedGear,
-        common_items: characterInput.common_items
-      },
-      realMissions: realMissions || [],
-      offscreenMissions: offscreenMissions || [],
-      rulesVersion: linkedVersion
-    });
-
-    characterInput.level = derived.level;
-    characterInput.completed_missions = derived.completed_missions;
-    characterInput.commissary_reward = derived.commissary_reward;
-  }
-
-  // update character (authz: creator_id check above + filter below)
-  const { data, error } = await supabaseAdmin.from('characters').update(characterInput).eq('id', id).eq('creator_id', profile.id).select();
-  if (error) {
-    console.error(error);
-    return { data, error };
-  }
-  if (!data || data.length === 0) {
-    return { data: null, error: 'Character update returned no rows' };
-  }
-
-  const character = data[0];
-
-  // update traits
-  const { data: traitsSet, error: traitsSetError } = await setCharacterTraits(character.id, traitFields);
-  if (traitsSetError) {
-    console.error(traitsSetError);
-    return { data: null, error: traitsSetError };
-  }
-
-  // update gear
-  if (classGear) {
-    const { data: gearSet, error: gearSetError } = await setCharacterGear(
-      character.id,
-      classGear
-    );
-    if (gearSetError) {
-      console.error(gearSetError);
-      return { data: null, error: gearSetError };
-    }
-  }
-
-  // update abilities
-  let newAbilityRows = null;
-  if (classAbilities) {
-    const { data: abilitiesSet, error: abilitiesSetError } = await setCharacterAbilities(character.id, classAbilities);
-    if (abilitiesSetError) {
-      console.error(abilitiesSetError);
-      return { data: null, error: abilitiesSetError };
-    }
-    newAbilityRows = abilitiesSet;
-  }
-
-  if (linkedVersion === 'v2') {
-    // Abilities are reconciled above: kept abilities retain their row ids, so
-    // the form's perk references pass through remap unchanged. Only abilities
-    // the user swapped out get a different id (their old row is gone), and
-    // remap drops the submitted perks that pointed at them — otherwise the
-    // perk insert would hit a foreign key violation. When abilities weren't
-    // submitted at all, the rows (and ids) are untouched — no remap needed.
-    const perksToSave = newAbilityRows
-      ? remapPerkAbilityIds(abilityPerks, previousAbilities, newAbilityRows)
-      : abilityPerks;
-    const { error: perksError } = await setCharacterPerks(character.id, perksToSave);
-    if (perksError) {
-      return { data: null, error: perksError };
-    }
-  }
-
-  return { data: character, error };
-}
-
 const deleteCharacter = async (id, profile) => {
   // Admin read for the ownership probe — see updateCharacter for the same
   // reasoning. The creator_id JS check + .eq() filter still enforce authz.
@@ -388,55 +162,6 @@ const getCharacterTraits = async (id) => {
   const { data, error } = await supabaseAdmin.from('traits').select('*').eq('character_id', id);
   return { data, error };
 }
-
-// Apply a diffChildRows result: inserts -> updates -> deletes. Deletes run
-// last and target only truly-removed row ids, so a mid-flight failure leaves
-// extra rows rather than missing ones (never a mass delete).
-const applyChildDiff = async (table, characterId, { toInsert, toUpdate, toDelete }) => {
-  if (toInsert.length > 0) {
-    const rows = toInsert.map(fields => ({ character_id: characterId, ...fields }));
-    const { error } = await supabaseAdmin.from(table).insert(rows);
-    if (error) {
-      console.error(error);
-      return { data: null, error };
-    }
-  }
-  for (const { id: rowId, ...changes } of toUpdate) {
-    const { error } = await supabaseAdmin.from(table).update(changes).eq('id', rowId);
-    if (error) {
-      console.error(error);
-      return { data: null, error };
-    }
-  }
-  if (toDelete.length > 0) {
-    const { error } = await supabaseAdmin.from(table).delete().in('id', toDelete).eq('character_id', characterId);
-    if (error) {
-      console.error(error);
-      return { data: null, error };
-    }
-  }
-  return { data: true, error: null };
-};
-
-const setCharacterTraits = async (id, traits) => {
-  // Internal helper: authz is enforced by the calling function (createCharacter/updateCharacter).
-  const { data: existing, error: fetchError } = await supabaseAdmin.from('traits').select('*').eq('character_id', id);
-  if (fetchError) {
-    console.error(fetchError);
-    return { data: null, error: fetchError };
-  }
-
-  // Drop empty/missing slots so we never persist null- or ''-named traits
-  // (the form always submits three non-empty traits; this guards other callers).
-  const desired = (Array.isArray(traits) ? traits : [])
-    .filter(name => name != null && name !== '')
-    .map(name => ({ name }));
-  const diff = diffChildRows(existing, desired, {
-    keyOf: r => r.name,
-    rowFields: item => ({ name: item.name })
-  });
-  return applyChildDiff('traits', id, diff);
-};
 
 const getCharacterGear = async (id, client = supabase) => {
   // Fetch character gear rows
@@ -482,37 +207,6 @@ const getCharacterGear = async (id, client = supabase) => {
 
   return { data: mergedGear, error: null };
 }
-
-const setCharacterGear = async (id, gear) => {
-  const normalizedGear = normalizeGearItems(gear);
-
-  // Internal helper: authz is enforced by the calling function (createCharacter/updateCharacter).
-  const { data: existing, error: fetchError } = await supabaseAdmin.from('class_gear').select('*').eq('character_id', id);
-  if (fetchError) {
-    return { data: null, error: fetchError };
-  }
-
-  const desired = [];
-  if (normalizedGear.length > 0) {
-    const { gearNameToClassId, gearNameToDescription } = await buildClassContentLookupMaps();
-    for (const item of normalizedGear) {
-      const clsId = item.class_id ?? gearNameToClassId.get(item.name);
-      if (!clsId) {
-        const errorMessage = `[setCharacterGear] Missing class_id for gear item "${item.name}"`;
-        console.error(errorMessage, { characterId: id, item });
-        return { data: null, error: errorMessage };
-      }
-      const desc = item.description ?? gearNameToDescription.get(item.name);
-      desired.push({ name: item.name, class_id: clsId, description: desc || null });
-    }
-  }
-
-  const diff = diffChildRows(existing, desired, {
-    keyOf: r => `${r.class_id}:${r.name}`,
-    rowFields: item => ({ name: item.name, class_id: item.class_id, description: item.description })
-  });
-  return applyChildDiff('class_gear', id, diff);
-};
 
 const getCharacterAbilities = async (id, client = supabase) => {
   // First get the character abilities
@@ -572,101 +266,6 @@ const getCharacterAbilityPerks = async (id) => {
     .order('position', { ascending: true });
   if (error) return { data: null, error };
   return { data: Array.isArray(data) ? data : [], error: null };
-};
-
-const setCharacterPerks = async (characterId, perks) => {
-  const normalized = normalizeAbilityPerks(perks);
-
-  // Internal helper: authz is enforced by the calling function (createCharacter/updateCharacter).
-  const { data: existing, error: fetchError } = await supabaseAdmin
-    .from('character_perks')
-    .select('*')
-    .eq('character_id', characterId);
-  if (fetchError) {
-    return { data: null, error: fetchError };
-  }
-
-  // Pass 1: reconcile rows on ability+position. compounds_with is resolved in
-  // pass 2 against the surviving row set, so it is not part of the row diff
-  // (inserts therefore store it as NULL via DB default).
-  const diff = diffChildRows(existing, normalized, {
-    keyOf: r => `${r.class_ability_id}:${r.position}`,
-    rowFields: p => ({ class_ability_id: p.class_ability_id, text: p.text, position: p.position })
-  });
-  const { error: applyError } = await applyChildDiff('character_perks', characterId, diff);
-  if (applyError) {
-    return { data: null, error: applyError };
-  }
-
-  // Pass 2: resolve compound links ('position-N' sentinels from the form,
-  // row UUIDs from the agent/API path) against the current rows. With stable
-  // ids a UUID may legitimately reference a kept row, which the old
-  // inserted-rows-only check could not honor.
-  const { data: current, error: selError } = await supabaseAdmin
-    .from('character_perks')
-    .select('*')
-    .eq('character_id', characterId);
-  if (selError) {
-    return { data: null, error: selError };
-  }
-
-  const linkUpdates = resolveCompoundLinks(normalized, current);
-  for (const u of linkUpdates) {
-    const { error: updError } = await supabaseAdmin
-      .from('character_perks')
-      .update({ compounds_with: u.compounds_with })
-      .eq('id', u.id);
-    if (updError) {
-      return { data: null, error: updError };
-    }
-  }
-
-  return { data: current, error: null };
-};
-
-const setCharacterAbilities = async (id, abilities) => {
-  const normalizedAbilities = normalizeAbilityItems(abilities);
-
-  // Internal helper: authz is enforced by the calling function (createCharacter/updateCharacter).
-  const { data: existing, error: fetchError } = await supabaseAdmin.from('class_abilities').select('*').eq('character_id', id);
-  if (fetchError) {
-    return { data: null, error: fetchError };
-  }
-
-  const desired = [];
-  if (normalizedAbilities.length > 0) {
-    const { abilityNameToClassId, abilityNameToDescription } = await buildClassContentLookupMaps();
-    for (const item of normalizedAbilities) {
-      const clsId = item.class_id ?? abilityNameToClassId.get(item.name);
-      if (!clsId) {
-        const errorMessage = `[setCharacterAbilities] Missing class_id for ability "${item.name}"`;
-        console.error(errorMessage, { characterId: id, item });
-        return { data: null, error: errorMessage };
-      }
-      const desc = item.description ?? abilityNameToDescription.get(item.name);
-      desired.push({ name: item.name, class_id: clsId, description: desc || null });
-    }
-  }
-
-  // rowFields intentionally omits essence_cost/cooldown/duration: the save
-  // path never writes them (they live on the class catalog and are merged in
-  // at read time by getCharacterAbilities), so they aren't part of the diff.
-  const diff = diffChildRows(existing, desired, {
-    keyOf: r => `${r.class_id}:${r.name}`,
-    rowFields: item => ({ name: item.name, class_id: item.class_id, description: item.description })
-  });
-  const { error: applyError } = await applyChildDiff('class_abilities', id, diff);
-  if (applyError) {
-    return { data: null, error: applyError };
-  }
-
-  // Return the full post-reconcile set (kept + inserted): updateCharacter
-  // remaps the form's perk references against these rows.
-  const { data: current, error: selError } = await supabaseAdmin.from('class_abilities').select('*').eq('character_id', id);
-  if (selError) {
-    return { data: null, error: selError };
-  }
-  return { data: current, error: null };
 };
 
 const getCharacterRecentMissions = async (characterId, limit = 5) => {
@@ -1014,12 +613,52 @@ const getCharacterForAgent = async (id, actor = {}) => {
 };
 
 // Compatibility adapter: routes and importers continue using this model's
-// public functions while all character writes now cross the service boundary.
-// The adapter can be replaced by an RPC-backed implementation without changing
-// those callers or the service contract.
+// public functions while the service owns write orchestration. The adapter can
+// be replaced by an RPC-backed implementation without changing those callers.
 const characterService = new CharacterService({
-  createCharacter: createCharacterPersistenceFlow,
-  updateCharacter: updateCharacterPersistenceFlow
+  getRulesVersion: classId => effectiveRulesVersion(classId),
+  resolveClassReference: resolveCharacterClassReference,
+  getCharacter: id => getCharacter(id, supabaseAdmin),
+  createCharacterRow: input => supabaseAdmin.from('characters').insert(input).select(),
+  updateCharacterRow: (id, input, actor) => supabaseAdmin
+    .from('characters')
+    .update(input)
+    .eq('id', id)
+    .eq('creator_id', actor.id)
+    .select(),
+  ...(typeof supabaseAdmin.rpc === 'function' ? {
+    saveCharacterAtomic: async ({ characterId, creatorId, character, traits, gear, abilities, perks }) => {
+      const { data, error } = await supabaseAdmin.rpc('save_character_atomic', {
+        p_character_id: characterId,
+        p_creator_id: creatorId,
+        p_character: character,
+        p_traits: traits,
+        p_gear: gear,
+        p_abilities: abilities,
+        p_perks: perks
+      });
+      return { data, error };
+    }
+  } : {}),
+  getChildRows: (table, characterId) => supabaseAdmin
+    .from(table)
+    .select('*')
+    .eq('character_id', characterId),
+  insertChildRows: (table, characterId, rows) => supabaseAdmin
+    .from(table)
+    .insert(rows.map(row => ({ character_id: characterId, ...row }))),
+  updateChildRow: (table, rowId, changes) => supabaseAdmin
+    .from(table)
+    .update(changes)
+    .eq('id', rowId),
+  deleteChildRows: (table, characterId, rowIds) => supabaseAdmin
+    .from(table)
+    .delete()
+    .in('id', rowIds)
+    .eq('character_id', characterId),
+  getClassContentLookupMaps: buildClassContentLookupMaps,
+  getRealMissions: id => getCharacterRealMissionsForDerivation(id, supabaseAdmin),
+  listOffscreenMissions: id => listOffscreenMissions({ characterId: id, supabase: supabaseAdmin })
 });
 
 const createCharacter = (input, actor) => characterService.createCharacter(input, actor);

--- a/models/character.test.js
+++ b/models/character.test.js
@@ -212,11 +212,9 @@ test('createCharacter drops v2-only fields when linked class is v1', async () =>
   const { data, error } = await createCharacter(payload, { id: 'profile-1' });
   expect(error).toBeFalsy();
   expect(data).toBeTruthy();
-  // The fake admin client always echoes characterRowBase, so we check that
-  // the payload mutation happened: createCharacter should have deleted v2
-  // keys before insert.
-  expect(payload.quirks).toBeUndefined();
-  expect(payload.accessories).toBeUndefined();
+  // Request payloads remain immutable; the persistence copy strips v2 keys.
+  expect(payload.quirks).toHaveLength(1);
+  expect(payload.accessories).toHaveLength(1);
 });
 
 test('createCharacter preserves v2 fields when linked class is v2', async () => {
@@ -276,8 +274,8 @@ test('createCharacter strips v1-only fields (perks, additional_gear) when class 
   };
   const { error } = await createCharacter(payload, { id: 'profile-1' });
   expect(error).toBeFalsy();
-  expect(payload.perks).toBeUndefined();
-  expect(payload.additional_gear).toBeUndefined();
+  expect(payload.perks).toBe('leftover v1 free text');
+  expect(payload.additional_gear).toBe('leftover v1 gear');
 
   mock.module('./_base', () => ({
     supabase: fakeAnon, supabaseAdmin: fakeAdmin,

--- a/models/lfg-agent.test.js
+++ b/models/lfg-agent.test.js
@@ -2,6 +2,7 @@
 // Integration tests for agent-scoped LFG model wrappers.
 // Requires local Supabase to be running (http://127.0.0.1:54321).
 const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { Client } = require('pg');
 const { supabaseAdmin } = require('./_base');
 
 const {
@@ -23,28 +24,28 @@ const SERVICE_ROLE_KEY = process.env.SUPABASE_SECRET_KEY;
 const SUPABASE_URL = process.env.SUPABASE_URL;
 
 async function createAuthUser(email) {
-  const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users`, {
-    method: 'POST',
-    headers: {
-      apikey: SERVICE_ROLE_KEY,
-      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ email, password: 'test-password-123', email_confirm: true })
-  });
-  const json = await res.json();
-  if (!json.id) throw new Error(`createAuthUser failed: ${JSON.stringify(json)}`);
-  return json.id; // auth user UUID
+  const db = new Client({ connectionString: process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' });
+  await db.connect();
+  const { rows } = await db.query(
+    `insert into auth.users (id, aud, role, email, email_confirmed_at, created_at, updated_at, raw_app_meta_data, raw_user_meta_data)
+     values (gen_random_uuid(), 'authenticated', 'authenticated', $1, now(), now(), now(), '{}'::jsonb, '{}'::jsonb) returning id`,
+    [email]
+  );
+  await db.end();
+  return rows[0].id;
 }
 
 async function deleteAuthUser(userId) {
-  await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${userId}`, {
-    method: 'DELETE',
-    headers: {
-      apikey: SERVICE_ROLE_KEY,
-      Authorization: `Bearer ${SERVICE_ROLE_KEY}`
-    }
-  });
+  const db = new Client({ connectionString: process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' });
+  await db.connect();
+  try {
+    await db.query('delete from auth.users where id = $1', [userId]);
+  } catch (error) {
+    // Some legacy fixtures intentionally leave their profile cleanup to the
+    // next local reset; match the old best-effort admin-delete behavior.
+    if (error.code !== '23503') throw error;
+  }
+  await db.end();
 }
 
 async function createProfile(authUserId, name) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:unit": "bun scripts/run-tests.mjs unit",
     "test:http": "bun scripts/run-tests.mjs http",
     "test:integration": "bun scripts/run-tests.mjs integration",
+    "check": "bun scripts/check.mjs",
     "setup": "bun run scripts/setup.mjs",
     "seed:classes": "bun run util/seed-classes.js",
     "seed:admin": "bun run util/seed-admin.js",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = new URL('..', import.meta.url).pathname;
+const sourceDirectories = ['models', 'routes', 'services', 'util', 'views'];
+
+const sourceFiles = (directory) => readdirSync(join(root, directory), { withFileTypes: true })
+  .flatMap(entry => entry.isDirectory()
+    ? sourceFiles(`${directory}/${entry.name}`)
+    : entry.name.endsWith('.js') && !entry.name.endsWith('.test.js') ? [`${directory}/${entry.name}`] : []);
+
+for (const file of sourceDirectories.flatMap(sourceFiles).sort()) {
+  const result = spawnSync('node', ['--check', file], { cwd: root, stdio: 'inherit' });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process';
 
 const root = new URL('..', import.meta.url).pathname;
 const integrationFiles = new Set([
+  'models/character-atomic.integration.test.js',
   'models/lfg-agent.test.js',
   'routes/bot-link.test.js'
 ]);

--- a/services/character/input.js
+++ b/services/character/input.js
@@ -1,0 +1,128 @@
+const { sanitizeHttpUrl } = require('../../util/url');
+const { validateAbilityPerks } = require('../../util/validate');
+
+const V2_ONLY_FIELDS = ['quirks', 'accessories', 'ability_perks'];
+const V1_ONLY_FIELDS = ['perks', 'additional_gear'];
+const CREATOR_MODES = ['advent', 'aspiring', 'aspirant'];
+
+// Submitted character payloads are ordinary JSON-like data. Clone them before
+// transforming so route callers (and import callers) retain their request body.
+const cloneInput = (input) => {
+  if (!input || typeof input !== 'object') return {};
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => {
+    if (Array.isArray(value)) return [key, value.map(item => item && typeof item === 'object' ? { ...item } : item)];
+    if (value && typeof value === 'object') return [key, { ...value }];
+    return [key, value];
+  }));
+};
+
+const normalizeNamedJsonbList = (input) => {
+  if (!Array.isArray(input)) return [];
+  return input.map(item => {
+    if (!item) return null;
+    if (typeof item === 'string') {
+      const name = item.trim();
+      return name ? { name } : null;
+    }
+    if (typeof item === 'object' && typeof item.name === 'string') {
+      const name = item.name.trim();
+      if (!name) return null;
+      const result = { name };
+      if (typeof item.description === 'string' && item.description.trim()) result.description = item.description.trim();
+      return result;
+    }
+    return null;
+  }).filter(Boolean);
+};
+
+const normalizeClassItems = (items) => {
+  if (!Array.isArray(items)) return [];
+  return items.map(item => {
+    if (!item) return null;
+    if (typeof item === 'string') {
+      const value = item.trim();
+      if (!value) return null;
+      const separator = value.indexOf('::');
+      const name = separator === -1 ? value : value.slice(separator + 2).trim();
+      return name ? { name } : null;
+    }
+    if (typeof item === 'object' && typeof item.name === 'string') {
+      const name = item.name.trim();
+      return name ? { ...item, name } : null;
+    }
+    return null;
+  }).filter(Boolean);
+};
+
+const normalizeAbilityPerks = (perks) => {
+  if (!Array.isArray(perks)) return [];
+  return perks.map((perk, index) => {
+    if (!perk || typeof perk !== 'object') return null;
+    const text = typeof perk.text === 'string' ? perk.text.trim() : '';
+    const classAbilityId = perk.class_ability_id || null;
+    if (!text || !classAbilityId) return null;
+    return {
+      class_ability_id: classAbilityId,
+      text,
+      position: Number.isFinite(Number(perk.position)) ? Number(perk.position) : index,
+      compounds_with: perk.compounds_with_id || perk.compounds_with || null
+    };
+  }).filter(Boolean);
+};
+
+/**
+ * Prepare an input payload for the character persistence flow without doing
+ * database access. Class id/name resolution belongs to the caller; pass its
+ * resolved rules version here so this stays deterministic and unit-testable.
+ */
+const normalizeCharacterInput = (input, context = {}) => {
+  const data = cloneInput(input);
+  const rulesVersion = context.rulesVersion === 'v2' ? 'v2' : 'v1';
+
+  if (context.creatorId) data.creator_id = context.creatorId;
+  for (const field of rulesVersion === 'v2' ? V1_ONLY_FIELDS : V2_ONLY_FIELDS) delete data[field];
+
+  const childData = {
+    traits: [data.trait0, data.trait1, data.trait2],
+    abilityPerks: data.ability_perks,
+    classGear: data.gear,
+    classAbilities: data.abilities
+  };
+  delete data.trait0;
+  delete data.trait1;
+  delete data.trait2;
+  delete data.ability_perks;
+  delete data.gear;
+  delete data.abilities;
+
+  if (rulesVersion === 'v2') {
+    const validation = validateAbilityPerks(normalizeAbilityPerks(childData.abilityPerks));
+    if (!validation.ok) return { data: null, childData: null, error: validation.errors.join(' ') };
+    data.quirks = normalizeNamedJsonbList(data.quirks);
+    data.accessories = normalizeNamedJsonbList(data.accessories);
+  }
+
+  const items = Array.isArray(data.common_items) ? data.common_items : (data.common_items ? [data.common_items] : []);
+  data.common_items = items.map(item => typeof item === 'string' ? item.trim() : '').filter(Boolean);
+  data.is_public = data.is_public === 'on';
+  data.hide_from_search = data.hide_from_search === 'on';
+
+  if (data.creator_mode == null || data.creator_mode === '') data.creator_mode = null;
+  else if (!CREATOR_MODES.includes(data.creator_mode)) {
+    return { data: null, childData: null, error: `Invalid creator_mode: ${data.creator_mode}` };
+  }
+
+  if (context.normalizeAutoCalculate) data.auto_calculate = data.auto_calculate === 'on' || data.auto_calculate === true;
+  if ('image_url' in data) data.image_url = data.image_url ? sanitizeHttpUrl(data.image_url) : null;
+
+  return { data, childData, error: null };
+};
+
+module.exports = {
+  cloneInput,
+  normalizeCharacterInput,
+  normalizeNamedJsonbList,
+  normalizeGearItems: normalizeClassItems,
+  normalizeAbilityItems: normalizeClassItems,
+  normalizeAbilityPerks
+};

--- a/services/character/input.test.js
+++ b/services/character/input.test.js
@@ -1,0 +1,57 @@
+const { test, expect } = require('bun:test');
+const { normalizeCharacterInput } = require('./input');
+
+test('normalizes a v1 payload without mutating the submitted request', () => {
+  const input = {
+    name: '  Scout  ',
+    trait0: 'Brave', trait1: '', trait2: 'Clever',
+    gear: ['Ranger::Knife'], abilities: ['Ranger::Dodge'],
+    common_items: [' rope ', '', 3], is_public: 'on', hide_from_search: 'off',
+    quirks: [{ name: 'v2 only' }], ability_perks: [{ class_ability_id: 'a', text: 'ignored' }]
+  };
+
+  const result = normalizeCharacterInput(input, { rulesVersion: 'v1', creatorId: 'owner' });
+
+  expect(result.error).toBeNull();
+  expect(result.data).toMatchObject({ creator_id: 'owner', common_items: ['rope'], is_public: true, hide_from_search: false });
+  expect(result.data).not.toHaveProperty('quirks');
+  expect(result.data).not.toHaveProperty('ability_perks');
+  expect(result.data).not.toHaveProperty('trait0');
+  expect(result.childData.traits).toEqual(['Brave', '', 'Clever']);
+  expect(result.childData.classGear).toEqual(['Ranger::Knife']);
+  expect(input.quirks).toHaveLength(1);
+  expect(input).toHaveProperty('trait0');
+});
+
+test('normalizes v2 fields and strips legacy free-text fields', () => {
+  const result = normalizeCharacterInput({
+    quirks: [' Synthetic ', { name: 'Veteran', description: '  Seen it all ' }, { name: ' ' }],
+    accessories: [{ name: ' Monocle ' }], perks: 'legacy', additional_gear: 'legacy gear',
+    ability_perks: [{ class_ability_id: 'ability-1', text: '  Deal more damage  ', position: '2' }],
+    creator_mode: 'aspiring', image_url: 'https://example.test/image.png'
+  }, { rulesVersion: 'v2' });
+
+  expect(result.error).toBeNull();
+  expect(result.data.quirks).toEqual([{ name: 'Synthetic' }, { name: 'Veteran', description: 'Seen it all' }]);
+  expect(result.data.accessories).toEqual([{ name: 'Monocle' }]);
+  expect(result.data).not.toHaveProperty('perks');
+  expect(result.data).not.toHaveProperty('additional_gear');
+  expect(result.data.image_url).toBe('https://example.test/image.png');
+  expect(result.childData.abilityPerks[0].text).toBe('  Deal more damage  ');
+});
+
+test('returns established validation errors for invalid creator mode and perks', () => {
+  expect(normalizeCharacterInput({ creator_mode: 'nope' }, { rulesVersion: 'v1' })).toMatchObject({
+    data: null, error: 'Invalid creator_mode: nope'
+  });
+  const tooLong = Array.from({ length: 26 }, (_, index) => `word${index}`).join(' ');
+  expect(normalizeCharacterInput({ ability_perks: [{ class_ability_id: 'a', text: tooLong }] }, { rulesVersion: 'v2' }).error)
+    .toMatch(/25 words/);
+});
+
+test('normalizes update booleans and missing list fields deterministically', () => {
+  const result = normalizeCharacterInput({ auto_calculate: true, image_url: 'javascript:bad' }, {
+    rulesVersion: 'v1', normalizeAutoCalculate: true
+  });
+  expect(result.data).toMatchObject({ auto_calculate: true, common_items: [], is_public: false, hide_from_search: false, image_url: null });
+});

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -1,23 +1,314 @@
+const {
+  cloneInput,
+  normalizeCharacterInput,
+  normalizeGearItems,
+  normalizeAbilityItems,
+  normalizeAbilityPerks
+} = require('./input');
+const { deriveCharacterTotals } = require('../../util/character-derived');
+const { remapPerkAbilityIds, remapPerkAbilityIdsByName } = require('../../util/ability-perks');
+const { diffChildRows, resolveCompoundLinks } = require('../../util/reconcile');
+
+const V2_ONLY_FIELDS = ['quirks', 'accessories', 'ability_perks'];
+
+const REQUIRED_ADAPTER_METHODS = [
+  'getRulesVersion',
+  'resolveClassReference',
+  'getCharacter',
+  'createCharacterRow',
+  'updateCharacterRow',
+  'getChildRows',
+  'insertChildRows',
+  'updateChildRow',
+  'deleteChildRows',
+  'getClassContentLookupMaps',
+  'getRealMissions',
+  'listOffscreenMissions'
+];
+
+const resolveSubmittedGear = (gear, gearNameToClassId) => {
+  const submitted = Array.isArray(gear) ? gear : (gear ? [gear] : []);
+  return submitted.map(item => {
+    if (!item) return null;
+    if (typeof item === 'string') {
+      const trimmed = item.trim();
+      if (!trimmed) return null;
+      const name = trimmed.includes('::') ? trimmed.split('::')[1].trim() : trimmed;
+      return name ? { name, class_id: gearNameToClassId.get(name) || null } : null;
+    }
+    if (typeof item === 'object' && item.name) {
+      return { name: item.name, class_id: item.class_id || gearNameToClassId.get(item.name) || null };
+    }
+    return null;
+  }).filter(Boolean);
+};
+
 /**
- * Application boundary for character writes. The adapter deliberately owns
- * storage details; callers only receive the established `{ data, error }`
- * result contract.
+ * Application boundary for character writes. The adapter owns storage and
+ * catalog queries; this service owns validation, authorization, sequencing,
+ * and reconciliation decisions.
  */
 class CharacterService {
   constructor(adapter) {
-    if (!adapter || typeof adapter.createCharacter !== 'function' || typeof adapter.updateCharacter !== 'function') {
-      throw new TypeError('CharacterService requires createCharacter and updateCharacter adapter methods');
+    const missing = REQUIRED_ADAPTER_METHODS.filter(method => typeof adapter?.[method] !== 'function');
+    if (missing.length > 0) {
+      throw new TypeError(`CharacterService requires adapter methods: ${missing.join(', ')}`);
     }
     this.adapter = adapter;
   }
 
-  createCharacter(input, actor) {
-    return this.adapter.createCharacter(input, actor);
+  async createCharacter(input, actor) {
+    // Preserve historical ordering: creation chooses the version before a
+    // class-name lookup may populate class_id.
+    const rulesVersion = await this.adapter.getRulesVersion(input.class_id);
+    const prepared = await this.adapter.resolveClassReference(input);
+    const normalized = normalizeCharacterInput(prepared, { rulesVersion, creatorId: actor.id });
+    if (normalized.error) return { data: null, error: normalized.error };
+
+    const { data: characterInput, childData } = normalized;
+    if (typeof this.adapter.saveCharacterAtomic === 'function') {
+      return this.saveCharacterAtomic({
+        id: null, actor, characterInput, childData, rulesVersion, previousAbilities: []
+      });
+    }
+    const created = await this.adapter.createCharacterRow(characterInput);
+    if (created.error || !created.data || created.data.length === 0) {
+      return created.error ? created : { data: null, error: 'Character creation returned no rows' };
+    }
+    const character = created.data[0];
+
+    const traitsResult = await this.reconcileTraits(character.id, childData.traits);
+    if (traitsResult.error) return { data: null, error: traitsResult.error };
+
+    if (childData.classGear) {
+      const gearResult = await this.reconcileGear(character.id, childData.classGear);
+      if (gearResult.error) return { data: null, error: gearResult.error };
+    }
+
+    let abilityRows = null;
+    if (childData.classAbilities) {
+      const abilityResult = await this.reconcileAbilities(character.id, childData.classAbilities);
+      if (abilityResult.error) return { data: null, error: abilityResult.error };
+      abilityRows = abilityResult.data;
+    }
+
+    if (rulesVersion === 'v2') {
+      const perks = remapPerkAbilityIdsByName(childData.abilityPerks, abilityRows || []);
+      const perksResult = await this.reconcilePerks(character.id, perks);
+      if (perksResult.error) return { data: null, error: perksResult.error };
+    }
+    return { data: character, error: created.error };
   }
 
-  updateCharacter(id, input, actor) {
-    return this.adapter.updateCharacter(id, input, actor);
+  async updateCharacter(id, input, actor) {
+    const existing = await this.adapter.getCharacter(id);
+    if (existing.error) return { data: null, error: existing.error };
+    if (existing.data.creator_id != actor.id) return { data: null, error: 'Unauthorized' };
+
+    let rulesVersion = await this.adapter.getRulesVersion(input.class_id);
+    let prepared = cloneInput(input);
+    if (rulesVersion !== 'v2') {
+      for (const field of V2_ONLY_FIELDS) delete prepared[field];
+    }
+    prepared = await this.adapter.resolveClassReference(prepared);
+    rulesVersion = await this.adapter.getRulesVersion(prepared.class_id);
+
+    const normalized = normalizeCharacterInput(prepared, {
+      rulesVersion,
+      normalizeAutoCalculate: true
+    });
+    if (normalized.error) return { data: null, error: normalized.error };
+    const { data: characterInput, childData } = normalized;
+
+    if (characterInput.auto_calculate) {
+      const { gearNameToClassId } = await this.adapter.getClassContentLookupMaps();
+      const [missions, offscreenMissions] = await Promise.all([
+        this.adapter.getRealMissions(id),
+        this.adapter.listOffscreenMissions(id)
+      ]);
+      if (missions.error || offscreenMissions.error) {
+        return { data: null, error: missions.error || offscreenMissions.error };
+      }
+      const derived = deriveCharacterTotals({
+        character: {
+          class_id: characterInput.class_id,
+          gear: resolveSubmittedGear(childData.classGear, gearNameToClassId),
+          common_items: characterInput.common_items
+        },
+        realMissions: missions.data || [],
+        offscreenMissions: offscreenMissions.data || [],
+        rulesVersion
+      });
+      characterInput.level = derived.level;
+      characterInput.completed_missions = derived.completed_missions;
+      characterInput.commissary_reward = derived.commissary_reward;
+    }
+
+    const previousAbilities = Array.isArray(existing.data.abilities) ? existing.data.abilities : [];
+    if (typeof this.adapter.saveCharacterAtomic === 'function') {
+      return this.saveCharacterAtomic({
+        id, actor, characterInput, childData, rulesVersion, previousAbilities
+      });
+    }
+    const updated = await this.adapter.updateCharacterRow(id, characterInput, actor);
+    if (updated.error || !updated.data || updated.data.length === 0) {
+      return updated.error ? updated : { data: null, error: 'Character update returned no rows' };
+    }
+    const character = updated.data[0];
+
+    const traitsResult = await this.reconcileTraits(character.id, childData.traits);
+    if (traitsResult.error) return { data: null, error: traitsResult.error };
+    if (childData.classGear) {
+      const gearResult = await this.reconcileGear(character.id, childData.classGear);
+      if (gearResult.error) return { data: null, error: gearResult.error };
+    }
+
+    let abilityRows = null;
+    if (childData.classAbilities) {
+      const abilityResult = await this.reconcileAbilities(character.id, childData.classAbilities);
+      if (abilityResult.error) return { data: null, error: abilityResult.error };
+      abilityRows = abilityResult.data;
+    }
+    if (rulesVersion === 'v2') {
+      const perks = abilityRows
+        ? remapPerkAbilityIds(childData.abilityPerks, previousAbilities, abilityRows)
+        : childData.abilityPerks;
+      const perksResult = await this.reconcilePerks(character.id, perks);
+      if (perksResult.error) return { data: null, error: perksResult.error };
+    }
+    return { data: character, error: updated.error };
+  }
+
+  async saveCharacterAtomic({ id, actor, characterInput, childData, rulesVersion, previousAbilities }) {
+    const traits = (Array.isArray(childData.traits) ? childData.traits : [])
+      .filter(name => name != null && name !== '')
+      .map(name => ({ name }));
+    const maps = await this.adapter.getClassContentLookupMaps();
+    const gear = childData.classGear == null ? null : normalizeGearItems(childData.classGear).map(item => ({
+      name: item.name,
+      class_id: item.class_id ?? maps.gearNameToClassId.get(item.name),
+      description: item.description ?? maps.gearNameToDescription.get(item.name) ?? null
+    }));
+    const abilities = childData.classAbilities == null ? null : normalizeAbilityItems(childData.classAbilities).map(item => ({
+      name: item.name,
+      class_id: item.class_id ?? maps.abilityNameToClassId.get(item.name),
+      description: item.description ?? maps.abilityNameToDescription.get(item.name) ?? null
+    }));
+    if ((gear || []).some(item => !item.class_id)) {
+      const item = gear.find(row => !row.class_id);
+      return { data: null, error: `[setCharacterGear] Missing class_id for gear item "${item.name}"` };
+    }
+    if ((abilities || []).some(item => !item.class_id)) {
+      const item = abilities.find(row => !row.class_id);
+      return { data: null, error: `[setCharacterAbilities] Missing class_id for ability "${item.name}"` };
+    }
+
+    let perks = null;
+    if (rulesVersion === 'v2') {
+      const byOldId = new Map(previousAbilities.map(ability => [ability.id, ability]));
+      const submitted = normalizeAbilityPerks(childData.abilityPerks);
+      const names = new Set((abilities || previousAbilities).map(ability => ability.name));
+      perks = submitted.map(perk => {
+        const ability = byOldId.get(perk.class_ability_id);
+        const abilityName = ability?.name || (typeof perk.class_ability_id === 'string' && !perk.class_ability_id.includes('-')
+          ? perk.class_ability_id
+          : null);
+        return abilityName && names.has(abilityName)
+          ? { ...perk, class_ability_id: abilities ? null : perk.class_ability_id, ability_name: abilityName }
+          : abilities ? null : perk;
+      }).filter(Boolean);
+    }
+    return this.adapter.saveCharacterAtomic({
+      characterId: id,
+      creatorId: actor.id,
+      character: characterInput,
+      traits,
+      gear,
+      abilities,
+      perks
+    });
+  }
+
+  async applyChildDiff(table, characterId, diff) {
+    if (diff.toInsert.length > 0) {
+      const result = await this.adapter.insertChildRows(table, characterId, diff.toInsert);
+      if (result.error) return result;
+    }
+    for (const { id, ...changes } of diff.toUpdate) {
+      const result = await this.adapter.updateChildRow(table, id, changes);
+      if (result.error) return result;
+    }
+    if (diff.toDelete.length > 0) {
+      const result = await this.adapter.deleteChildRows(table, characterId, diff.toDelete);
+      if (result.error) return result;
+    }
+    return { data: true, error: null };
+  }
+
+  async reconcileTraits(characterId, traits) {
+    const existing = await this.adapter.getChildRows('traits', characterId);
+    if (existing.error) return existing;
+    const desired = (Array.isArray(traits) ? traits : [])
+      .filter(name => name != null && name !== '')
+      .map(name => ({ name }));
+    return this.applyChildDiff('traits', characterId, diffChildRows(existing.data, desired, {
+      keyOf: row => row.name,
+      rowFields: item => ({ name: item.name })
+    }));
+  }
+
+  async reconcileGear(characterId, gear) {
+    const existing = await this.adapter.getChildRows('class_gear', characterId);
+    if (existing.error) return existing;
+    const { gearNameToClassId, gearNameToDescription } = await this.adapter.getClassContentLookupMaps();
+    const desired = [];
+    for (const item of normalizeGearItems(gear)) {
+      const classId = item.class_id ?? gearNameToClassId.get(item.name);
+      if (!classId) return { data: null, error: `[setCharacterGear] Missing class_id for gear item "${item.name}"` };
+      desired.push({ name: item.name, class_id: classId, description: item.description ?? gearNameToDescription.get(item.name) ?? null });
+    }
+    return this.applyChildDiff('class_gear', characterId, diffChildRows(existing.data, desired, {
+      keyOf: row => `${row.class_id}:${row.name}`,
+      rowFields: item => ({ name: item.name, class_id: item.class_id, description: item.description })
+    }));
+  }
+
+  async reconcileAbilities(characterId, abilities) {
+    const existing = await this.adapter.getChildRows('class_abilities', characterId);
+    if (existing.error) return existing;
+    const { abilityNameToClassId, abilityNameToDescription } = await this.adapter.getClassContentLookupMaps();
+    const desired = [];
+    for (const item of normalizeAbilityItems(abilities)) {
+      const classId = item.class_id ?? abilityNameToClassId.get(item.name);
+      if (!classId) return { data: null, error: `[setCharacterAbilities] Missing class_id for ability "${item.name}"` };
+      desired.push({ name: item.name, class_id: classId, description: item.description ?? abilityNameToDescription.get(item.name) ?? null });
+    }
+    const applied = await this.applyChildDiff('class_abilities', characterId, diffChildRows(existing.data, desired, {
+      keyOf: row => `${row.class_id}:${row.name}`,
+      rowFields: item => ({ name: item.name, class_id: item.class_id, description: item.description })
+    }));
+    return applied.error ? applied : this.adapter.getChildRows('class_abilities', characterId);
+  }
+
+  async reconcilePerks(characterId, perks) {
+    const existing = await this.adapter.getChildRows('character_perks', characterId);
+    if (existing.error) return existing;
+    const desired = normalizeAbilityPerks(perks);
+    const applied = await this.applyChildDiff('character_perks', characterId, diffChildRows(existing.data, desired, {
+      keyOf: row => `${row.class_ability_id}:${row.position}`,
+      rowFields: perk => ({ class_ability_id: perk.class_ability_id, text: perk.text, position: perk.position })
+    }));
+    if (applied.error) return applied;
+    const current = await this.adapter.getChildRows('character_perks', characterId);
+    if (current.error) return current;
+    for (const update of resolveCompoundLinks(desired, current.data)) {
+      const result = await this.adapter.updateChildRow('character_perks', update.id, {
+        compounds_with: update.compounds_with
+      });
+      if (result.error) return result;
+    }
+    return current;
   }
 }
 
-module.exports = { CharacterService };
+module.exports = { CharacterService, resolveSubmittedGear };

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -1,0 +1,23 @@
+/**
+ * Application boundary for character writes. The adapter deliberately owns
+ * storage details; callers only receive the established `{ data, error }`
+ * result contract.
+ */
+class CharacterService {
+  constructor(adapter) {
+    if (!adapter || typeof adapter.createCharacter !== 'function' || typeof adapter.updateCharacter !== 'function') {
+      throw new TypeError('CharacterService requires createCharacter and updateCharacter adapter methods');
+    }
+    this.adapter = adapter;
+  }
+
+  createCharacter(input, actor) {
+    return this.adapter.createCharacter(input, actor);
+  }
+
+  updateCharacter(id, input, actor) {
+    return this.adapter.updateCharacter(id, input, actor);
+  }
+}
+
+module.exports = { CharacterService };

--- a/services/character/service.test.js
+++ b/services/character/service.test.js
@@ -1,27 +1,89 @@
 const { test, expect } = require('bun:test');
 const { CharacterService } = require('./service');
 
-test('CharacterService forwards create/update requests to its injected persistence adapter', async () => {
-  const calls = [];
-  const adapter = {
-    createCharacter: async (input, actor) => {
-      calls.push(['create', input, actor]);
-      return { data: { id: 'new-character' }, error: null };
-    },
-    updateCharacter: async (id, input, actor) => {
-      calls.push(['update', id, input, actor]);
-      return { data: { id }, error: null };
-    }
-  };
-  const service = new CharacterService(adapter);
-  const actor = { id: 'profile-1' };
+const ok = data => ({ data, error: null });
 
-  expect(await service.createCharacter({ name: 'New' }, actor)).toMatchObject({ data: { id: 'new-character' }, error: null });
-  expect(await service.updateCharacter('character-1', { name: 'Changed' }, actor)).toMatchObject({ data: { id: 'character-1' }, error: null });
+const makeAdapter = (calls, overrides = {}) => ({
+  getRulesVersion: async () => 'v1',
+  resolveClassReference: async input => ({ ...input }),
+  getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', abilities: [] }),
+  createCharacterRow: async input => {
+    calls.push(['createCharacterRow', input]);
+    return ok([{ id: 'new-character' }]);
+  },
+  updateCharacterRow: async (id, input, actor) => {
+    calls.push(['updateCharacterRow', id, input, actor]);
+    return ok([{ id }]);
+  },
+  getChildRows: async (table, id) => {
+    calls.push(['getChildRows', table, id]);
+    return ok([]);
+  },
+  insertChildRows: async (table, id, rows) => {
+    calls.push(['insertChildRows', table, id, rows]);
+    return ok(true);
+  },
+  updateChildRow: async (table, id, changes) => {
+    calls.push(['updateChildRow', table, id, changes]);
+    return ok(true);
+  },
+  deleteChildRows: async (table, id, rowIds) => {
+    calls.push(['deleteChildRows', table, id, rowIds]);
+    return ok(true);
+  },
+  getClassContentLookupMaps: async () => ({
+    gearNameToClassId: new Map([['Rifle', 'class-1']]),
+    gearNameToDescription: new Map(),
+    abilityNameToClassId: new Map(),
+    abilityNameToDescription: new Map()
+  }),
+  getRealMissions: async () => ok([]),
+  listOffscreenMissions: async () => ok([]),
+  ...overrides
+});
+
+test('CharacterService creates through a recording adapter without mutating its request', async () => {
+  const calls = [];
+  const input = { name: 'New', trait0: 'Brave', is_public: 'on', gear: ['Class::Rifle'] };
+  const service = new CharacterService(makeAdapter(calls));
+
+  expect(await service.createCharacter(input, { id: 'profile-1' })).toEqual({
+    data: { id: 'new-character' }, error: null
+  });
+  expect(input).toEqual({ name: 'New', trait0: 'Brave', is_public: 'on', gear: ['Class::Rifle'] });
   expect(calls).toEqual([
-    ['create', { name: 'New' }, actor],
-    ['update', 'character-1', { name: 'Changed' }, actor]
+    ['createCharacterRow', { name: 'New', is_public: true, hide_from_search: false, creator_id: 'profile-1', creator_mode: null, common_items: [] }],
+    ['getChildRows', 'traits', 'new-character'],
+    ['insertChildRows', 'traits', 'new-character', [{ name: 'Brave' }]],
+    ['getChildRows', 'class_gear', 'new-character'],
+    ['insertChildRows', 'class_gear', 'new-character', [{ name: 'Rifle', class_id: 'class-1', description: null }]]
   ]);
+});
+
+test('CharacterService stops a create when a child write fails', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getChildRows: async () => ({ data: null, error: 'trait failure' })
+  }));
+
+  expect(await service.createCharacter({ name: 'New' }, { id: 'profile-1' })).toEqual({
+    data: null, error: 'trait failure'
+  });
+  expect(calls).toEqual([['createCharacterRow', {
+    name: 'New', is_public: false, hide_from_search: false, creator_id: 'profile-1', creator_mode: null, common_items: []
+  }]]);
+});
+
+test('CharacterService enforces ownership before update persistence', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ id: 'character-1', creator_id: 'another-profile', abilities: [] })
+  }));
+
+  expect(await service.updateCharacter('character-1', { name: 'Changed' }, { id: 'profile-1' })).toEqual({
+    data: null, error: 'Unauthorized'
+  });
+  expect(calls).toEqual([]);
 });
 
 test('CharacterService rejects an incomplete persistence adapter', () => {

--- a/services/character/service.test.js
+++ b/services/character/service.test.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('bun:test');
+const { CharacterService } = require('./service');
+
+test('CharacterService forwards create/update requests to its injected persistence adapter', async () => {
+  const calls = [];
+  const adapter = {
+    createCharacter: async (input, actor) => {
+      calls.push(['create', input, actor]);
+      return { data: { id: 'new-character' }, error: null };
+    },
+    updateCharacter: async (id, input, actor) => {
+      calls.push(['update', id, input, actor]);
+      return { data: { id }, error: null };
+    }
+  };
+  const service = new CharacterService(adapter);
+  const actor = { id: 'profile-1' };
+
+  expect(await service.createCharacter({ name: 'New' }, actor)).toMatchObject({ data: { id: 'new-character' }, error: null });
+  expect(await service.updateCharacter('character-1', { name: 'Changed' }, actor)).toMatchObject({ data: { id: 'character-1' }, error: null });
+  expect(calls).toEqual([
+    ['create', { name: 'New' }, actor],
+    ['update', 'character-1', { name: 'Changed' }, actor]
+  ]);
+});
+
+test('CharacterService rejects an incomplete persistence adapter', () => {
+  expect(() => new CharacterService({ createCharacter() {} })).toThrow(/requires/);
+});

--- a/supabase/migrations/20260710000000_atomic_character_writes.sql
+++ b/supabase/migrations/20260710000000_atomic_character_writes.sql
@@ -1,0 +1,128 @@
+-- Atomically persist a character and its submitted child collections. This is
+-- intentionally service-role-only: application authorization remains in
+-- CharacterService, while this function supplies transaction boundaries.
+CREATE OR REPLACE FUNCTION public.save_character_atomic(
+  p_character_id uuid,
+  p_creator_id uuid,
+  p_character jsonb,
+  p_traits jsonb,
+  p_gear jsonb,
+  p_abilities jsonb,
+  p_perks jsonb
+)
+RETURNS public.characters
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  saved public.characters;
+  item jsonb;
+  perk_id uuid;
+  ability_id uuid;
+  source_perk_id uuid;
+  target_perk_id uuid;
+BEGIN
+  IF p_character_id IS NULL THEN
+    INSERT INTO public.characters (
+      creator_id, is_public, is_deceased, hide_from_search, auto_calculate,
+      name, class, vitality, might, resilience, spirit, arcane, will, sensory,
+      reflex, vigor, skill, intelligence, luck, mission_id, level,
+      completed_missions, commissary_reward, appearance, additional_gear,
+      image_url, image_crop, flavor, ideas, background, perks, private_notes,
+      class_id, common_items, quirks, accessories, creator_mode
+    )
+    SELECT
+      record.creator_id, COALESCE(record.is_public, false), COALESCE(record.is_deceased, false), COALESCE(record.hide_from_search, false), COALESCE(record.auto_calculate, false),
+      record.name, record.class, record.vitality, record.might, record.resilience, record.spirit, record.arcane, record.will, record.sensory,
+      record.reflex, record.vigor, record.skill, record.intelligence, record.luck, record.mission_id, record.level,
+      record.completed_missions, record.commissary_reward, record.appearance, record.additional_gear,
+      record.image_url, record.image_crop, record.flavor, record.ideas, record.background, record.perks, record.private_notes,
+      record.class_id, COALESCE(record.common_items, '[]'::jsonb), COALESCE(record.quirks, '[]'::jsonb), COALESCE(record.accessories, '[]'::jsonb), record.creator_mode
+    FROM jsonb_populate_record(NULL::public.characters, p_character) AS record
+    RETURNING * INTO saved;
+  ELSE
+    UPDATE public.characters AS current
+    SET
+      is_public = record.is_public, is_deceased = record.is_deceased,
+      hide_from_search = record.hide_from_search, auto_calculate = record.auto_calculate,
+      name = record.name, class = record.class, vitality = record.vitality,
+      might = record.might, resilience = record.resilience, spirit = record.spirit,
+      arcane = record.arcane, will = record.will, sensory = record.sensory,
+      reflex = record.reflex, vigor = record.vigor, skill = record.skill,
+      intelligence = record.intelligence, luck = record.luck, mission_id = record.mission_id,
+      level = record.level, completed_missions = record.completed_missions,
+      commissary_reward = record.commissary_reward, appearance = record.appearance,
+      additional_gear = record.additional_gear, image_url = record.image_url,
+      image_crop = record.image_crop, flavor = record.flavor, ideas = record.ideas,
+      background = record.background, perks = record.perks, private_notes = record.private_notes,
+      class_id = record.class_id, common_items = record.common_items,
+      quirks = record.quirks, accessories = record.accessories,
+      creator_mode = record.creator_mode
+    FROM jsonb_populate_record(current, p_character) AS record
+    WHERE current.id = p_character_id AND current.creator_id = p_creator_id
+    RETURNING current.* INTO saved;
+    IF saved.id IS NULL THEN
+      RAISE EXCEPTION 'Character update returned no rows';
+    END IF;
+  END IF;
+
+  DELETE FROM public.traits WHERE character_id = saved.id;
+  INSERT INTO public.traits (character_id, name)
+  SELECT saved.id, trait_item->>'name'
+  FROM jsonb_array_elements(COALESCE(p_traits, '[]'::jsonb)) AS trait_item;
+
+  IF p_gear IS NOT NULL THEN
+    DELETE FROM public.class_gear WHERE character_id = saved.id;
+    INSERT INTO public.class_gear (character_id, name, class_id, description)
+    SELECT saved.id, gear_item->>'name', (gear_item->>'class_id')::uuid, gear_item->>'description'
+    FROM jsonb_array_elements(p_gear) AS gear_item;
+  END IF;
+
+  IF p_abilities IS NOT NULL THEN
+    DELETE FROM public.class_abilities WHERE character_id = saved.id;
+    INSERT INTO public.class_abilities (character_id, name, class_id, description)
+    SELECT saved.id, ability_item->>'name', (ability_item->>'class_id')::uuid, ability_item->>'description'
+    FROM jsonb_array_elements(p_abilities) AS ability_item;
+  END IF;
+
+  IF p_perks IS NOT NULL THEN
+    DELETE FROM public.character_perks WHERE character_id = saved.id;
+    FOR item IN SELECT value FROM jsonb_array_elements(p_perks)
+    LOOP
+      ability_id := NULL;
+      IF item ? 'class_ability_id' AND item->>'class_ability_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+        ability_id := (item->>'class_ability_id')::uuid;
+      END IF;
+      IF ability_id IS NULL AND item ? 'ability_name' THEN
+        SELECT id INTO ability_id FROM public.class_abilities
+        WHERE character_id = saved.id AND name = item->>'ability_name'
+        ORDER BY id LIMIT 1;
+      END IF;
+      INSERT INTO public.character_perks (character_id, class_ability_id, text, position)
+      VALUES (saved.id, ability_id, item->>'text', COALESCE((item->>'position')::integer, 0));
+    END LOOP;
+
+    FOR item IN SELECT value FROM jsonb_array_elements(p_perks)
+    LOOP
+      IF item->>'compounds_with' LIKE 'position-%' THEN
+        SELECT cp.id INTO source_perk_id
+        FROM public.character_perks cp
+        WHERE cp.character_id = saved.id
+          AND cp.position = (item->>'position')::integer
+          AND (item->>'ability_name' IS NULL OR cp.class_ability_id = (
+            SELECT id FROM public.class_abilities WHERE character_id = saved.id AND name = item->>'ability_name' ORDER BY id LIMIT 1
+          ));
+        SELECT cp.id INTO target_perk_id
+        FROM public.character_perks cp
+        WHERE cp.character_id = saved.id
+          AND cp.position = substring(item->>'compounds_with' FROM 'position-(.*)')::integer
+          AND cp.class_ability_id = (SELECT class_ability_id FROM public.character_perks WHERE id = source_perk_id);
+        UPDATE public.character_perks SET compounds_with = target_perk_id WHERE id = source_perk_id;
+      END IF;
+    END LOOP;
+  END IF;
+
+  RETURN saved;
+END;
+$$;

--- a/supabase/migrations/20260710000001_atomic_character_writes_permissions.sql
+++ b/supabase/migrations/20260710000001_atomic_character_writes_permissions.sql
@@ -1,0 +1,1 @@
+REVOKE ALL ON FUNCTION public.save_character_atomic(uuid, uuid, jsonb, jsonb, jsonb, jsonb, jsonb) FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260710000002_atomic_character_writes_service_role.sql
+++ b/supabase/migrations/20260710000002_atomic_character_writes_service_role.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION public.save_character_atomic(uuid, uuid, jsonb, jsonb, jsonb, jsonb, jsonb) TO service_role;


### PR DESCRIPTION
## What changed

Introduces the transactional character write boundary.

- Extracts deterministic character input rules and `CharacterService` orchestration.
- Keeps model and route response contracts compatible through a Supabase adapter.
- Adds transactional Postgres RPC persistence for character rows and child records.

## Why

Character creation and updates previously performed multi-step writes that could leave partial state after a child failure.

## Stack

Base: `jm-improve-ramp-in` (merge that PR first).

## Validation

- Unit and HTTP suites
- Local-Supabase atomic character integration tests
- Static checks
