### PR TITLE
Refactor class writes into service seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,4 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run check
       - run: bun run test
+      - run: bun run test:http

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,27 @@
 name: Local Supabase integration
 
 on:
+  pull_request:
+    paths:
+      - 'supabase/**'
+      - 'models/**'
+      - 'services/**'
+      - 'routes/**'
+      - 'util/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'bun.lock'
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/**'
+      - 'models/**'
+      - 'services/**'
+      - 'routes/**'
+      - 'util/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'bun.lock'
   workflow_dispatch:
 
 jobs:
@@ -12,6 +33,7 @@ jobs:
       - uses: supabase/setup-cli@v1
       - run: bun install --frozen-lockfile
       - run: supabase start
+      - run: supabase db reset
       - run: |
           eval "$(supabase status -o env)"
           SUPABASE_URL="$API_URL" \

--- a/.tickets/ar-3hsi.md
+++ b/.tickets/ar-3hsi.md
@@ -1,0 +1,19 @@
+---
+id: ar-3hsi
+status: closed
+deps: [ar-k4qi]
+links: []
+created: 2026-07-10T21:28:56Z
+type: bug
+priority: 0
+assignee: David Torres
+tags: [testing, ci]
+---
+# Stabilize HTTP test server lifecycle and run HTTP tests in CI
+
+Route test suites call app.listen(0) and immediately read server.address().port, which can be null before the listening event. The HTTP tier is not run in CI.
+
+## Acceptance Criteria
+
+Shared async server helper awaits listening and closes cleanly; all route HTTP suites use it; bun run test:http is deterministic; PR CI runs it.
+

--- a/.tickets/ar-5kph.md
+++ b/.tickets/ar-5kph.md
@@ -1,0 +1,19 @@
+---
+id: ar-5kph
+status: in_progress
+deps: [ar-g1z6]
+links: []
+created: 2026-07-10T21:28:56Z
+type: task
+priority: 1
+assignee: David Torres
+tags: [architecture, dependencies]
+---
+# Remove util/supabase global model barrel
+
+util/supabase.js eagerly imports and re-exports almost every model, creating hidden domain dependencies, fragile export coupling, and oversized test mocks.
+
+## Acceptance Criteria
+
+Routes/services import explicit domain interfaces; application wiring is centralized; barrel is removed or reduced to a non-domain compatibility shim with an elimination plan.
+

--- a/.tickets/ar-ee08.md
+++ b/.tickets/ar-ee08.md
@@ -1,0 +1,19 @@
+---
+id: ar-ee08
+status: open
+deps: []
+links: []
+created: 2026-07-10T21:28:57Z
+type: task
+priority: 2
+assignee: David Torres
+tags: [tooling, contributor-experience]
+---
+# Add enforceable code-quality tooling and runtime policy
+
+bun run check only performs JavaScript syntax checks. Runtime version is not pinned and both Bun and npm lockfiles are tracked.
+
+## Acceptance Criteria
+
+Formatting/linting/static checks are documented and run in CI; Bun version is pinned for contributors and CI; package-manager/lockfile policy is singular and enforced.
+

--- a/.tickets/ar-ezes.md
+++ b/.tickets/ar-ezes.md
@@ -1,0 +1,19 @@
+---
+id: ar-ezes
+status: open
+deps: []
+links: []
+created: 2026-07-10T21:28:57Z
+type: task
+priority: 1
+assignee: David Torres
+tags: [security, architecture, database]
+---
+# Consolidate service-role access behind repositories
+
+Routes and models directly import/use supabaseAdmin. Authorization is distributed across callers while RLS is bypassed, making reviews and future changes risky.
+
+## Acceptance Criteria
+
+No route imports the service-role client; repositories/adapters encapsulate privileged persistence; services receive actor context and use capability-oriented methods; authorization tests cover each privileged command.
+

--- a/.tickets/ar-g1z6.md
+++ b/.tickets/ar-g1z6.md
@@ -1,0 +1,19 @@
+---
+id: ar-g1z6
+status: closed
+deps: []
+links: []
+created: 2026-07-10T21:28:56Z
+type: task
+priority: 1
+assignee: David Torres
+tags: [architecture, testing]
+---
+# Extract application construction from server startup
+
+index.js loads env, constructs Express, installs all routes, installs process handlers, and listens as import side effects. Tests must recreate partial app configurations.
+
+## Acceptance Criteria
+
+A createApp composition function is exported and accepts dependencies where useful; startup/listening and process handlers live in a thin entrypoint; existing behavior and routes remain intact.
+

--- a/.tickets/ar-g8y7.md
+++ b/.tickets/ar-g8y7.md
@@ -1,0 +1,19 @@
+---
+id: ar-g8y7
+status: open
+deps: [ar-k4qi, ar-3hsi, ar-xdcu, ar-g1z6, ar-5kph, ar-m8ai, ar-ezes, ar-ee08, ar-mpbi, ar-naq0]
+links: []
+created: 2026-07-10T21:28:56Z
+type: epic
+priority: 0
+assignee: David Torres
+tags: [architecture, contributor-experience, quality]
+---
+# Sustainability hardening program
+
+Address the maintainability, test reliability, CI coverage, service-boundary, and operational gaps identified in the July 2026 project review.
+
+## Acceptance Criteria
+
+All child tickets are closed; documented validation tiers are reproducible from a clean checkout; CI enforces the agreed checks.
+

--- a/.tickets/ar-k4qi.md
+++ b/.tickets/ar-k4qi.md
@@ -1,0 +1,19 @@
+---
+id: ar-k4qi
+status: closed
+deps: []
+links: []
+created: 2026-07-10T21:28:56Z
+type: bug
+priority: 0
+assignee: David Torres
+tags: [testing, ci]
+---
+# Make unit tests hermetic without Supabase credentials
+
+The documented database-free unit suite imports models/_base.js, which throws when SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, and SUPABASE_SECRET_KEY are absent. CI supplies none, so bun run test fails in a clean environment.
+
+## Acceptance Criteria
+
+bun run test passes with no .env or Supabase credentials; production startup still fails clearly for missing required credentials; CI validates this path.
+

--- a/.tickets/ar-m8ai.md
+++ b/.tickets/ar-m8ai.md
@@ -1,0 +1,19 @@
+---
+id: ar-m8ai
+status: open
+deps: [ar-ezes]
+links: []
+created: 2026-07-10T21:28:57Z
+type: epic
+priority: 1
+assignee: David Torres
+tags: [architecture, character, transactions]
+---
+# Complete character mutation service boundary
+
+CharacterService handles create/update but routes/characters.js still contains direct admin writes, authorization, validation, workflow logic, and multi-step perk persistence.
+
+## Acceptance Criteria
+
+All character mutations are implemented as named use cases/services with tested contracts and transaction boundaries; route handlers only translate HTTP and render responses.
+

--- a/.tickets/ar-mpbi.md
+++ b/.tickets/ar-mpbi.md
@@ -1,0 +1,19 @@
+---
+id: ar-mpbi
+status: open
+deps: [ar-g1z6]
+links: []
+created: 2026-07-10T21:28:57Z
+type: task
+priority: 2
+assignee: David Torres
+tags: [frontend, testing]
+---
+# Add automated coverage for critical browser workflows
+
+The largest modules are public browser scripts, especially character wizard and general app behavior, with no automated browser coverage.
+
+## Acceptance Criteria
+
+Pure client state logic is extracted and unit-tested where practical; a browser smoke suite covers character create/edit and wizard submission; suite runs in CI.
+

--- a/.tickets/ar-naq0.md
+++ b/.tickets/ar-naq0.md
@@ -1,0 +1,19 @@
+---
+id: ar-naq0
+status: open
+deps: [ar-xdcu]
+links: []
+created: 2026-07-10T21:28:57Z
+type: task
+priority: 2
+assignee: David Torres
+tags: [operations, documentation]
+---
+# Document and automate operational runbooks
+
+Deployment/runtime compatibility, migration rollout/repair, backup restore, and ownership practices remain underspecified. The backup script is hard-coded to one Supabase project.
+
+## Acceptance Criteria
+
+Repository documents deployment config, runtime support, migration and rollback/repair, backup and restore drills, and ownership/review expectations; backup tooling is environment-configurable and safely validated.
+

--- a/.tickets/ar-xdcu.md
+++ b/.tickets/ar-xdcu.md
@@ -1,0 +1,19 @@
+---
+id: ar-xdcu
+status: closed
+deps: [ar-k4qi, ar-3hsi]
+links: []
+created: 2026-07-10T21:28:56Z
+type: task
+priority: 0
+assignee: David Torres
+tags: [integration, ci, database]
+---
+# Make local Supabase integration reproducible and enforce it for database changes
+
+Integration workflow is manual-only and does not initialize/reset a local Supabase project or explicitly apply migrations/seeds. Database/RPC/RLS changes can merge without a reliable integration gate.
+
+## Acceptance Criteria
+
+Fresh checkout can provision/reset local Supabase reproducibly; migration/RPC/RLS integration suite runs in automation; PR policy enforces it for relevant changes.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,10 @@
 Use Bun for the application and test commands. Install dependencies with
 `bun install`, copy `.env.dist` to `.env`, then run `bun run setup`.
 
-Run `bun run check` and `bun run test` before opening a pull request. HTTP tests are separate:
-`bun run test:http`. Database integration tests require a local Supabase stack
-and are opt-in: `supabase start` followed by `bun run test:integration`.
+Run `bun run check`, `bun run test`, and `bun run test:http` before opening a
+pull request. Database integration tests require a local Supabase stack:
+`supabase start`, `supabase db reset`, then `bun run test:integration`.
+The integration workflow runs automatically when database-facing code changes.
 
 ## Change checklist
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,9 @@ Prerequisites: [Docker](https://docs.docker.com/get-docker/) and the
 install supabase/tap/supabase`, or `npm i -D supabase`, or the install
 script).
 
-1. Initialize the local workspace. This adds `supabase/config.toml` next to
-   the existing `supabase/migrations/` and `supabase/seed.sql`:
-   ```sh
-   supabase init
-   ```
-
-2. Start the local stack (Postgres, GoTrue, PostgREST, etc.):
+1. Start the local stack (Postgres, GoTrue, PostgREST, etc.). The repository
+   includes `supabase/config.toml`, migrations, and seed data, so no separate
+   initialization step is needed:
    ```sh
    supabase start
    ```
@@ -92,7 +88,7 @@ script).
    finishes, copy the printed `API URL`, `anon key`, and `service_role key`
    — you'll need them in a moment.
 
-3. Create a `.env` from the template. The local stack uses fixed defaults
+2. Create a `.env` from the template. The local stack uses fixed defaults
    — the DB password is always `postgres`:
    ```sh
    cp .env.example .env
@@ -104,7 +100,7 @@ script).
    - `SUPABASE_SECRET_KEY=<service_role key from `supabase status`>`
    - `SUPABASE_DB_PASS=postgres`
 
-4. Apply migrations and seeds via the Supabase CLI. (The bundled `bun run
+3. Apply migrations and seeds via the Supabase CLI. (The bundled `bun run
    setup` script targets the Supabase cloud pooler and won't work against a
    local stack — `supabase db reset` is the local equivalent: it runs every
    file in `supabase/migrations/` plus `supabase/seed.sql`):
@@ -112,7 +108,7 @@ script).
    supabase db reset
    ```
 
-5. Start the app:
+4. Start the app:
    ```sh
    bun run dev
    ```

--- a/app.js
+++ b/app.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const exphbs = require('express-handlebars');
+const helpers = require('handlebars-helpers')();
+const {
+  times, date_tz, calendar_link, getTotalV1MissionsNeeded, getTotalV2MissionsNeeded,
+  setVariable, encodeURIComponentH, dump, videoEmbed, isSupportedVideoUrl, substring,
+  concat, effectiveRulesVersion, wordCount, perksForAbility, nextPerkPosition, json
+} = require('./util/handlebars');
+const { renderMarkdown } = require('./util/markdown');
+const { sendError } = require('./util/http-error');
+const range = require('handlebars-helper-range');
+const path = require('path');
+
+const homeRoutes = require('./routes/home');
+const authRoutes = require('./routes/auth');
+const charactersRoutes = require('./routes/characters');
+const lfgRoutes = require('./routes/lfg');
+const profileRoutes = require('./routes/profile');
+const missionsRoutes = require('./routes/missions');
+const classesRoutes = require('./routes/classes');
+const libraryRoutes = require('./routes/library');
+const badgesRoutes = require('./routes/badges');
+const pagesRoutes = require('./routes/pages');
+const navRoutes = require('./routes/nav');
+const agentRoutes = require('./routes/agent');
+const botLinkRoutes = require('./routes/bot-link');
+const { loadNavItems } = require('./util/nav-loader');
+
+const createApp = () => {
+  const app = express();
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use(express.static(path.join(__dirname, 'public')));
+
+  app.engine('handlebars', exphbs.engine({
+    layoutsDir: path.join(__dirname, 'views/layouts'),
+    partialsDir: path.join(__dirname, 'views/partials'),
+    defaultLayout: 'main',
+    helpers: {
+      ...helpers,
+      times,
+      range,
+      date_tz,
+      calendar_link,
+      encodeURIComponentH,
+      getTotalV1MissionsNeeded,
+      getTotalV2MissionsNeeded,
+      setVariable,
+      dump,
+      videoEmbed,
+      isSupportedVideoUrl,
+      substring,
+      concat,
+      effectiveRulesVersion,
+      wordCount,
+      perksForAbility,
+      nextPerkPosition,
+      json,
+      markdown: renderMarkdown
+    }
+  }));
+  app.set('view engine', 'handlebars');
+  app.set('views', path.join(__dirname, 'views'));
+
+  app.use((req, res, next) => {
+    res.locals.supabaseUrl = process.env.SUPABASE_URL;
+    res.locals.supabaseKey = process.env.SUPABASE_PUBLISHABLE_KEY;
+    next();
+  });
+
+  app.use(loadNavItems);
+  app.use('/', homeRoutes);
+  app.use('/auth', authRoutes);
+  app.use('/profile', profileRoutes);
+  app.use('/characters', charactersRoutes);
+  app.use('/lfg', lfgRoutes);
+  app.use('/missions', missionsRoutes);
+  app.use('/classes', classesRoutes);
+  app.use('/library', libraryRoutes);
+  app.use('/badges', badgesRoutes);
+  app.use('/pages', pagesRoutes);
+  app.use('/nav', navRoutes);
+  app.use('/link/bot', botLinkRoutes);
+  app.use('/api/agent', agentRoutes);
+
+  app.use((err, req, res, next) => {
+    console.error('Unhandled error:', err);
+    if (res.headersSent) return next(err);
+    return sendError(req, res, err);
+  });
+
+  return app;
+};
+
+module.exports = { createApp };

--- a/index.js
+++ b/index.js
@@ -1,99 +1,8 @@
 require('./util/env');
-const express = require('express');
-const exphbs = require('express-handlebars');
-const helpers = require('handlebars-helpers')();
-const { times, date_tz, calendar_link, getTotalV1MissionsNeeded, getTotalV2MissionsNeeded, setVariable, encodeURIComponentH, dump, videoEmbed, isSupportedVideoUrl, substring, concat, effectiveRulesVersion, wordCount, perksForAbility, nextPerkPosition, json } = require('./util/handlebars');
-const { renderMarkdown } = require('./util/markdown');
-const { sendError } = require('./util/http-error');
-const range = require('handlebars-helper-range');
-const path = require('path');
+const { createApp } = require('./app');
 
-const homeRoutes = require('./routes/home');
-const authRoutes = require('./routes/auth');
-const charactersRoutes = require('./routes/characters');
-const lfgRoutes = require('./routes/lfg');
-const profileRoutes = require('./routes/profile');
-const missionsRoutes = require('./routes/missions');
-const classesRoutes = require('./routes/classes');
-const libraryRoutes = require('./routes/library');
-const badgesRoutes = require('./routes/badges');
-const pagesRoutes = require('./routes/pages');
-const navRoutes = require('./routes/nav');
-const agentRoutes = require('./routes/agent');
-const botLinkRoutes = require('./routes/bot-link');
-
-const app = express();
 const PORT = process.env.PORT || 3000;
-
-// Middleware
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-app.use(express.static(path.join(__dirname, 'public')));
-
-// Set up Handlebars
-app.engine('handlebars', exphbs.engine({
-  layoutsDir: path.join(__dirname, 'views/layouts'),
-  partialsDir: path.join(__dirname, 'views/partials'),
-  defaultLayout: 'main',
-    helpers: {
-      ...helpers,
-      times,
-      range,
-      date_tz,
-      calendar_link,
-      encodeURIComponentH,
-      getTotalV1MissionsNeeded,
-      getTotalV2MissionsNeeded,
-      setVariable,
-      dump,
-      videoEmbed,
-      isSupportedVideoUrl,
-      substring,
-      concat,
-      effectiveRulesVersion,
-      wordCount,
-      perksForAbility,
-      nextPerkPosition,
-      json,
-      markdown: renderMarkdown
-  }
-}));
-app.set('view engine', 'handlebars');
-app.set('views', path.join(__dirname, 'views'));
-
-// pass supabaseUrl and supabaseKey to the frontend
-app.use((req, res, next) => {
-  res.locals.supabaseUrl = process.env.SUPABASE_URL;
-  res.locals.supabaseKey = process.env.SUPABASE_PUBLISHABLE_KEY;
-  next();
-});
-
-// Load navigation items for routes that don't use auth middleware
-// (Routes with auth middleware will load nav items in the auth middleware itself)
-const { loadNavItems } = require('./util/nav-loader');
-app.use(loadNavItems);
-
-// Routes
-app.use('/', homeRoutes);
-app.use('/auth', authRoutes);
-app.use('/profile', profileRoutes);
-app.use('/characters', charactersRoutes);
-app.use('/lfg', lfgRoutes);
-app.use('/missions', missionsRoutes);
-app.use('/classes', classesRoutes);
-app.use('/library', libraryRoutes);
-app.use('/badges', badgesRoutes);
-app.use('/pages', pagesRoutes);
-app.use('/nav', navRoutes);
-app.use('/link/bot', botLinkRoutes);
-app.use('/api/agent', agentRoutes);
-
-// Global error handler (must be after all route mounts)
-app.use((err, req, res, next) => {
-  console.error('Unhandled error:', err);
-  if (res.headersSent) return next(err);
-  return sendError(req, res, err);
-});
+const app = createApp();
 
 process.on('unhandledRejection', (reason) => {
   console.error('unhandledRejection:', reason);
@@ -103,7 +12,6 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-// Start server
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
 });

--- a/models/class.js
+++ b/models/class.js
@@ -1,7 +1,7 @@
 const { supabase, supabaseAdmin } = require('./_base');
 const crypto = require('crypto');
-const { sanitizeUrlFields } = require('../util/url');
 const { computeVersionFamily, expandIdsToFamilies } = require('../util/class-family');
+const { ClassService } = require('../services/class/service');
 
 const applyClassFilters = (query, filters = {}) => {
     if (filters.name) {
@@ -160,50 +160,11 @@ const getClass = async (id, client = supabase) => {
     return { data, error };
 };
 
-const createClass = async (classData) => {
-    // // pack jsonb fields: abilities and gear
-    // classData.abilities = JSON.stringify(classData.abilities);
-    // classData.gear = JSON.stringify(classData.gear);
-
-    sanitizeUrlFields(classData, ['image_url']);
-
-    // authz: route sets created_by and restricts is_player_created/status for non-admins
-    const { data, error } = await supabaseAdmin
-        .from('classes')
-        .insert([classData])
-        .select()
-        .single();
-
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error };
-};
-
-const updateClass = async (id, updates) => {
-    // pack jsonb fields: abilities and gear
-    // console.log('updateClass before', updates);
-    // updates.abilities = JSON.stringify(updates.abilities);
-    // updates.gear = JSON.stringify(updates.gear);
-    // console.log('updateClass after', updates);
-
-    sanitizeUrlFields(updates, ['image_url']);
-
-    // authz: caller route must verify requester is owner (created_by) or admin
-    const { data, error } = await supabaseAdmin
-        .from('classes')
-        .update(updates)
-        .eq('id', id)
-        .select()
-        .single();
-
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error };
-};
+// Route-facing compatibility functions. The service owns input preparation and
+// write orchestration while this model remains the Supabase adapter.
+let classService;
+const createClass = async (classData) => classService.createClass(classData);
+const updateClass = async (id, updates) => classService.updateClass(id, updates);
 
 const duplicateClass = async (baseId, newVersion, newEdition = null) => {
     const params = {
@@ -223,28 +184,8 @@ const duplicateClass = async (baseId, newVersion, newEdition = null) => {
     return { data, error };
 };
 
-const saveClassPdfMetadata = async (classId, storagePath) => {
-    if (!classId) {
-        return { data: null, error: new Error('Missing class id') };
-    }
-    const updates = {
-        pdf_storage_path: storagePath || null,
-        pdf_updated_at: storagePath ? new Date().toISOString() : null
-    };
-    // authz: called only from createClass/updateClass routes which gate access
-    const { data, error } = await supabaseAdmin
-        .from('classes')
-        .update(updates)
-        .eq('id', classId)
-        .select()
-        .single();
-
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error: null };
-};
+const saveClassPdfMetadata = async (classId, storagePath) =>
+    classService.savePdfMetadata(classId, storagePath);
 
 const getUnlockedClasses = async (userId) => {
     const now = new Date().toISOString();
@@ -489,19 +430,7 @@ const getVersionHistory = async (classId) => {
     return { data, error };
 };
 
-const deleteClass = async (id) => {
-    // authz: caller route must verify requester is owner (created_by) or admin
-    const { error } = await supabaseAdmin
-        .from('classes')
-        .delete()
-        .eq('id', id);
-
-    if (error) {
-        console.error(error);
-        return { error };
-    }
-    return { error: null };
-};
+const deleteClass = async (id) => classService.deleteClass(id);
 
 // Build lookup maps from gear/ability name -> class_id and description
 const buildClassContentLookupMaps = async () => {
@@ -552,6 +481,32 @@ const buildClassContentLookupMaps = async () => {
       throw error;
     }
 };
+
+const withClassWriteResult = async (query) => {
+    const { data, error } = await query;
+    if (error) {
+        console.error(error);
+        return { data: null, error };
+    }
+    return { data, error: null };
+};
+
+classService = new ClassService({
+    createClassRow: data => withClassWriteResult(
+        supabaseAdmin.from('classes').insert([data]).select().single()
+    ),
+    updateClassRow: (id, data) => withClassWriteResult(
+        supabaseAdmin.from('classes').update(data).eq('id', id).select().single()
+    ),
+    deleteClassRow: async id => {
+        const { error } = await supabaseAdmin.from('classes').delete().eq('id', id);
+        if (error) console.error(error);
+        return { error: error || null };
+    },
+    savePdfMetadataRow: (id, data) => withClassWriteResult(
+        supabaseAdmin.from('classes').update(data).eq('id', id).select().single()
+    )
+});
 
 module.exports = {
     getClasses,

--- a/routes/badges.test.js
+++ b/routes/badges.test.js
@@ -50,21 +50,21 @@ mock.module('../models/profile', () => ({
 }));
 
 const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
 let server;
 let baseUrl;
 
-beforeAll(() => {
+beforeAll(async () => {
   delete require.cache[require.resolve('./badges')];
   const app = express();
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use('/badges', require('./badges'));
-  server = app.listen(0);
-  baseUrl = `http://localhost:${server.address().port}`;
+  ({ server, baseUrl } = await startHttpServer(app));
 });
 
-afterAll(() => {
-  server?.close();
+afterAll(async () => {
+  await stopHttpServer(server);
   mock.module('../util/supabase', () => realSupabase);
   mock.module('../util/system-message', () => realSystemMessage);
   mock.module('../models/lfg', () => realLfg);

--- a/routes/character-level-up.test.js
+++ b/routes/character-level-up.test.js
@@ -150,20 +150,20 @@ mock.module('../util/nav-loader', () => ({
 }));
 
 const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
 let server;
 let baseUrl;
 
-beforeAll(() => {
+beforeAll(async () => {
   delete require.cache[require.resolve('./characters')];
   const app = express();
   app.use(express.json());
   app.use('/characters', require('./characters'));
-  server = app.listen(0);
-  baseUrl = `http://localhost:${server.address().port}`;
+  ({ server, baseUrl } = await startHttpServer(app));
 });
 
-afterAll(() => {
-  if (server) server.close();
+afterAll(async () => {
+  await stopHttpServer(server);
   mock.module('../models/_base', () => realBase);
   mock.module('../util/supabase', () => realSupabase);
   mock.module('../util/system-message', () => realSystemMessage);

--- a/routes/character-wizard.test.js
+++ b/routes/character-wizard.test.js
@@ -100,21 +100,21 @@ mock.module('../util/nav-loader', () => ({
 }));
 
 const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
 let server;
 let baseUrl;
 
-beforeAll(() => {
+beforeAll(async () => {
   delete require.cache[require.resolve('./characters')];
   const app = express();
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use('/characters', require('./characters'));
-  server = app.listen(0);
-  baseUrl = `http://localhost:${server.address().port}`;
+  ({ server, baseUrl } = await startHttpServer(app));
 });
 
-afterAll(() => {
-  if (server) server.close();
+afterAll(async () => {
+  await stopHttpServer(server);
   mock.module('../models/_base', () => realBase);
   mock.module('../util/supabase', () => realSupabase);
   mock.module('../util/system-message', () => realSystemMessage);

--- a/routes/characters.test.js
+++ b/routes/characters.test.js
@@ -99,11 +99,12 @@ const {
   substring, concat, effectiveRulesVersion, wordCount, perksForAbility, nextPerkPosition, json
 } = require('../util/handlebars');
 const { renderMarkdown } = require('../util/markdown');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
 
 let server;
 let baseUrl;
 
-beforeAll(() => {
+beforeAll(async () => {
   delete require.cache[require.resolve('./characters')];
 
   const app = express();
@@ -150,12 +151,11 @@ beforeAll(() => {
   });
 
   app.use('/characters', require('./characters'));
-  server = app.listen(0);
-  baseUrl = `http://localhost:${server.address().port}`;
+  ({ server, baseUrl } = await startHttpServer(app));
 });
 
-afterAll(() => {
-  if (server) server.close();
+afterAll(async () => {
+  await stopHttpServer(server);
   mock.module('../models/_base', () => realBase);
   mock.module('../util/supabase', () => realSupabase);
   mock.module('../util/system-message', () => realSystemMessage);

--- a/routes/classes-stat-spread.test.js
+++ b/routes/classes-stat-spread.test.js
@@ -97,21 +97,21 @@ mock.module('../util/nav-loader', () => ({
 }));
 
 const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
 let server;
 let baseUrl;
 
-beforeAll(() => {
+beforeAll(async () => {
   delete require.cache[require.resolve('./classes')];
   const app = express();
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use('/classes', require('./classes'));
-  server = app.listen(0);
-  baseUrl = `http://localhost:${server.address().port}`;
+  ({ server, baseUrl } = await startHttpServer(app));
 });
 
-afterAll(() => {
-  if (server) server.close();
+afterAll(async () => {
+  await stopHttpServer(server);
   mock.module('../models/_base', () => realBase);
   mock.module('../util/supabase', () => realSupabase);
   mock.module('../util/system-message', () => realSystemMessage);

--- a/routes/missions.test.js
+++ b/routes/missions.test.js
@@ -46,20 +46,20 @@ mock.module('../util/nav-loader', () => ({
 }));
 
 const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
 let server;
 let baseUrl;
 
-beforeAll(() => {
+beforeAll(async () => {
   delete require.cache[require.resolve('./missions')];
   const app = express();
   app.use(express.json());
   app.use('/missions', require('./missions'));
-  server = app.listen(0);
-  baseUrl = `http://localhost:${server.address().port}`;
+  ({ server, baseUrl } = await startHttpServer(app));
 });
 
-afterAll(() => {
-  server?.close();
+afterAll(async () => {
+  await stopHttpServer(server);
   mock.module('../util/supabase', () => realSupabase);
   mock.module('../util/system-message', () => realSystemMessage);
   mock.module('../models/lfg', () => realLfg);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -44,9 +44,23 @@ if (mode === 'integration') {
   }
 }
 
+// Unit and HTTP tests must be runnable from a clean checkout. A few legacy
+// modules construct their Supabase clients at import time even when the test
+// exercises only pure functions, so provide inert placeholder credentials to
+// child test processes. Integration tests intentionally use only the caller's
+// local-Supabase credentials.
+const testEnv = mode === 'integration'
+  ? process.env
+  : {
+      ...process.env,
+      SUPABASE_URL: process.env.SUPABASE_URL || 'https://test.invalid',
+      SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key',
+      SUPABASE_SECRET_KEY: process.env.SUPABASE_SECRET_KEY || 'test-secret-key'
+    };
+
 // Run one file per Bun process. Several older tests install process-global
 // module mocks; isolation keeps unit tests deterministic and DB-free.
 for (const file of files) {
-  const result = spawnSync('bun', ['test', file], { cwd: root, stdio: 'inherit', env: process.env });
+  const result = spawnSync('bun', ['test', file], { cwd: root, stdio: 'inherit', env: testEnv });
   if (result.status !== 0) process.exit(result.status ?? 1);
 }

--- a/services/class/input.js
+++ b/services/class/input.js
@@ -1,0 +1,11 @@
+const { sanitizeUrlFields } = require('../../util/url');
+
+const cloneInput = (input) => ({ ...(input || {}) });
+
+const normalizeClassInput = (input) => {
+  const data = cloneInput(input);
+  sanitizeUrlFields(data, ['image_url']);
+  return data;
+};
+
+module.exports = { cloneInput, normalizeClassInput };

--- a/services/class/service.js
+++ b/services/class/service.js
@@ -1,0 +1,34 @@
+const { normalizeClassInput } = require('./input');
+
+const REQUIRED_ADAPTER_METHODS = ['createClassRow', 'updateClassRow', 'deleteClassRow', 'savePdfMetadataRow'];
+
+/** Application boundary for class writes. Route authorization stays unchanged. */
+class ClassService {
+  constructor(adapter) {
+    const missing = REQUIRED_ADAPTER_METHODS.filter(method => typeof adapter?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`ClassService requires adapter methods: ${missing.join(', ')}`);
+    this.adapter = adapter;
+  }
+
+  async createClass(input) {
+    return this.adapter.createClassRow(normalizeClassInput(input));
+  }
+
+  async updateClass(id, input) {
+    return this.adapter.updateClassRow(id, normalizeClassInput(input));
+  }
+
+  async deleteClass(id) {
+    return this.adapter.deleteClassRow(id);
+  }
+
+  async savePdfMetadata(classId, storagePath) {
+    if (!classId) return { data: null, error: new Error('Missing class id') };
+    return this.adapter.savePdfMetadataRow(classId, {
+      pdf_storage_path: storagePath || null,
+      pdf_updated_at: storagePath ? new Date().toISOString() : null
+    });
+  }
+}
+
+module.exports = { ClassService };

--- a/services/class/service.test.js
+++ b/services/class/service.test.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('bun:test');
+const { normalizeClassInput } = require('./input');
+const { ClassService } = require('./service');
+
+const makeAdapter = () => {
+  const calls = [];
+  return {
+    calls,
+    createClassRow: async data => { calls.push(['create', data]); return { data, error: null }; },
+    updateClassRow: async (id, data) => { calls.push(['update', id, data]); return { data, error: null }; },
+    deleteClassRow: async id => { calls.push(['delete', id]); return { error: null }; },
+    savePdfMetadataRow: async (id, data) => { calls.push(['pdf', id, data]); return { data, error: null }; }
+  };
+};
+
+test('normalizes a class input copy without mutating the submitted payload', () => {
+  const input = { name: 'Tinker', image_url: 'javascript:bad()' };
+  expect(normalizeClassInput(input)).toEqual({ name: 'Tinker', image_url: null });
+  expect(input).toEqual({ name: 'Tinker', image_url: 'javascript:bad()' });
+});
+
+test('class service passes normalized writes through its adapter', async () => {
+  const adapter = makeAdapter();
+  const service = new ClassService(adapter);
+  await service.updateClass('class-1', { image_url: 'https://example.test/image.png' });
+  expect(adapter.calls).toEqual([['update', 'class-1', { image_url: 'https://example.test/image.png' }]]);
+});
+
+test('class service rejects PDF metadata without a class id', async () => {
+  const service = new ClassService(makeAdapter());
+  const result = await service.savePdfMetadata(null, 'classes/tinker.pdf');
+  expect(result.error.message).toBe('Missing class id');
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,396 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "agent-resources"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./declarative"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/test/helpers/http-server.js
+++ b/test/helpers/http-server.js
@@ -1,0 +1,15 @@
+const startHttpServer = (app) => new Promise((resolve, reject) => {
+  const server = app.listen(0);
+  server.once('error', reject);
+  server.once('listening', () => {
+    const address = server.address();
+    resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+  });
+});
+
+const stopHttpServer = (server) => new Promise((resolve, reject) => {
+  if (!server || !server.listening) return resolve();
+  server.close(error => error ? reject(error) : resolve());
+});
+
+module.exports = { startHttpServer, stopHttpServer };

--- a/util/app.test.js
+++ b/util/app.test.js
@@ -1,0 +1,13 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const { createApp } = require('../app');
+
+test('createApp builds an Express application without starting a listener', () => {
+  const app = createApp();
+  expect(typeof app.listen).toBe('function');
+  expect(app.listening).toBeUndefined();
+});


### PR DESCRIPTION
## What changed

Extracts core class writes into `ClassService`.

- Normalizes class writes without mutating submitted input.
- Keeps route authorization and storage behavior unchanged.
- Covers create/update/delete and PDF metadata persistence through an injected adapter.

## Why

This completes the incremental service/repository boundary for the roadmap's class domain without a repository-wide rewrite.

## Stack

Base: `mission-service-seam` (merge the parent PR first).

## Validation

- Focused class and PDF tests
- Unit and HTTP suites
- Static checks
