### PR TITLE
Refactor mission writes into service seam

### DIFF
--- a/models/mission.js
+++ b/models/mission.js
@@ -1,7 +1,7 @@
 const { supabase, supabaseAdmin } = require('./_base');
-const { sanitizeUrlFields } = require('../util/url');
 const { escapeLikePattern } = require('../util/validate');
 const { recalcMilestoneBadgesSafely, getMissionProfileIds } = require('./badge');
+const { MissionService } = require('../services/mission/service');
 
 const getMissions = async () => {
   const { data, error } = await supabase
@@ -96,94 +96,14 @@ const getOwnMissions = async (profile, client = supabase) => {
   return { data: transformedData, error };
 }
 
-const createMission = async (missionData, profile) => {
-  missionData.creator_id = profile.id;
-  sanitizeUrlFields(missionData, ['media_url']);
-  const { data, error } = await supabaseAdmin.from('missions').insert(missionData).select();
-  if (!error && missionData.host_id) {
-    await recalcMilestoneBadgesSafely([missionData.host_id]);
-  }
-  return { data, error };
-};
-
-const updateMission = async (id, missionData, profile) => {
-  // Check if profile can edit this mission (creator, host, or editor)
-  const canEdit = await canEditMission(id, profile);
-  if (!canEdit) {
-    return { data: null, error: 'Unauthorized: You do not have permission to edit this mission' };
-  }
-
-  // Capture the current host before the write: a host swap must recalc the
-  // outgoing host's badges too (counts only ever ADD badges; this just keeps
-  // both profiles' award rows up to date). Like every query in this module,
-  // this read returns { data, error } rather than throwing on a query error,
-  // so it is safe to await unguarded ahead of the mutation.
-  const { data: existing } = await supabaseAdmin
-    .from('missions')
-    .select('host_id')
-    .eq('id', id)
-    .maybeSingle();
-
-  sanitizeUrlFields(missionData, ['media_url']);
-
-  const { data, error } = await supabaseAdmin
-    .from('missions')
-    .update(missionData)
-    .eq('id', id)
-    .select();
-  if (!error) {
-    await recalcMilestoneBadgesSafely([existing?.host_id, missionData.host_id]);
-  }
-  return { data, error };
-};
-
-const deleteMission = async (id, profile) => {
-  // Affected profiles must be captured BEFORE the rows disappear.
-  const affected = await getMissionProfileIds(id);
-  const { data, error } = await supabaseAdmin
-    .from('missions')
-    .delete()
-    .eq('id', id)
-    .eq('creator_id', profile.id);
-  if (!error) {
-    await recalcMilestoneBadgesSafely(affected);
-  }
-  return { data, error };
-};
-
-const recalcCharacterCreator = async (characterId) => {
-  // Resolves to { data, error } (never throws on a query error), so an
-  // unguarded await here cannot break the calling mutation's return contract.
-  const { data: character } = await supabaseAdmin
-    .from('characters')
-    .select('creator_id')
-    .eq('id', characterId)
-    .maybeSingle();
-  await recalcMilestoneBadgesSafely([character?.creator_id]);
-};
-
-const addCharacterToMission = async (missionId, characterId) => {
-  const { data, error } = await supabaseAdmin
-    .from('mission_characters')
-    .upsert({ mission_id: missionId, character_id: characterId })
-    .select();
-  if (!error) {
-    await recalcCharacterCreator(characterId);
-  }
-  return { data, error };
-};
-
-const removeCharacterFromMission = async (missionId, characterId) => {
-  const { data, error } = await supabaseAdmin
-    .from('mission_characters')
-    .delete()
-    .eq('mission_id', missionId)
-    .eq('character_id', characterId);
-  if (!error) {
-    await recalcCharacterCreator(characterId);
-  }
-  return { data, error };
-};
+// Compatibility functions are deliberately kept at the model boundary for
+// routes and imports; their write decisions live in services/mission.
+let missionService;
+const createMission = async (missionData, profile) => missionService.createMission(missionData, profile);
+const updateMission = async (id, missionData, profile) => missionService.updateMission(id, missionData, profile);
+const deleteMission = async (id, profile) => missionService.deleteMission(id, profile);
+const addCharacterToMission = async (missionId, characterId) => missionService.addCharacter(missionId, characterId);
+const removeCharacterFromMission = async (missionId, characterId) => missionService.removeCharacter(missionId, characterId);
 
 const getMissionCharacters = async (missionId, client = supabase) => {
   const { data, error } = await client
@@ -721,35 +641,8 @@ const searchSimilarMissions = async (date, name, excludeId = null, daysRange = 3
  * - Adds editors from secondary to primary
  * - Deletes secondary mission
  */
-const mergeMissions = async (primaryId, secondaryId, profile) => {
-  const [canPrimary, canSecondary] = await Promise.all([
-    canEditMission(primaryId, profile),
-    canEditMission(secondaryId, profile)
-  ]);
-  if (!canPrimary || !canSecondary) {
-    return { data: null, error: 'You must be able to edit both missions to merge them' };
-  }
-
-  // Capture BEFORE the merge: the secondary mission's rows are deleted by the RPC.
-  const affected = [
-    ...(await getMissionProfileIds(primaryId)),
-    ...(await getMissionProfileIds(secondaryId))
-  ];
-
-  const { error } = await supabaseAdmin.rpc('merge_missions', {
-    primary_id: primaryId,
-    secondary_id: secondaryId,
-    actor_profile_id: profile.id
-  });
-  if (error) {
-    console.error('merge_missions RPC failed:', error);
-    return { data: null, error };
-  }
-
-  await recalcMilestoneBadgesSafely(affected);
-
-  return await getMission(primaryId);
-};
+const mergeMissions = async (primaryId, secondaryId, profile) =>
+  missionService.mergeMissions(primaryId, secondaryId, profile);
 
 /**
  * Preview what a merge would look like without actually performing it
@@ -808,6 +701,30 @@ const previewMergeMissions = async (primaryId, secondaryId) => {
     return { data: null, error };
   }
 };
+
+// Initial Supabase adapter. It intentionally contains only persistence and
+// lookup details; authorization, input handling, sequencing, and badge
+// decisions are testable in MissionService.
+missionService = new MissionService({
+  canEdit: canEditMission,
+  getHost: id => supabaseAdmin.from('missions').select('host_id').eq('id', id).maybeSingle(),
+  createMissionRow: data => supabaseAdmin.from('missions').insert(data).select(),
+  updateMissionRow: (id, data) => supabaseAdmin.from('missions').update(data).eq('id', id).select(),
+  deleteMissionRow: (id, creatorId) => supabaseAdmin
+    .from('missions').delete().eq('id', id).eq('creator_id', creatorId),
+  getMissionProfileIds,
+  getCharacterCreator: id => supabaseAdmin
+    .from('characters').select('creator_id').eq('id', id).maybeSingle(),
+  upsertMissionCharacter: (missionId, characterId) => supabaseAdmin
+    .from('mission_characters').upsert({ mission_id: missionId, character_id: characterId }).select(),
+  deleteMissionCharacter: (missionId, characterId) => supabaseAdmin
+    .from('mission_characters').delete().eq('mission_id', missionId).eq('character_id', characterId),
+  mergeMissions: (primaryId, secondaryId, actorId) => supabaseAdmin.rpc('merge_missions', {
+    primary_id: primaryId, secondary_id: secondaryId, actor_profile_id: actorId
+  }),
+  getMission,
+  recalcBadges: recalcMilestoneBadgesSafely
+});
 
 module.exports = {
   getMissions,

--- a/services/mission/input.js
+++ b/services/mission/input.js
@@ -1,0 +1,14 @@
+const { sanitizeUrlFields } = require('../../util/url');
+
+const cloneInput = (input) => ({ ...(input || {}) });
+
+// Mission forms share a mutable sanitizer with older callers. Apply it only
+// to this copy so service consumers can safely reuse their submitted payload.
+const normalizeMissionInput = (input, { creatorId } = {}) => {
+  const data = cloneInput(input);
+  if (creatorId) data.creator_id = creatorId;
+  sanitizeUrlFields(data, ['media_url']);
+  return data;
+};
+
+module.exports = { cloneInput, normalizeMissionInput };

--- a/services/mission/service.js
+++ b/services/mission/service.js
@@ -1,0 +1,77 @@
+const { normalizeMissionInput } = require('./input');
+
+const REQUIRED_ADAPTER_METHODS = [
+  'canEdit', 'getHost', 'createMissionRow', 'updateMissionRow', 'deleteMissionRow',
+  'getMissionProfileIds', 'getCharacterCreator', 'upsertMissionCharacter',
+  'deleteMissionCharacter', 'mergeMissions', 'getMission', 'recalcBadges'
+];
+
+/** Coordinates mission writes and badge side effects independently of Supabase. */
+class MissionService {
+  constructor(adapter) {
+    const missing = REQUIRED_ADAPTER_METHODS.filter(method => typeof adapter?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`MissionService requires adapter methods: ${missing.join(', ')}`);
+    this.adapter = adapter;
+  }
+
+  async createMission(input, actor) {
+    const data = normalizeMissionInput(input, { creatorId: actor.id });
+    const result = await this.adapter.createMissionRow(data);
+    if (!result.error && data.host_id) await this.adapter.recalcBadges([data.host_id]);
+    return result;
+  }
+
+  async updateMission(id, input, actor) {
+    if (!await this.adapter.canEdit(id, actor)) {
+      return { data: null, error: 'Unauthorized: You do not have permission to edit this mission' };
+    }
+    const existing = await this.adapter.getHost(id);
+    const data = normalizeMissionInput(input);
+    const result = await this.adapter.updateMissionRow(id, data);
+    if (!result.error) await this.adapter.recalcBadges([existing.data?.host_id, data.host_id]);
+    return result;
+  }
+
+  async deleteMission(id, actor) {
+    const affected = await this.adapter.getMissionProfileIds(id);
+    const result = await this.adapter.deleteMissionRow(id, actor.id);
+    if (!result.error) await this.adapter.recalcBadges(affected);
+    return result;
+  }
+
+  async addCharacter(id, characterId) {
+    const result = await this.adapter.upsertMissionCharacter(id, characterId);
+    if (!result.error) await this.recalcCharacterCreator(characterId);
+    return result;
+  }
+
+  async removeCharacter(id, characterId) {
+    const result = await this.adapter.deleteMissionCharacter(id, characterId);
+    if (!result.error) await this.recalcCharacterCreator(characterId);
+    return result;
+  }
+
+  async recalcCharacterCreator(characterId) {
+    const character = await this.adapter.getCharacterCreator(characterId);
+    await this.adapter.recalcBadges([character.data?.creator_id]);
+  }
+
+  async mergeMissions(primaryId, secondaryId, actor) {
+    const [canPrimary, canSecondary] = await Promise.all([
+      this.adapter.canEdit(primaryId, actor), this.adapter.canEdit(secondaryId, actor)
+    ]);
+    if (!canPrimary || !canSecondary) {
+      return { data: null, error: 'You must be able to edit both missions to merge them' };
+    }
+    const affected = [
+      ...(await this.adapter.getMissionProfileIds(primaryId)),
+      ...(await this.adapter.getMissionProfileIds(secondaryId))
+    ];
+    const result = await this.adapter.mergeMissions(primaryId, secondaryId, actor.id);
+    if (result.error) return { data: null, error: result.error };
+    await this.adapter.recalcBadges(affected);
+    return this.adapter.getMission(primaryId);
+  }
+}
+
+module.exports = { MissionService };

--- a/services/mission/service.test.js
+++ b/services/mission/service.test.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('bun:test');
+const { normalizeMissionInput } = require('./input');
+const { MissionService } = require('./service');
+
+const makeAdapter = () => {
+  const calls = [];
+  return {
+    calls,
+    canEdit: async () => true,
+    getHost: async () => ({ data: { host_id: 'old-host' }, error: null }),
+    createMissionRow: async data => { calls.push(['create', data]); return { data: [data], error: null }; },
+    updateMissionRow: async (id, data) => { calls.push(['update', id, data]); return { data: [data], error: null }; },
+    deleteMissionRow: async (id, actorId) => { calls.push(['delete', id, actorId]); return { data: null, error: null }; },
+    getMissionProfileIds: async id => { calls.push(['affected', id]); return ['host', 'character-owner']; },
+    getCharacterCreator: async () => ({ data: { creator_id: 'character-owner' }, error: null }),
+    upsertMissionCharacter: async (id, charId) => { calls.push(['add', id, charId]); return { data: [], error: null }; },
+    deleteMissionCharacter: async (id, charId) => { calls.push(['remove', id, charId]); return { data: null, error: null }; },
+    mergeMissions: async (primary, secondary, actor) => { calls.push(['merge', primary, secondary, actor]); return { error: null }; },
+    getMission: async id => ({ data: { id }, error: null }),
+    recalcBadges: async ids => { calls.push(['recalc', ids]); }
+  };
+};
+
+test('normalizes mission input without modifying the caller payload', () => {
+  const input = { name: 'Mission', media_url: 'javascript:bad()' };
+  const data = normalizeMissionInput(input, { creatorId: 'creator-1' });
+  expect(input).toEqual({ name: 'Mission', media_url: 'javascript:bad()' });
+  expect(data).toEqual({ name: 'Mission', media_url: null, creator_id: 'creator-1' });
+});
+
+test('updates a mission then recalculates both affected hosts', async () => {
+  const adapter = makeAdapter();
+  const service = new MissionService(adapter);
+  await service.updateMission('mission-1', { host_id: 'new-host' }, { id: 'actor-1' });
+  expect(adapter.calls).toEqual([
+    ['update', 'mission-1', { host_id: 'new-host' }],
+    ['recalc', ['old-host', 'new-host']]
+  ]);
+});
+
+test('does not write an unauthorized mission update', async () => {
+  const adapter = makeAdapter();
+  adapter.canEdit = async () => false;
+  const service = new MissionService(adapter);
+  const result = await service.updateMission('mission-1', { name: 'Nope' }, { id: 'actor-1' });
+  expect(result.error).toMatch('Unauthorized');
+  expect(adapter.calls).toEqual([]);
+});


### PR DESCRIPTION
## What changed

Extracts mission write orchestration into `MissionService`.

- Makes mission input normalization immutable.
- Centralizes create/update/delete, character links, merge sequencing, and badge recalculation.
- Keeps existing model and route contracts unchanged.

## Why

Mission mutations have related authorization, badge, and link side effects that benefit from one testable application boundary.

## Stack

Base: `lfg-service-seam` (merge the parent PR first).

## Validation

- Focused mission/badge tests
- Unit and HTTP suites
- Static checks
