### PR TITLE
Consolidate service-role access behind repositories (ar-ezes)

### DIFF
--- a/.tickets/ar-ezes.md
+++ b/.tickets/ar-ezes.md
@@ -1,6 +1,6 @@
 ---
 id: ar-ezes
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-10T21:28:57Z

--- a/docs/superpowers/plans/2026-07-10-consolidate-service-role.md
+++ b/docs/superpowers/plans/2026-07-10-consolidate-service-role.md
@@ -1,0 +1,552 @@
+# Consolidate Service-Role Access Behind Repositories — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move every `supabaseAdmin` (service-role, RLS-bypassing) usage behind per-domain repository modules, and route every privileged command through an actor-aware, policy-guarded service capability method.
+
+**Architecture:** Five layers per domain — `models/_base.js` (constructs the clients), `services/<domain>/repository.js` (the only consumer of `supabaseAdmin`; all privileged reads + writes), `services/<domain>/policy.js` (pure authorization predicates), `services/<domain>/service.js` (capability methods taking an actor; load → policy → throw-or-mutate), and routes (build the actor, call capabilities, never import `supabaseAdmin`). Denials throw `AuthorizationError`, mapped to HTTP 403.
+
+**Tech Stack:** Node.js/CommonJS, Express 4, `@supabase/supabase-js`, Bun test runner (`bun:test`, `mock.module`). Test entry: `scripts/run-tests.mjs` via `bun run test:unit` and `bun run test:http`.
+
+## Global Constraints
+
+- **Actor shape:** `{ userId, profileId, role }`, built by `actorFromLocals(res.locals)`. This matches the existing agent-read convention (`models/class.js` `resolveClassAgentAccess`, `canViewClassPdf`, `auth.js:128` `role === 'admin'`). Admin = `role === 'admin'`.
+- **System actor:** internal, non-user-triggered privileged commands (badge recalculation, mission/character backfill, conduit denormalization) use the frozen `SYSTEM_ACTOR` (`role: 'system'`), never constructed from request input. Policies grant it unconditionally.
+- **Denial contract:** a policy denial makes the capability method **throw `AuthorizationError`** (`code: 'forbidden'`, `status: 403`). Capability methods never return `{ error: 'Unauthorized' }`. Existing services that do so today are migrated to throw.
+- **Only two files may import `supabaseAdmin`:** `models/_base.js` (defines it) and `services/*/repository.js`. Zero references in `routes/`, `util/`, and non-`_base` `models/`.
+- **Repository return shape:** privileged reads and writes return Supabase-style `{ data, error }` (repositories do NOT throw — only the service's policy step throws). This keeps `console.error`/error-propagation behavior identical to today.
+- **Preserve double-guarded writes:** every creator-only write is guarded twice today (JS `creator_id` compare + `.eq('creator_id', …)` SQL filter). The policy reproduces the JS check; the repository method keeps the `.eq('creator_id', …)` filter. Do not drop either.
+- **Async route safety:** any route handler that can reach a throwing capability method must be wrapped with `asyncHandler` (or keep an explicit `try/catch → sendError`). Express 4 does not catch async throws.
+- **No behavior change beyond authorization consolidation.** RLS policies, anon/RLS read paths (`res.locals.supabase` for web routes), and domain logic are unchanged. The one intentional behavioral change is the agent admin-read path (Task 12).
+- **Verification gate (every task):** `bun run test:unit` and `bun run test:http` both exit 0. Paste the actual exit codes in the task report.
+
+---
+
+## Task ordering
+
+1. Foundation (`util/*`)
+2. `class` — reference domain (existing service; owner-or-admin)
+3. `profile` — reference for a new service with self-only authz
+4. `rules`
+5. `pdf` (storage)
+6. `badge`
+7. `agent-token`
+8. `bot-link` + `routes/agent.js` + `routes/bot-link.js` (depends on Task 7 repo)
+9. `mission` (existing service; resolve no-authz flags)
+10. `character` + `routes/characters.js` (existing service; net-new route surface)
+11. `lfg` (existing service; large agent surface)
+12. Agent admin-read path cleanup (`util/auth.js:149`) + final grep gate
+
+Each domain task is an independently shippable slice: after it, that domain imports no `supabaseAdmin` outside its repository, its privileged commands are policy-guarded, and its authz tests pass. The suite stays green after every task because untouched domains keep their current model code.
+
+---
+
+### Task 1: Foundation — actor, error, async wrapper, 403 mapping
+
+**Files:**
+- Create: `util/errors.js`
+- Create: `util/actor.js`
+- Create: `util/async-handler.js`
+- Modify: `util/http-error.js` (`classifyError` gains a `forbidden` → 403 case)
+- Test: `util/errors.test.js`, `util/actor.test.js`, `util/async-handler.test.js`, `util/http-error.test.js` (extend if it exists; else create)
+
+**Interfaces:**
+- Produces:
+  - `AuthorizationError` — `new AuthorizationError(message?, { reason? })`; fields `name='AuthorizationError'`, `code='forbidden'`, `status=403`, optional `reason`.
+  - `actorFromLocals(locals) → { userId, profileId, role }`
+  - `SYSTEM_ACTOR` — frozen `{ userId: null, profileId: null, role: 'system' }`
+  - `isAdmin(actor) → boolean`, `isSystem(actor) → boolean`
+  - `asyncHandler(fn) → (req,res,next) => void`
+  - `classifyError` maps `code === 'forbidden'` (and `AuthorizationError`) to `{ status: 403 }`.
+
+- [ ] **Step 1: Write failing tests**
+
+`util/errors.test.js`:
+```js
+const { test, expect } = require('bun:test');
+const { AuthorizationError } = require('./errors');
+
+test('AuthorizationError carries a forbidden code and 403 status', () => {
+  const err = new AuthorizationError('nope', { reason: 'not_owner' });
+  expect(err).toBeInstanceOf(Error);
+  expect(err.name).toBe('AuthorizationError');
+  expect(err.code).toBe('forbidden');
+  expect(err.status).toBe(403);
+  expect(err.reason).toBe('not_owner');
+  expect(err.message).toBe('nope');
+});
+
+test('AuthorizationError has a default message', () => {
+  expect(new AuthorizationError().message).toBe('Not authorized');
+});
+```
+
+`util/actor.test.js`:
+```js
+const { test, expect } = require('bun:test');
+const { actorFromLocals, SYSTEM_ACTOR, isAdmin, isSystem } = require('./actor');
+
+test('actorFromLocals reads user id, profile id, and role', () => {
+  const actor = actorFromLocals({ user: { id: 'u1' }, profile: { id: 'p1', role: 'admin' } });
+  expect(actor).toEqual({ userId: 'u1', profileId: 'p1', role: 'admin' });
+});
+
+test('actorFromLocals tolerates missing user/profile', () => {
+  expect(actorFromLocals({})).toEqual({ userId: null, profileId: null, role: null });
+  expect(actorFromLocals(undefined)).toEqual({ userId: null, profileId: null, role: null });
+});
+
+test('SYSTEM_ACTOR is a frozen system-role actor', () => {
+  expect(SYSTEM_ACTOR.role).toBe('system');
+  expect(Object.isFrozen(SYSTEM_ACTOR)).toBe(true);
+});
+
+test('isAdmin / isSystem discriminate on role', () => {
+  expect(isAdmin({ role: 'admin' })).toBe(true);
+  expect(isAdmin({ role: 'user' })).toBe(false);
+  expect(isSystem(SYSTEM_ACTOR)).toBe(true);
+  expect(isSystem({ role: 'admin' })).toBe(false);
+});
+```
+
+`util/async-handler.test.js`:
+```js
+const { test, expect } = require('bun:test');
+const { asyncHandler } = require('./async-handler');
+
+test('asyncHandler forwards a rejected promise to next', async () => {
+  const boom = new Error('boom');
+  let passed = null;
+  const handler = asyncHandler(async () => { throw boom; });
+  await handler({}, {}, (e) => { passed = e; });
+  await new Promise((r) => setImmediate(r));
+  expect(passed).toBe(boom);
+});
+
+test('asyncHandler does not call next on success', async () => {
+  let called = false;
+  const handler = asyncHandler(async (req, res) => { res.ok = true; });
+  const res = {};
+  await handler({}, res, () => { called = true; });
+  await new Promise((r) => setImmediate(r));
+  expect(res.ok).toBe(true);
+  expect(called).toBe(false);
+});
+```
+
+`util/http-error.test.js` (add this case; create the file with a require of `./http-error` if absent):
+```js
+const { test, expect } = require('bun:test');
+const { AuthorizationError } = require('./errors');
+const httpError = require('./http-error');
+
+test('a forbidden-coded error classifies as 403', () => {
+  // classifyError is not exported by default; assert via sendError capture instead.
+  const res = { headersSent: false, statusCode: null, status(c){ this.statusCode = c; return this; }, json(){ return this; }, render(){ return this; }, format(map){ (map.default || (()=>{}))(); return this; }, type(){ return this; }, send(){ return this; } };
+  const req = { accepts: () => 'json', headers: {}, xhr: true, get: () => undefined };
+  httpError.sendError(req, res, new AuthorizationError('denied'));
+  expect(res.statusCode).toBe(403);
+});
+```
+> Note: inspect `util/http-error.js`'s `sendError` content-negotiation before finalizing this test's `res`/`req` doubles; adjust the doubles to whatever `sendError` actually calls so the assertion targets the resolved status. If `classifyError` is exported, prefer asserting `classifyError(new AuthorizationError()).status === 403` directly.
+
+- [ ] **Step 2: Run tests, verify they fail** — `bun test util/errors.test.js util/actor.test.js util/async-handler.test.js` → FAIL (modules not defined).
+
+- [ ] **Step 3: Implement**
+
+`util/errors.js`:
+```js
+class AuthorizationError extends Error {
+  constructor(message = 'Not authorized', { reason = null } = {}) {
+    super(message);
+    this.name = 'AuthorizationError';
+    this.code = 'forbidden';
+    this.status = 403;
+    if (reason) this.reason = reason;
+  }
+}
+
+module.exports = { AuthorizationError };
+```
+
+`util/actor.js`:
+```js
+// Who is performing a privileged command, derived from the request.
+// Shape matches the existing agent-read convention ({ userId, profileId, role }).
+const actorFromLocals = (locals = {}) => ({
+  userId: (locals && locals.user && locals.user.id) || null,
+  profileId: (locals && locals.profile && locals.profile.id) || null,
+  role: (locals && locals.profile && locals.profile.role) || null,
+});
+
+// Trusted actor for internal, non-user-triggered privileged commands
+// (badge recalculation, backfill, denormalization). Never built from input.
+const SYSTEM_ACTOR = Object.freeze({ userId: null, profileId: null, role: 'system' });
+
+const isAdmin = (actor) => !!actor && actor.role === 'admin';
+const isSystem = (actor) => !!actor && actor.role === 'system';
+
+module.exports = { actorFromLocals, SYSTEM_ACTOR, isAdmin, isSystem };
+```
+
+`util/async-handler.js`:
+```js
+// Forward a rejected async route handler to Express's error pipeline so a
+// thrown AuthorizationError reaches the central handler (app.js) and maps to 403.
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+module.exports = { asyncHandler };
+```
+
+`util/http-error.js` — add a `forbidden` case to `classifyError`'s `switch (error && error.code)`, mirroring the existing `'42501'` 403 case:
+```js
+    case 'forbidden':
+      base = { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND };
+      break;
+```
+
+- [ ] **Step 4: Run tests, verify pass** — the four `util/*` test files pass.
+- [ ] **Step 5: Green gate** — `bun run test:unit` and `bun run test:http` exit 0.
+- [ ] **Step 6: Commit** — `feat: add actor context, AuthorizationError, async handler, 403 mapping (ar-ezes)`
+
+---
+
+### Task 2: `class` domain — reference implementation
+
+The pattern every later domain follows. `class` already has `services/class/{service,input}.js`; this task adds `repository.js` + `policy.js`, moves all `class` admin access out of `models/class.js`, gives the service actor-aware capability methods, and rewires `routes/classes.js`.
+
+**Files:**
+- Create: `services/class/repository.js`, `services/class/policy.js`, `services/class/policy.test.js`, `services/class/repository.test.js`
+- Modify: `services/class/service.js` (actor params, policy, throw), `services/class/service.test.js`
+- Modify: `models/class.js` (delete inline adapter + admin queries; delegate to repository)
+- Modify: `routes/classes.js` (build actor, pass to capabilities, `asyncHandler`, drop any direct authz now owned by the service)
+
+**Admin sites to move into `services/class/repository.js`** (from `models/class.js`): `createUnlockCodes` insert (58), `fetchClassFamilyRows` read (99), `isClassUnlocked` read (130), `getUnlockedClasses` read (192), `getUnlockedClassIdsForUser` read (214), `listClassesForAgent` read (311), `getClassForAgent` read (345), `unlockClass` insert (406), and the inline adapter `createClassRow`/`updateClassRow`/`deleteClassRow`/`savePdfMetadataRow` (494–509).
+
+**Repository method inventory** (`services/class/repository.js`, only consumer of `supabaseAdmin` for class). Each method holds the exact query currently inline; the model keeps the surrounding logic (e.g. `computeVersionFamily`, date math):
+- Writes: `insertClass(data)`, `updateClass(id, data)`, `deleteClass(id)`, `saveClassPdfMetadata(id, data)`, `insertUnlockCodes(rows)`, `insertUnlock(payload)`
+- Reads: `fetchClassFamilyRows()`, `activeUnlockRows({ userId, classIds, nowIso })`, `unlockedClassRows({ userId, nowIso })`, `unlockedClassIdRows({ userId, nowIso })`, `fetchClassByIdAdmin(id)`, `fetchClassesForAgentAdmin(filters, actor)`
+
+- [ ] **Step 1: Write `services/class/policy.js` and its failing test.** Policy predicates are pure — no I/O.
+
+```js
+// services/class/policy.js
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// A class may be edited or deleted by its creator or an admin.
+const canManageClass = (actor, classRow) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor && !!actor.profileId && !!classRow && actor.profileId === classRow.created_by;
+};
+
+// Only admins mint unlock codes for a class (today's requireAdmin route).
+const canMintUnlockCodes = (actor) => isAdmin(actor) || isSystem(actor);
+
+module.exports = { canManageClass, canMintUnlockCodes };
+```
+
+`services/class/policy.test.js`:
+```js
+const { test, expect } = require('bun:test');
+const { canManageClass, canMintUnlockCodes } = require('./policy');
+
+const cls = { id: 'c1', created_by: 'p1' };
+
+test('creator may manage their class', () => {
+  expect(canManageClass({ profileId: 'p1', role: 'user' }, cls)).toBe(true);
+});
+test('a non-creator non-admin may not manage the class', () => {
+  expect(canManageClass({ profileId: 'p2', role: 'user' }, cls)).toBe(false);
+});
+test('admin and system may manage any class', () => {
+  expect(canManageClass({ profileId: 'pX', role: 'admin' }, cls)).toBe(true);
+  expect(canManageClass({ role: 'system' }, cls)).toBe(true);
+});
+test('only admin/system may mint unlock codes', () => {
+  expect(canMintUnlockCodes({ role: 'admin' })).toBe(true);
+  expect(canMintUnlockCodes({ role: 'system' })).toBe(true);
+  expect(canMintUnlockCodes({ profileId: 'p1', role: 'user' })).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run policy test, verify fail, implement `policy.js`, verify pass.**
+
+- [ ] **Step 3: Create `services/class/repository.js`.** Move each admin query listed above verbatim into its named method, following the shape of the existing inline adapter (`withClassWriteResult` → a shared `withResult` helper). Example (full file starts here; transcribe the remaining queries from `models/class.js` at the cited lines):
+```js
+const { supabaseAdmin } = require('../../models/_base');
+
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) { console.error(error); return { data: null, error }; }
+  return { data, error: null };
+};
+
+module.exports = {
+  insertClass: (data) => withResult(supabaseAdmin.from('classes').insert([data]).select().single()),
+  updateClass: (id, data) => withResult(supabaseAdmin.from('classes').update(data).eq('id', id).select().single()),
+  deleteClass: async (id) => {
+    const { error } = await supabaseAdmin.from('classes').delete().eq('id', id);
+    if (error) console.error(error);
+    return { error: error || null };
+  },
+  saveClassPdfMetadata: (id, data) => withResult(supabaseAdmin.from('classes').update(data).eq('id', id).select().single()),
+  insertUnlockCodes: (rows) => withResult(supabaseAdmin.from('class_unlock_codes').insert(rows).select()),
+  insertUnlock: (payload) => withResult(supabaseAdmin.from('class_unlocks').insert([payload]).select().single()),
+  fetchClassFamilyRows: async () => {
+    // returns raw rows or null on failure; caller applies computeVersionFamily
+    try {
+      const { data, error } = await supabaseAdmin.from('classes').select('id, base_class_id, rules_edition');
+      if (error || !Array.isArray(data)) { if (error) console.error(error); return null; }
+      return data;
+    } catch (e) { console.error(e); return null; }
+  },
+  // activeUnlockRows / unlockedClassRows / unlockedClassIdRows / fetchClassByIdAdmin /
+  // fetchClassesForAgentAdmin — move the queries at models/class.js:130,192,214,345,311.
+};
+```
+Add a light `services/class/repository.test.js` that asserts the module exports every method name above (guards against a missed extraction); deep behavior is covered by the model/service tests that already exercise these paths.
+
+- [ ] **Step 4: Rewrite `models/class.js`** to delegate: `require('../services/class/repository')`, delete the `supabaseAdmin` import and the inline adapter. Each former admin function now calls the repository and keeps its non-admin logic. The service is instantiated with the repository (see Step 5). Keep every exported function name in `module.exports` unchanged.
+
+- [ ] **Step 5: Update `services/class/service.js`** — capability methods take `actor` first and enforce policy by throwing:
+```js
+const { AuthorizationError } = require('../../util/errors');
+const { canManageClass, canMintUnlockCodes } = require('./policy');
+const { normalizeClassInput } = require('./input');
+// constructor receives the repository (was: adapter)
+async updateClass(actor, id, input) {
+  const { data: existing, error } = await this.repo.fetchClassByIdAdmin(id);
+  if (error) return { data: null, error };
+  if (!existing) throw new AuthorizationError('Class not found', { reason: 'not_found' });
+  if (!canManageClass(actor, existing)) throw new AuthorizationError('Not the class owner', { reason: 'not_owner' });
+  return this.repo.updateClass(id, normalizeClassInput(input));
+}
+```
+`createClass(actor, input)` needs no ownership check (creator becomes owner) — set `created_by` from `actor.profileId`. `deleteClass(actor, id)` mirrors `updateClass`. `mintUnlockCodes(actor, params)` throws unless `canMintUnlockCodes(actor)`. Update `service.test.js` to (a) pass an actor, (b) assert denials **throw** `AuthorizationError` (was: returned `{error}`), (c) assert authorized calls reach the repo. Provide a fake repo in tests (same shape as the old fake adapter).
+
+- [ ] **Step 6: Rewire `routes/classes.js`** — replace the direct owner-or-admin check at `classes.js:664-668` (for `PUT /classes/:id`) with `actorFromLocals(res.locals)` passed into `classService.updateClass(actor, id, input)`; wrap the handler in `asyncHandler`. Do the same for create/delete/unlock-code routes. Remove now-dead route-level authz that the service now owns. The route imports no `supabaseAdmin`.
+
+- [ ] **Step 7: Green gate** — `bun run test:unit`, `bun run test:http` exit 0. Grep gate for this slice: `grep -rn "supabaseAdmin" models/class.js routes/classes.js` → zero.
+- [ ] **Step 8: Commit** — `refactor: move class privileged access behind repository + actor policy (ar-ezes)`
+
+---
+
+### Task 3: `profile` domain — reference for a new service with self-only authz
+
+**Files:** Create `services/profile/{repository,service,policy,policy.test,service.test}.js`; modify `models/profile.js`, `routes/profile.js`.
+
+**Admin sites** (`models/profile.js`): `getProfile` self-read (25) + `class_unlocks` grant-gate read (45); `getProfileByIdAdmin` (72); `getProfileByNameAdmin` (77); `createProfile` insert (83); `updateUser` `auth.admin.updateUserById` (134) + `profiles` update (139); `setDiscordId` update (145); `searchProfilesAdmin` (179).
+
+**Repository methods:** `fetchOwnProfile(userId)`, `fetchStarterUnlockRows(userId)`, `fetchProfileByIdAdmin(id)`, `fetchProfileByNameAdmin(name)`, `insertProfile(row)`, `updateAuthUser(userId, attrs)`, `updateProfileByUserId(userId, fields)`, `updateDiscord(userId, discordId, discordEmail)`, `searchProfilesAdmin(nameQuery)`.
+
+**Policy** (`services/profile/policy.js`) — all profile mutations act on **self**:
+```js
+const { isAdmin, isSystem } = require('../../util/actor');
+// Actor may mutate the profile owned by targetUserId (self), or is admin/system.
+const canMutateOwnProfile = (actor, targetUserId) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor && !!actor.userId && actor.userId === targetUserId;
+};
+module.exports = { canMutateOwnProfile };
+```
+`policy.test.js`: self → true; other user → false; admin/system → true.
+
+**Service capabilities** (`services/profile/service.js`): `updateUser(actor, userId, email, password, fields)`, `setDiscordId(actor, userId, discordId, discordEmail)`, `createProfileForUser(actor, user)`. Each throws `AuthorizationError` unless `canMutateOwnProfile(actor, userId)`, then delegates to the repository. Because the routes always act on `res.locals.user.id`, denial is only reachable if an actor's id diverges from the target — the test asserts that a mismatched actor throws.
+
+**Model:** `models/profile.js` delegates through the service/repository, drops `supabaseAdmin`. `getProfile` keeps its create-on-PGRST116 logic but reads via `repository.fetchOwnProfile` and creates via `service.createProfileForUser(SYSTEM_ACTOR, user)` (the self-provisioning path acts on the just-verified user; `getProfileByIdAdmin`/`getProfileByNameAdmin`/`searchProfilesAdmin` become thin pass-throughs to repository reads (they are `requireAdmin`-gated at their routes — no per-record ownership).
+
+**Routes:** `routes/profile.js` builds `actor = actorFromLocals(res.locals)`, passes to `updateUser`/`setDiscordId`; wrap those handlers in `asyncHandler`. The `PUT /`, `POST /discord/sync`, `POST /discord/clear` handlers currently rely on `isAuthenticated` + self-scoping — keep `isAuthenticated`; the service now enforces self-authz explicitly.
+
+**Tests:** policy unit tests; a service test that a mismatched actor throws and a self actor succeeds (fake repository). Green gate. Grep `models/profile.js routes/profile.js` → zero `supabaseAdmin`.
+
+**Commit:** `refactor: move profile privileged access behind repository + self-authz policy (ar-ezes)`
+
+---
+
+### Task 4: `rules` domain
+
+**Files:** Create `services/rules/{repository,service,policy,policy.test,service.test}.js`; modify `models/rules.js`, `routes/library.js`.
+
+**Admin sites** (`models/rules.js`, service-role only): `listRulesPdfUnlocks` read (66, PURE-READ, admin-manage listing), `createRulesPdfUnlockCodes` insert (143, COMMAND, **admin-only**), `getRulesPdfFamilyIds` read (185, authz-support), `canViewRulesPdf` unlock read (220, authz-support). The other rules mutations use the anon client and are **out of scope** — do not touch them.
+
+**Repository methods:** `listUnlockGrantsAdmin(pdfId)`, `insertUnlockCodes(rows)`, `fetchPdfFamilyIdsByTitle(title)`, `fetchActiveUnlockForUser({ userId, familyIds })`.
+
+**Policy** (`services/rules/policy.js`): `canMintRulesUnlockCodes(actor) = isAdmin(actor) || isSystem(actor)`. Test: admin/system true; user false.
+
+**Service:** `mintUnlockCodes(actor, params)` throws unless `canMintRulesUnlockCodes(actor)`, then `repository.insertUnlockCodes`. `getRulesPdfFamilyIds`/`canViewRulesPdf` are authorization-support reads used by the view path — expose them through the service as plain (non-throwing) reads that consult the repository; the view route already gates via `canViewRulesPdf`.
+
+**Model/routes:** `models/rules.js` delegates and drops `supabaseAdmin`. `routes/library.js` `POST /library/:id/codes` (`requireAdmin`) builds the actor and calls `rulesService.mintUnlockCodes(actor, …)` under `asyncHandler`. `createdByProfileId` stays server-set from `res.locals.profile.id`.
+
+**Tests + gate + commit:** `refactor: move rules privileged access behind repository + admin policy (ar-ezes)`
+
+---
+
+### Task 5: `pdf` domain (storage adapter)
+
+**Files:** Create `services/pdf/repository.js` (+ a thin `services/pdf/service.js` if a capability seam helps; storage ops themselves carry no per-record ownership — the *calling* domain authorizes); modify `models/pdf.js`, and the call sites in `routes/classes.js`/`routes/library.js` only insofar as they import `supabaseAdmin` (they do not — they call `models/pdf.js`).
+
+**Admin sites** (`models/pdf.js`, storage): upload (33), remove-previous (49), `getSignedPdfUrl` (93), `deletePdfObject` remove (106).
+
+**Repository methods** (`services/pdf/repository.js`): `uploadObject(bucket, path, bytes, opts)`, `removeObject(bucket, path)`, `createSignedUrl(bucket, path, ttl)`. These are the only `supabaseAdmin.storage` consumers.
+
+**Policy:** none inside `pdf` — the *class*/*rules* callers own authorization (class PDF: owner-or-admin, already enforced by `canManageClass` in Task 2 and the class-update route; rules PDF: `requireAdmin`). Document this in a header comment: "pdf storage is a persistence adapter; authorization belongs to the owning domain's policy."
+
+**Model:** `models/pdf.js` keeps its validation/orchestration (`storeClassPdf`, `storeRulesPdf`, `deletePdfObject`, `getSignedPdfUrl`) but performs storage I/O via `services/pdf/repository.js`; drops `supabaseAdmin`.
+
+**Tests:** a repository export-shape test; behavior stays covered by existing class/library PDF tests. Confirm `getSignedPdfUrl`'s view gating (`canViewClassPdf`/`canViewRulesPdf`) is unchanged. Green gate. Grep `models/pdf.js` → zero `supabaseAdmin`.
+
+**Commit:** `refactor: move pdf storage access behind repository (ar-ezes)`
+
+---
+
+### Task 6: `badge` domain
+
+**Files:** Create `services/badge/{repository,service,policy,policy.test,service.test}.js`; modify `models/badge.js`, `routes/badges.js`.
+
+**Admin sites** (`models/badge.js`): counters `getMissionCounters` (10,19 PURE-READ), `recalculateMilestoneBadges` catalog read (57) + upsert (75, COMMAND system), `getMissionProfileIds` reads (105,106 COMMAND-support), `badgeImageUrl` storage (118 PURE-READ), `listProfileBadges` (129 PURE-READ), `getProfileBadges` catalog (182 PURE-READ), `getBadgeCatalog` (214 PURE-READ), `findGrantableBadge` (232, authz-support), `grantBadge` upsert (254, COMMAND **admin-only**), `revokeBadge` delete (272, COMMAND **admin-only**).
+
+**Repository methods:** `countMissionsPlayed(profileId)`, `countMissionsHosted(profileId)`, `fetchActiveMilestoneBadges()`, `upsertProfileBadges(rows)`, `fetchMissionHostId(missionId)`, `fetchMissionCharacterCreators(missionId)`, `publicBadgeImageUrl(path)`, `listProfileBadgeRows(profileId)`, `fetchBadgeCatalog()`, `fetchGrantableBadgeBySlug(slug)`, `upsertGrantedBadge(row)`, `deleteProfileBadge({ profileId, badgeId })`.
+
+**Policy** (`services/badge/policy.js`): `canGrantBadge(actor) = isAdmin(actor)`; `canRevokeBadge(actor) = isAdmin(actor)`. The milestone-category prohibition (`findGrantableBadge` blocks `category === 'milestone'`) stays as a domain guard inside the service, not the policy. `recalculateMilestoneBadges` is invoked with `SYSTEM_ACTOR` from mission/character hooks — policy grants system unconditionally, but recalc has no policy call at all (it is system-only by construction; expose it as `recalcMilestones(SYSTEM_ACTOR, profileId)` or keep it internal to the badge service and only callable via the domain).
+
+**Service capabilities:** `grantBadge(actor, { targetProfileId, slug, ... })` throws unless `canGrantBadge(actor)`, then enforces the milestone guard, then `repository.upsertGrantedBadge`. `revokeBadge(actor, { targetProfileId, slug })` mirrors. Pure-read helpers stay non-throwing reads through the repository.
+
+**Model/routes:** `models/badge.js` delegates, drops `supabaseAdmin`; preserve the counter comments (private missions must count). `routes/badges.js` `POST /grant` and `POST /revoke` (`isAuthenticated, requireAdmin`) build the actor and call the service under `asyncHandler`.
+
+**Tests:** policy unit tests (admin grants, non-admin throws); service test that milestone slug is rejected and a non-admin actor throws. Green gate.
+
+**Commit:** `refactor: move badge privileged access behind repository + admin policy (ar-ezes)`
+
+---
+
+### Task 7: `agent-token` domain
+
+**Files:** Create `services/agent-token/{repository,service,policy,policy.test,service.test}.js`; modify `models/agent-token.js`. (No route changes yet; `util/auth.js`'s `verifyAgentToken` usage stays, now via the repository. `routes/agent.js`'s `agent_api_tokens` lookup moves here in Task 8.)
+
+**Admin sites** (`models/agent-token.js`): `createAgentToken` insert (30, COMMAND self), `listAgentTokens` read (61, self read), `revokeAgentToken` update (86, COMMAND self-agent), `verifyAgentToken` lookup (110, auth read) + `last_used_at` update (122, system write). Plus, owned by this domain but currently in `routes/agent.js:94`: the `agent_api_tokens` `select('id, profile:profile_id(id,name)')` by id lookup (moved in Task 8).
+
+**Repository methods:** `insertToken(row)`, `listTokens({ userId, profileId, includeRevoked })`, `revokeToken({ tokenId, userId, profileId })` (keep the `.eq('user_id').eq('profile_id').is('revoked_at', null)` scoping), `findTokenByHash(hash)`, `touchLastUsed(tokenId)`, `fetchTokenWithProfile(tokenId)` (for the Task-8 claim lookup).
+
+**Policy** (`services/agent-token/policy.js`): `canManageOwnTokens(actor, ownerProfileId) = isAdmin/isSystem || actor.profileId === ownerProfileId`. `createAgentToken`/`revokeAgentToken` act on the caller's own profile; `verifyAgentToken` is the authentication primitive (no actor — it *produces* the actor) and does not go through policy.
+
+**Service:** `createToken(actor, { name })` (owner = actor.profileId; throws only if a mismatched profileId is supplied), `revokeToken(actor, { tokenId })`, `listTokens(actor, opts)`. `verifyAgentToken` stays a plain function (used by middleware) that reads via the repository and issues the `last_used_at` write with `SYSTEM_ACTOR` semantics (no policy).
+
+**Model:** `models/agent-token.js` delegates, drops `supabaseAdmin`. Keep `AGENT_TOKEN_PREFIX` export and `verifyAgentToken`'s external contract (used by `util/auth.js` and its tests) identical.
+
+**Tests:** policy unit tests; service test that revoking another profile's token throws; verify `verifyAgentToken` still returns the `{ data: { userId, profile, tokenId, tokenName, tokenHint }, error }` shape `util/auth.js` depends on. Green gate.
+
+**Commit:** `refactor: move agent-token privileged access behind repository + owner policy (ar-ezes)`
+
+---
+
+### Task 8: `bot-link` domain + `routes/agent.js` + `routes/bot-link.js`
+
+Depends on Task 7 (agent-token repository owns the `agent_api_tokens` lookup).
+
+**Files:** Create `services/bot-link/{repository,service,policy,policy.test,service.test}.js`; modify `models/bot-link.js`, `routes/agent.js`, `routes/bot-link.js`.
+
+**Admin sites** — `models/bot-link.js`: `cleanupStaleLinks` delete (42, system), `countRecentPendingForDiscordId` read (50, rate-limit gate), `createPendingLink` insert (76, public), `getPendingLinkByCode` read (92), `attachTokenToPendingLink` update (101, authed web user), `consumePendingLink` update (124, public/possession). **`routes/agent.js`**: `agent_api_tokens` lookup (94 → **agent-token repo**, `fetchTokenWithProfile`), `pending_bot_links_raw_tokens` read (103) + delete (112 → **bot-link repo**). **`routes/bot-link.js`**: `pending_bot_links_raw_tokens` insert (53 → **bot-link repo**).
+
+**Repository methods** (`services/bot-link/repository.js`): `deleteStaleLinks(olderThanIso)`, `countRecentPending(discordUserId, sinceIso)`, `insertPendingLink(row)`, `fetchPendingByCode(code)`, `attachToken({ code, agentTokenId })` (keep unconsumed/unexpired/not-already-attached guards), `consumePending({ code, discordUserId })`, and the raw-token stash: `stashRawToken({ agentTokenId, rawToken })`, `fetchRawToken(agentTokenId)`, `deleteRawToken(agentTokenId)`.
+
+**Policy** (`services/bot-link/policy.js`) — authorization here is by protocol/possession, not identity, so keep it explicit and documented:
+- `createPendingLink`, `consumePendingLink`, and the raw-token claim (`fetchRawToken`+`deleteRawToken`) are **public by design** (the Discord bot is unauthenticated) — authorized by possession of a valid, matching, token-attached `code` + `discord_user_id`. Policy functions return `true` for these but exist so the design records the decision (e.g. `canClaimByPossession(link, { code, discordUserId }) = link && link.code === code && link.discord_user_id === discordUserId && !link.consumed_at && link.agent_token_id`).
+- `attachTokenToPendingLink` is performed by the authenticated web user who created the token — `canAttachToken(actor, link) = isSystem(actor) || (!!actor.profileId && link && link.agent_token_id == null)` (the token was just minted for this session).
+
+**Service:** `startLink({ discordUserId })` (public; rate-limit via repository), `claimLink({ code, discordUserId })` (public; consume + disclose-and-purge the raw token, all via repository; throw `AuthorizationError` only if possession check fails — currently a 4xx JSON error, preserve status), `confirmLink(actor, { tokenName })` (authenticated; create token via agent-token service, stash raw token, attach). Preserve today's exact HTTP responses in the routes (`202 pending`, `404/410/409`, etc.).
+
+**Routes:** `routes/agent.js` — remove `supabaseAdmin` import (19); the claim handler calls `botLinkService.claimLink(...)` and `agentTokenRepository.fetchTokenWithProfile(...)` via the agent-token service. `routes/bot-link.js` — remove `supabaseAdmin` import (12); the confirm handler calls `botLinkService.confirmLink(actor, ...)`. Public routes need no `asyncHandler`-403 mapping but must still forward errors; keep their existing explicit JSON error handling and status codes. `routes/bot-link.js:18` `isAuthenticated` stays.
+
+**Tests:** policy unit tests for possession + attach; service tests for the rate-limit gate and a possession-mismatch claim; preserve the existing `routes/bot-link.test.js` behavior (update its `supabaseAdmin` mock to the new repository seam). Green gate. Grep `routes/agent.js routes/bot-link.js models/bot-link.js` → zero `supabaseAdmin`.
+
+**Commit:** `refactor: move bot-link + agent-route privileged access behind repositories (ar-ezes)`
+
+---
+
+### Task 9: `mission` domain (existing service; resolve no-authz flags)
+
+**Files:** Create `services/mission/{repository,policy,policy.test}.js`; modify `services/mission/service.js` (+ `service.test.js`), `models/mission.js`, and mission-edit routes in `routes/missions.js`.
+
+**Admin sites** (`models/mission.js`): `setUnregisteredCharacterNames` (128), `addMissionEditor` (406), `removeMissionEditor` (421), `canEditMission` reads (442,459), `isCreator` read (485), and the inline adapter (708–724: `getHost`, `createMissionRow`, `updateMissionRow`, `deleteMissionRow`, `getCharacterCreator`, `upsertMissionCharacter`, `deleteMissionCharacter`, `mergeMissions` RPC).
+
+**Repository:** move the inline adapter verbatim into `services/mission/repository.js`, plus `updateUnregisteredNames(missionId, names)`, `upsertEditor(row)`, `deleteEditor({ missionId, profileId })`, `fetchMissionPermissionRow(missionId)` (creator_id, host_id), `fetchEditorRow({ missionId, profileId })`, `fetchCreatorId(missionId)`.
+
+**Policy** (`services/mission/policy.js`) — reproduce `canEditMission`/`isCreator`, now pure over pre-loaded rows:
+- `canEditMission(actor, { mission, editorRow })` = system/admin, or `actor.profileId` ∈ {`mission.creator_id`, `mission.host_id`} or `editorRow` present.
+- `isMissionCreator(actor, mission)` = system/admin or `actor.profileId === mission.creator_id`.
+
+**Resolve the flagged no-authz mutations** (this is the security-hardening core of the task):
+- `addCharacterToMission` / `removeCharacterFromMission`: today no check. New rule — the actor must pass `canEditMission`, **except** the internal backfill path (`routes/characters.js` `createBackfillMissionForCharacter`) which calls with `SYSTEM_ACTOR`. Capability: `addCharacter(actor, { missionId, characterId })` loads the permission row, throws unless `canEditMission`. Update the backfill caller to pass `SYSTEM_ACTOR`.
+- `addMissionEditor` / `removeMissionEditor`: today gated only at the route. New rule — capability requires `isMissionCreator(actor, mission)`; throws otherwise. Verify the routes that expose editor management and pass the actor.
+- `setUnregisteredCharacterNames`: preserve today's `canEditMission` gate, now via the policy inside the capability.
+
+**Service:** convert `createMission`/`updateMission`/`deleteMission`/`addCharacter`/`removeCharacter`/`mergeMissions` to **throw** `AuthorizationError` on denial (was `{ error: 'Unauthorized' }`), keeping the same underlying checks (`updateMission` → `canEditMission`; `deleteMission` → creator-only `.eq('creator_id')` preserved; `mergeMissions` → dual `canEditMission`). Add `setUnregisteredNames`, `addEditor`, `removeEditor`, `addCharacter`, `removeCharacter` capabilities with the rules above. Update `service.test.js` to assert throws and to cover the newly-gated commands (including the `SYSTEM_ACTOR` backfill path).
+
+**Model/routes:** `models/mission.js` delegates, drops `supabaseAdmin`. Callers of the changed functions build actors; wrap route handlers in `asyncHandler`. Update `routes/missions.js` and any mission-edit callers; internal callers use `SYSTEM_ACTOR`.
+
+**Tests + gate:** Grep `models/mission.js` → zero `supabaseAdmin`. Green gate.
+
+**Commit:** `refactor: move mission privileged access behind repository + policy; close addCharacter/editor authz gaps (ar-ezes)`
+
+---
+
+### Task 10: `character` domain + `routes/characters.js` (net-new route surface)
+
+**Files:** Create `services/character/{repository,policy,policy.test}.js`; modify `services/character/service.js` (+ tests), `models/character.js`, `routes/characters.js`.
+
+**Admin sites** — `models/character.js`: `deleteCharacter` probe+write (150,155), pure-read helpers `getCharacterTraits/Gear/Abilities/AbilityPerks` (162,168,213,262), `markCharacterDeceased` probe+write (364,370), `upgradeCharacterClass` probe+write (393,411), `searchCharactersForAgent` (554), `getCharacterForAgent` (587), and the inline adapter (618–662). **`routes/characters.js`**: `getOwnedCharacterForMutation` probe (86), `updateOwnedCharacterFields` write (103), `appendCharacterPerks` reads+writes (134,141,193,199,239), derivation reads (614,615,680,681,1389,1390,1399), level-up credit read (1344) + offscreen write (1377).
+
+**Repository** (`services/character/repository.js`): move the inline adapter verbatim, plus `fetchCharacterOwnership(id)` (id, creator_id, class_id), `deleteCharacter({ id, creatorId })`, `setDeceased({ id, creatorId })`, `updateClass({ id, creatorId, classId, className })`, `updateOwnedFields({ id, creatorId, fields })`, the perk methods (`fetchAllowedAbilityIds`, `fetchExistingPerks`, `insertPerks`, `updatePerkLinks`), the trait/gear/ability/perk read helpers, and the agent-search reads. All `supabaseAdmin` for character lives here.
+
+**Policy** (`services/character/policy.js`): `canMutateCharacter(actor, character)` = system/admin or `actor.profileId === character.creator_id`. (Reproduces the double-guard JS side; repository keeps the `.eq('creator_id')` filter.)
+
+**Service capabilities** — existing `createCharacter`/`updateCharacter` convert to **throw**; add `deleteCharacter(actor, id)`, `markDeceased(actor, id, name)`, `upgradeClass(actor, id, targetClassId)`, and the **net-new** `updateStats(actor, id, fields)` and `levelUp(actor, id, payload)` (the `PATCH /:id/stats` and `POST /:id/level-up` route logic, including perk append and offscreen-credit spend, moved behind the service). Each loads ownership via the repository, throws unless `canMutateCharacter`, then mutates. The backfill/level-up internal mission writes call the mission service with `SYSTEM_ACTOR` (from Task 9).
+
+**Model/routes:** `models/character.js` delegates, drops `supabaseAdmin`. `routes/characters.js` — remove `supabaseAdmin` import (23) and the inline helpers `getOwnedCharacterForMutation`/`updateOwnedCharacterFields`/`appendCharacterPerks` (their logic now lives in the service/repository — **delete**, do not leave behind per No-Dead-Code); handlers build the actor, call capabilities, and are wrapped in `asyncHandler`. Derivation pure-reads move to repository methods the route calls.
+
+**Tests:** policy unit tests; service tests that a non-creator actor throws for delete/deceased/upgrade/stats/level-up and the creator succeeds; existing character route/wizard/level-up tests updated to the new seam. Grep `models/character.js routes/characters.js` → zero `supabaseAdmin`. Green gate.
+
+**Commit:** `refactor: move character privileged access + stats/level-up routes behind repository + policy (ar-ezes)`
+
+---
+
+### Task 11: `lfg` domain (existing service; large agent surface)
+
+**Files:** Create `services/lfg/{repository,policy,policy.test}.js`; modify `services/lfg/service.js` (+ tests), `models/lfg.js`, `routes/lfg.js`.
+
+**Admin sites** (`models/lfg.js`, 30): `deleteLfgPost` (152,157), `joinLfgPost` reads+write (172,185,201), `syncConduitHostId` (234,242), `updateJoinRequest` (252,262), `deleteJoinRequest` (276,281), inline adapter (292–296), `closeLfgPost` (342,352), and the agent surface `getPostsWithRequestsBy` (430), `getPostsByJoiner` (449,458), `getPostForAgent` (509), `joinForAgent` (575,586,598), `leaveForAgent` (618), `updateRequestForAgent` (643,657), `listEligibleCharactersForAgent` (669).
+
+**Repository** (`services/lfg/repository.js`): move the inline adapter verbatim, plus named methods for each site above (post CRUD/close, join-request CRUD, conduit sync, agent listings, eligibility reads). All `supabaseAdmin` for lfg lives here.
+
+**Policy** (`services/lfg/policy.js`): `canManagePost(actor, post)` = system/admin or `actor.profileId === post.creator_id` (covers update/delete/close). `canModerateJoinRequest(actor, post)` = system/admin or host (`actor.profileId === post.creator_id`). `canJoinAsCharacter(actor, character)` = `actor.profileId === character.creator_id && !character.is_deceased` (player joins). `canManageOwnJoinRequest(actor, request)` = `actor.profileId === request.profile_id` (leave/withdraw).
+
+**Resolve flagged no-authz mutations:** `updateJoinRequest` (approve/reject) — enforce `canModerateJoinRequest` in the capability (was caller-enforced). `deleteJoinRequest` (leave) — enforce `canManageOwnJoinRequest` (or host moderation) in the capability. `syncConduitHostId` is internal denormalization — `SYSTEM_ACTOR`, no policy.
+
+**Service:** convert `createPost`/`updatePost` to **throw**; add `deletePost`, `closePost`, `join`, `updateJoinRequest`, `leave`, and actor-aware agent-surface capabilities (`listForAgent`, `getForAgent`, `joinForAgent`, `leaveForAgent`, `updateRequestForAgent`, `listEligibleCharactersForAgent`) that load via repository, apply policy, throw on denial. Preserve the agent routes' current status codes (`not_host` → 403, etc.). Update `service.test.js` for throws + the newly-gated commands.
+
+**Model/routes:** `models/lfg.js` delegates, drops `supabaseAdmin`. `routes/lfg.js` and the agent lfg routes build actors, call capabilities, `asyncHandler`. Grep `models/lfg.js` → zero `supabaseAdmin`. Green gate.
+
+**Commit:** `refactor: move lfg privileged access behind repository + policy; close join-request authz gaps (ar-ezes)`
+
+---
+
+### Task 12: Agent admin-read path cleanup + final grep gate
+
+**Files:** Modify `util/auth.js` (`isAgentAuthenticated`), any model read functions still relying on `res.locals.supabase === supabaseAdmin` for agent requests, `util/auth.test.js`.
+
+- [ ] **Step 1:** Remove `res.locals.supabase = supabaseAdmin` at `util/auth.js:149`. For agent requests, `res.locals.supabase` becomes the RLS/anon client (or is left unset where every read on the agent path now goes through a repository privileged read). The agent `actor` already carries `role`/`profileId`; agent read capabilities (added in Tasks 2/10/11 for class/character/lfg) authorize via that actor, not via an admin request client.
+- [ ] **Step 2:** Audit every model read function that takes a `client`/`supabase` param and was being handed `supabaseAdmin` on the agent path (e.g. `getCharacter(id, res.locals.supabase)`, `getClass(id, res.locals.supabase)` in agent handlers). Route those through the domain's repository privileged read instead, so removing the admin client does not change what an agent can see.
+- [ ] **Step 3:** Remove the now-unused `supabaseAdmin` import from `util/auth.js`. Update `util/auth.test.js` (it currently mocks `models/_base` including `supabaseAdmin`; adjust to the new expectation that `isAgentAuthenticated` no longer assigns the admin client).
+- [ ] **Step 4: Final gate** — `grep -rn "supabaseAdmin" --include='*.js' routes/ util/ models/` returns hits **only** in `models/_base.js`. `grep -rn "supabaseAdmin" services/` returns hits only in `services/*/repository.js`. `bun run test:unit` and `bun run test:http` exit 0.
+- [ ] **Step 5: Commit** — `refactor: remove agent admin-read path; supabaseAdmin now only in _base + repositories (ar-ezes)`
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** (a) no route imports service-role client — Tasks 2–12 drop every route/`util` import; verified by Task 12 grep gate. (b) repositories encapsulate privileged persistence — every domain gets `services/<domain>/repository.js` as sole `supabaseAdmin` consumer. (c) services receive actor context + capability methods — every mutation becomes `capability(actor, …)` with a policy. (d) authz tests per privileged command — each domain adds `policy.test.js` and service throw-tests.
+- **Decisions surfaced for the pre-flight review (see handoff):** (1) existing services migrate from returning `{error:'Unauthorized'}` to throwing `AuthorizationError`; (2) previously-unauthorized mutations (`addCharacterToMission`, editor management, `updateJoinRequest`, `deleteJoinRequest`, stats/level-up route helpers) gain policy checks plus a `SYSTEM_ACTOR` bypass for internal/backfill callers.
+- **Type consistency:** actor is `{ userId, profileId, role }` everywhere; repositories return `{ data, error }`; only the service policy step throws.
+- **Ordering safety:** each domain task is self-contained and leaves the suite green; Task 8 depends on Task 7; Task 12 runs last because it removes the compatibility admin-read client the agent path uses until every agent read is behind a repository.

--- a/docs/superpowers/specs/2026-07-10-consolidate-service-role-design.md
+++ b/docs/superpowers/specs/2026-07-10-consolidate-service-role-design.md
@@ -1,0 +1,187 @@
+# Consolidate service-role access behind repositories
+
+- **Ticket:** ar-ezes (blocks ar-m8ai "Complete character mutation service boundary" and ar-g8y7 "Sustainability hardening program")
+- **Depends on:** ar-5kph (barrel removal) — closed
+- **Date:** 2026-07-10
+- **Type:** architecture / security refactor of already-tested code
+
+## Problem
+
+The service-role client `supabaseAdmin` (which bypasses row-level security) is
+imported and used directly across 3 routes and 11 models — 159 call sites in
+production code. Two concrete problems follow:
+
+1. **Distributed authorization with RLS bypassed.** Because privileged
+   persistence is scattered, every caller is individually responsible for
+   authorizing the actor before touching data that RLS would otherwise protect.
+   Authorization checks live in routes, ad hoc and easy to miss. A route that
+   forgets the ownership check performs an unauthorized privileged mutation with
+   no backstop.
+2. **No reviewable privileged-access boundary.** There is no single layer a
+   reviewer can read to answer "what privileged operations exist and who may
+   perform them." `supabaseAdmin` usage is spread across route handlers, large
+   read-heavy model files, and anonymous inline write adapters
+   (e.g. `models/class.js:494`).
+
+## Decisions
+
+All five decisions below were made explicitly during brainstorming.
+
+**Scope: foundation + all domains.** Fully satisfy every acceptance thread —
+(a) no route imports the service-role client, (b) repositories encapsulate
+privileged persistence, (c) services receive actor context and use
+capability-oriented methods, (d) authorization tests cover each privileged
+command — across all domains. The dependent ticket ar-m8ai is left near-empty.
+
+**Read boundary: all privileged data access.** Repositories own *every*
+`supabaseAdmin` read and write across all 11 models and 3 routes — privileged
+writes, load-for-authz reads, and unrelated privileged reads (badge counters,
+listings) alike. After this ticket, `supabaseAdmin` is imported in exactly two
+places: `models/_base.js` (which constructs it) and `services/*/repository.js`.
+
+**Actor context: explicit actor argument per call.** Services stay module
+singletons. Every capability method takes the actor as its first parameter —
+`characterService.deleteCharacter(actor, id)`. Actor is data, not a dependency,
+so this stays consistent with ar-5kph's decision to use direct module requires
+rather than dependency injection. The route builds the actor from `res.locals`
+and passes it in.
+
+**Repository layout: colocated per domain.** Each domain's privileged access
+lives in `services/<domain>/repository.js`, beside its existing `input.js`,
+`service.js`, and tests. A domain's full write/authz boundary lives in one
+folder ("files that change together live together"), matching the established
+`services/` structure.
+
+**Authorization shape: dedicated per-domain policy module.**
+`services/<domain>/policy.js` exposes pure predicates —
+`canDeleteCharacter(actor, resource) → true | { reason }` — with no I/O. The
+capability method loads the resource via the repository, calls the policy, and
+refuses on denial. Policies unit-test in isolation, directly satisfying "authz
+tests per privileged command."
+
+**Denial signal: throw a typed `AuthorizationError`.** On policy denial the
+capability method throws `AuthorizationError` (carrying `code: 'forbidden'`).
+An unchecked authorization result cannot silently fall through to a mutation —
+the exact footgun this ticket targets. This diverges from the codebase's
+`{ data, error }` return convention, which is acceptable precisely because authz
+denial must not be ignorable.
+
+## Layered architecture
+
+| Layer | File | Responsibility | Imports `supabaseAdmin`? |
+| --- | --- | --- | --- |
+| Base | `models/_base.js` | Sole constructor of `supabase` (anon/RLS) and `supabaseAdmin` (service-role) | — (defines it) |
+| **Repository** | `services/<domain>/repository.js` | All privileged data access for the domain — reads and writes. Intention-named methods returning `{ data, error }`. No authorization. | **Yes — the only consumer** |
+| **Policy** | `services/<domain>/policy.js` | Pure predicates `canX(actor, resource) → true \| { reason }`. No I/O. | No |
+| **Service** | `services/<domain>/service.js` | Capability methods `(actor, …)`. Per privileged command: load via repo → consult policy → throw `AuthorizationError` on denial → mutate via repo. Returns `{ data, error }` for DB/domain errors; throws only for authz. | No |
+| Route | `routes/*.js` | Builds actor from `res.locals`, calls `service.capability(actor, …)`. Never imports `supabaseAdmin`. | No |
+
+### Data flow (privileged command)
+
+```
+route handler
+  → actorFromLocals(res.locals)            // { userId, profileId, isAdmin }
+  → service.deleteCharacter(actor, id)
+      → repo.loadCharacter(id)             // privileged read behind repo
+      → policy.canDeleteCharacter(actor, char)
+          denied  → throw AuthorizationError → asyncHandler → central handler → sendError → 403
+          allowed → repo.deleteCharacter(id) → { data, error }
+```
+
+## Cross-cutting foundation (one shared task, TDD)
+
+- **`util/actor.js`** — `actorFromLocals(res.locals) → { userId, profileId, isAdmin }`.
+  One definition of "who is acting," derived from the authenticated user/profile
+  and the agent/admin flag set by `util/auth.js`.
+- **`util/errors.js`** — `AuthorizationError` (typed, `code: 'forbidden'`).
+- **`util/async-handler.js`** — wraps an async route handler so a rejected
+  promise forwards to `next(err)`. Required because routes today are
+  inconsistent (some `try/catch`, most not) and Express 4 does not catch async
+  throws; without it a thrown `AuthorizationError` becomes an unhandled
+  rejection and never reaches the central handler at `app.js:87`. Applied to
+  every privileged route handler.
+- **`util/http-error.js`** — `classifyError` gains an
+  `AuthorizationError` / `code: 'forbidden'` → **403** case, so both the central
+  error handler and direct `sendError` calls map denials consistently.
+
+## Scope — domain inventory
+
+Privileged call sites per production file (`supabaseAdmin`), and whether a
+`services/<domain>/` already exists:
+
+| Domain | Model sites | Route sites | Service today? |
+| --- | --- | --- | --- |
+| lfg | `models/lfg.js` (30) | — | yes |
+| character | `models/character.js` (24) | `routes/characters.js` (17) | yes |
+| mission | `models/mission.js` (17) | — | yes |
+| badge | `models/badge.js` (15) | — | **no (create)** |
+| class | `models/class.js` (13) | — | yes |
+| profile | `models/profile.js` (10) | — | **no (create)** |
+| bot-link | `models/bot-link.js` (7) | `routes/bot-link.js` (2) | **no (create)** |
+| agent-token | `models/agent-token.js` (6) | — | **no (create)** |
+| rules | `models/rules.js` (5) | — | **no (create)** |
+| pdf | `models/pdf.js` (5) | — | **no (create)** |
+| agent | — | `routes/agent.js` (4) | uses agent-token / bot-link repos |
+
+Additional non-domain site: **`util/auth.js:149`** sets
+`res.locals.supabase = supabaseAdmin` for agent-authenticated requests, so agent
+reads currently bypass RLS through shared model read functions. Under this
+design those agent read paths move to repository privileged reads and the
+admin-on-`res.locals` assignment is removed; the agent actor carries `isAdmin`
+so services authorize agent requests correctly.
+
+## Decomposition (independently shippable slices)
+
+1. **Foundation** — the four `util/*` pieces above, with tests. No behavior
+   change to existing routes yet.
+2. **Per domain** — extract `repository.js` (move the model's admin reads and
+   writes, and any route-level admin queries, behind named methods), add
+   `policy.js`, convert or create the actor-context capability service, rewire
+   routes to build and pass `actor` and drop the `supabaseAdmin` import, and add
+   an authorization test per privileged command.
+3. **Order** — validate the whole pattern end-to-end on **class** (smallest at
+   13 sites, already has a service) first; then the remaining domains, largest
+   last (`character` incl. its route, then `lfg`).
+
+Existing services already delegate writes to an inline adapter; that adapter's
+body moves verbatim into `repository.js`, and the service gains the actor
+parameter and policy consultation. Domains without a service get a fresh
+`services/<domain>/` created in the same shape. Model files retain only their
+non-privileged, RLS-scoped read functions (which take a client parameter);
+models that are entirely privileged (bot-link, agent-token, pdf) may reduce to a
+thin re-export or fold into the repository.
+
+## Non-goals
+
+- No change to RLS policies themselves.
+- No change to the anon/RLS-scoped read paths that already work
+  (`res.locals.supabase` for web routes remains the request-scoped client).
+- No dependency injection / router-factory conversion (actor is passed as data).
+- No new features; this is a structural/security refactor only.
+
+## Verification
+
+Done when all hold:
+
+1. The full suite passes (`bun run test:unit` and `bun run test:http`, per
+   `scripts/run-tests.mjs`; integration remains CI-gated).
+2. `supabaseAdmin` appears **only** in `models/_base.js` (its definition) and
+   `services/*/repository.js`. A grep across `routes/`, `util/`, and non-`_base`
+   `models/` for `supabaseAdmin` returns **zero** hits in production `.js`.
+3. Every privileged command has an authorization test asserting that a
+   non-authorized actor is refused (via `AuthorizationError` → 403) and an
+   authorized actor succeeds.
+
+## Risks
+
+- **Behavioral drift on the agent admin-read path.** Removing
+  `res.locals.supabase = supabaseAdmin` changes how agent reads reach data.
+  Mitigated by routing agent reads through repository privileged reads and
+  covering agent flows with the existing `routes/agent.js` / bot-link tests plus
+  new authz tests.
+- **Async throw not reaching the handler.** Mitigated by `util/async-handler.js`
+  on every privileged route handler and the `classifyError` 403 mapping;
+  verified by an authz test per command that asserts the 403.
+- **Large surface (159 sites).** Mitigated by the per-domain decomposition —
+  each slice is independently testable and shippable, and the grep gate catches
+  any leftover privileged reference.

--- a/models/agent-token.js
+++ b/models/agent-token.js
@@ -1,140 +1,26 @@
-const crypto = require('crypto');
-const { supabaseAdmin } = require('./_base');
+const { AgentTokenService, AGENT_TOKEN_PREFIX } = require('../services/agent-token/service');
+const agentTokenRepository = require('../services/agent-token/repository');
 
-const AGENT_TOKEN_PREFIX = 'ar_pat_';
-const AGENT_TOKEN_BYTES = 24;
+const agentTokenService = new AgentTokenService(agentTokenRepository);
 
-const hashAgentToken = (token) => crypto.createHash('sha256').update(token).digest('hex');
+// Route-facing compatibility functions. The service enforces the
+// manage-own-tokens policy (self, or admin/system) and throws
+// AuthorizationError on denial; this model remains the thin caller that
+// threads the actor through.
 
-const generateAgentToken = () => {
-  const secret = crypto.randomBytes(AGENT_TOKEN_BYTES).toString('base64url');
-  const token = `${AGENT_TOKEN_PREFIX}${secret}`;
-  return {
-    token,
-    tokenHint: secret.slice(-4)
-  };
-};
+// authz: self-command (or admin/system), enforced by agentTokenService.
+const createAgentToken = async (actor, { name } = {}) => agentTokenService.createToken(actor, { name });
 
-const createAgentToken = async ({ userId, profileId, name }) => {
-  const trimmedName = (name || '').trim();
-  if (!userId || !profileId) {
-    return { data: null, error: new Error('Missing user context') };
-  }
-  if (!trimmedName) {
-    return { data: null, error: new Error('Token name is required') };
-  }
+// authz: self-read (or admin/system), enforced by agentTokenService.
+const listAgentTokens = async (actor, { includeRevoked = false } = {}) =>
+  agentTokenService.listTokens(actor, { includeRevoked });
 
-  const { token, tokenHint } = generateAgentToken();
-  const tokenHash = hashAgentToken(token);
+// authz: self-command (or admin/system), enforced by agentTokenService.
+const revokeAgentToken = async (actor, { tokenId } = {}) => agentTokenService.revokeToken(actor, { tokenId });
 
-  const { data, error } = await supabaseAdmin
-    .from('agent_api_tokens')
-    .insert({
-      user_id: userId,
-      profile_id: profileId,
-      name: trimmedName,
-      token_hash: tokenHash,
-      token_hint: tokenHint
-    })
-    .select('id, name, token_hint, created_at, last_used_at, revoked_at')
-    .single();
-
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
-
-  return {
-    data: {
-      ...data,
-      token
-    },
-    error: null
-  };
-};
-
-const listAgentTokens = async ({ userId, profileId, includeRevoked = false }) => {
-  if (!userId || !profileId) {
-    return { data: null, error: new Error('Missing user context') };
-  }
-
-  let query = supabaseAdmin
-    .from('agent_api_tokens')
-    .select('id, name, token_hint, created_at, last_used_at, revoked_at')
-    .eq('user_id', userId)
-    .eq('profile_id', profileId)
-    .order('created_at', { ascending: false });
-
-  if (!includeRevoked) {
-    query = query.is('revoked_at', null);
-  }
-
-  const { data, error } = await query;
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
-
-  return { data, error: null };
-};
-
-const revokeAgentToken = async ({ tokenId, userId, profileId }) => {
-  if (!tokenId || !userId || !profileId) {
-    return { data: null, error: new Error('Missing revoke context') };
-  }
-
-  const { data, error } = await supabaseAdmin
-    .from('agent_api_tokens')
-    .update({ revoked_at: new Date().toISOString() })
-    .eq('id', tokenId)
-    .eq('user_id', userId)
-    .eq('profile_id', profileId)
-    .is('revoked_at', null)
-    .select('id, name, token_hint, created_at, last_used_at, revoked_at')
-    .single();
-
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
-
-  return { data, error: null };
-};
-
-const verifyAgentToken = async (token) => {
-  if (!token || !token.startsWith(AGENT_TOKEN_PREFIX)) {
-    return { data: null, error: new Error('Invalid token format') };
-  }
-
-  const tokenHash = hashAgentToken(token);
-  const { data, error } = await supabaseAdmin
-    .from('agent_api_tokens')
-    .select('id, user_id, profile_id, name, token_hint, revoked_at, profile:profile_id(id, user_id, name, role, timezone)')
-    .eq('token_hash', tokenHash)
-    .is('revoked_at', null)
-    .single();
-
-  if (error) {
-    return { data: null, error };
-  }
-
-  const now = new Date().toISOString();
-  await supabaseAdmin
-    .from('agent_api_tokens')
-    .update({ last_used_at: now })
-    .eq('id', data.id);
-
-  return {
-    data: {
-      tokenId: data.id,
-      tokenName: data.name,
-      tokenHint: data.token_hint,
-      userId: data.user_id,
-      profile: data.profile
-    },
-    error: null
-  };
-};
+// Authentication primitive: no actor (it produces one for the caller). Used
+// by util/auth.js's isAgentAuthenticated middleware.
+const verifyAgentToken = async (token) => agentTokenService.verifyAgentToken(token);
 
 module.exports = {
   AGENT_TOKEN_PREFIX,

--- a/models/badge.js
+++ b/models/badge.js
@@ -1,29 +1,21 @@
-const { supabase, supabaseAdmin } = require('./_base');
+const { BadgeService } = require('../services/badge/service');
+const badgeRepository = require('../services/badge/repository');
 
-const BADGES_BUCKET = process.env.SUPABASE_BADGES_BUCKET || 'badges';
+const { BADGES_BUCKET } = badgeRepository;
 
 const MILESTONE_TRACKS = ['newcomer', 'veteran_player', 'veteran_conduit'];
 
-// Counters deliberately use supabaseAdmin: private missions count toward
-// badges, and the shared anon client (no JWT) would be RLS-filtered.
-const getMissionCounters = async (profileId) => {
-  const { data: playedRows, error: playedError } = await supabaseAdmin
-    .from('mission_characters')
-    .select('mission_id, characters!inner(creator_id)')
-    .eq('characters.creator_id', profileId);
-  if (playedError) {
-    console.error(playedError);
-    return { data: null, error: playedError };
-  }
+const badgeService = new BadgeService(badgeRepository);
 
-  const { data: hostedRows, error: hostedError } = await supabaseAdmin
-    .from('missions')
-    .select('id')
-    .eq('host_id', profileId);
-  if (hostedError) {
-    console.error(hostedError);
-    return { data: null, error: hostedError };
-  }
+// Counters deliberately route through the repository's privileged client:
+// private missions count toward badges, and the shared anon client (no JWT)
+// would be RLS-filtered.
+const getMissionCounters = async (profileId) => {
+  const { data: playedRows, error: playedError } = await badgeRepository.countMissionsPlayed(profileId);
+  if (playedError) return { data: null, error: playedError };
+
+  const { data: hostedRows, error: hostedError } = await badgeRepository.countMissionsHosted(profileId);
+  if (hostedError) return { data: null, error: hostedError };
 
   const playedIds = new Set((playedRows || []).map(r => r.mission_id));
   const hostedIds = new Set((hostedRows || []).map(r => r.id));
@@ -50,19 +42,16 @@ const counterForTrack = (counters, track) => {
 // original awarded_at (and any granted_by) on re-runs — backfill and live
 // hooks share this single code path so retroactive and ongoing awards
 // cannot drift.
+//
+// System-by-construction: no user authorization exists for milestone
+// recalc (it is milestone-only, insert-only), so this never routes through
+// badgeService — it calls the repository directly, mirroring services/rules.
 const recalculateMilestoneBadges = async (profileId) => {
   const { data: counters, error: countersError } = await getMissionCounters(profileId);
   if (countersError) return { data: null, error: countersError };
 
-  const { data: catalog, error: catalogError } = await supabaseAdmin
-    .from('badges')
-    .select('id, track, threshold')
-    .eq('category', 'milestone')
-    .eq('is_active', true);
-  if (catalogError) {
-    console.error(catalogError);
-    return { data: null, error: catalogError };
-  }
+  const { data: catalog, error: catalogError } = await badgeRepository.fetchActiveMilestoneBadges();
+  if (catalogError) return { data: null, error: catalogError };
 
   const earned = (catalog || []).filter(b =>
     b.track && Number.isFinite(b.threshold) && b.threshold <= counterForTrack(counters, b.track)
@@ -72,13 +61,8 @@ const recalculateMilestoneBadges = async (profileId) => {
   }
 
   const rows = earned.map(b => ({ profile_id: profileId, badge_id: b.id }));
-  const { error: upsertError } = await supabaseAdmin
-    .from('profile_badges')
-    .upsert(rows, { onConflict: 'profile_id,badge_id', ignoreDuplicates: true });
-  if (upsertError) {
-    console.error(upsertError);
-    return { data: null, error: upsertError };
-  }
+  const { error: upsertError } = await badgeRepository.upsertProfileBadges(rows);
+  if (upsertError) return { data: null, error: upsertError };
   return { data: { awarded: earned.length, counters }, error: null };
 };
 
@@ -102,8 +86,8 @@ const getMissionProfileIds = async (missionId) => {
   if (!missionId) return [];
   try {
     const [{ data: mission }, { data: rows }] = await Promise.all([
-      supabaseAdmin.from('missions').select('host_id').eq('id', missionId).maybeSingle(),
-      supabaseAdmin.from('mission_characters').select('character:characters(creator_id)').eq('mission_id', missionId)
+      badgeRepository.fetchMissionHostId(missionId),
+      badgeRepository.fetchMissionCharacterCreators(missionId)
     ]);
     const ids = (rows || []).map(r => r.character?.creator_id);
     if (mission?.host_id) ids.push(mission.host_id);
@@ -114,8 +98,7 @@ const getMissionProfileIds = async (missionId) => {
   }
 };
 
-const badgeImageUrl = (imagePath) =>
-  supabaseAdmin.storage.from(BADGES_BUCKET).getPublicUrl(imagePath).data.publicUrl;
+const badgeImageUrl = (imagePath) => badgeRepository.publicBadgeImageUrl(imagePath);
 
 const TRACK_LABELS = {
   newcomer: 'Newcomer',
@@ -126,15 +109,8 @@ const TRACK_LABELS = {
 // Every active badge a profile holds, flat (admin manage page; also the
 // basis for the public display shelf).
 const listProfileBadges = async (profileId) => {
-  const { data: rows, error } = await supabaseAdmin
-    .from('profile_badges')
-    .select('awarded_at, granted_by, badge:badges(id, slug, name, description, category, track, rank, threshold, image_path, is_active)')
-    .eq('profile_id', profileId)
-    .order('awarded_at', { ascending: true });
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
+  const { data: rows, error } = await badgeRepository.listProfileBadgeRows(profileId);
+  if (error) return { data: null, error };
   const held = (rows || [])
     .filter(r => r.badge && r.badge.is_active)
     .map(r => ({
@@ -179,14 +155,8 @@ const getProfileBadges = async (profileId, { includeProgress = false } = {}) => 
     return { data: { display }, error: null };
   }
 
-  const { data: catalog, error: catalogError } = await supabaseAdmin
-    .from('badges')
-    .select('track, threshold, name')
-    .eq('category', 'milestone')
-    .eq('is_active', true)
-    .order('threshold', { ascending: true });
+  const { data: catalog, error: catalogError } = await badgeRepository.fetchActiveMilestoneBadges();
   if (catalogError) {
-    console.error(catalogError);
     return { data: { display }, error: null };
   }
 
@@ -211,75 +181,21 @@ const getProfileBadges = async (profileId, { includeProgress = false } = {}) => 
 };
 
 const getBadgeCatalog = async () => {
-  const { data, error } = await supabaseAdmin
-    .from('badges')
-    .select('*')
-    .eq('is_active', true)
-    .order('category', { ascending: true })
-    .order('track', { ascending: true })
-    .order('rank', { ascending: true })
-    .order('name', { ascending: true });
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
+  const { data, error } = await badgeRepository.fetchBadgeCatalog();
+  if (error) return { data: null, error };
   return { data: (data || []).map(b => ({ ...b, image_url: badgeImageUrl(b.image_path) })), error: null };
 };
 
-// Admin operations. Milestone badges are automatic-only: enforced here (the
-// authoritative gate), not just in the routes.
-const findGrantableBadge = async (badgeSlug) => {
-  const { data: badgeRow, error } = await supabaseAdmin
-    .from('badges')
-    .select('id, slug, category, is_active')
-    .eq('slug', badgeSlug)
-    .maybeSingle();
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
-  if (!badgeRow || !badgeRow.is_active) {
-    return { data: null, error: new Error('Badge not found') };
-  }
-  if (badgeRow.category === 'milestone') {
-    return { data: null, error: new Error('Milestone badges are awarded automatically and cannot be granted or revoked') };
-  }
-  return { data: badgeRow, error: null };
-};
+// authz: admin-only (badgeService enforces via canGrantBadge; throws
+// AuthorizationError on denial). The milestone-category/inactive guard is
+// the authoritative gate, enforced inside the service, not just the routes.
+const grantBadge = async (actor, { profileId, badgeSlug, grantedById }) =>
+  badgeService.grantBadge(actor, { profileId, badgeSlug, grantedById });
 
-const grantBadge = async ({ profileId, badgeSlug, grantedById }) => {
-  const { data: badgeRow, error } = await findGrantableBadge(badgeSlug);
-  if (error) return { data: null, error };
-
-  const { error: upsertError } = await supabaseAdmin
-    .from('profile_badges')
-    .upsert(
-      { profile_id: profileId, badge_id: badgeRow.id, granted_by: grantedById || null },
-      { onConflict: 'profile_id,badge_id', ignoreDuplicates: true }
-    );
-  if (upsertError) {
-    console.error(upsertError);
-    return { data: null, error: upsertError };
-  }
-  return { data: { slug: badgeRow.slug }, error: null };
-};
-
-// Revoking a badge the profile doesn't hold deletes 0 rows — no-op success.
-const revokeBadge = async ({ profileId, badgeSlug }) => {
-  const { data: badgeRow, error } = await findGrantableBadge(badgeSlug);
-  if (error) return { data: null, error };
-
-  const { error: deleteError } = await supabaseAdmin
-    .from('profile_badges')
-    .delete()
-    .eq('profile_id', profileId)
-    .eq('badge_id', badgeRow.id);
-  if (deleteError) {
-    console.error(deleteError);
-    return { data: null, error: deleteError };
-  }
-  return { data: { slug: badgeRow.slug }, error: null };
-};
+// authz: admin-only (badgeService enforces via canRevokeBadge). Revoking a
+// badge the profile doesn't hold deletes 0 rows — no-op success.
+const revokeBadge = async (actor, { profileId, badgeSlug }) =>
+  badgeService.revokeBadge(actor, { profileId, badgeSlug });
 
 module.exports = {
   BADGES_BUCKET,

--- a/models/badge.test.js
+++ b/models/badge.test.js
@@ -296,9 +296,12 @@ const GRANT_CATALOG = [
   { id: 'b-off', slug: 'retired', category: 'event', is_active: false }
 ];
 
+const ADMIN_ACTOR = { profileId: 'p-admin', role: 'admin' };
+const USER_ACTOR = { profileId: 'p-user', role: 'user' };
+
 test('grantBadge upserts an award with granted_by', async () => {
   state.tables = { badges: GRANT_CATALOG };
-  const { error } = await badge.grantBadge({ profileId: 'p1', badgeSlug: 'enclave-day-1', grantedById: 'p-admin' });
+  const { error } = await badge.grantBadge(ADMIN_ACTOR, { profileId: 'p1', badgeSlug: 'enclave-day-1', grantedById: 'p-admin' });
   expect(error).toBeNull();
   const upsert = state.upserts.find(u => u.table === 'profile_badges');
   expect(upsert.payload).toEqual({ profile_id: 'p1', badge_id: 'b-ed1', granted_by: 'p-admin' });
@@ -307,28 +310,40 @@ test('grantBadge upserts an award with granted_by', async () => {
 
 test('grantBadge rejects milestone badges', async () => {
   state.tables = { badges: GRANT_CATALOG };
-  const { error } = await badge.grantBadge({ profileId: 'p1', badgeSlug: 'newcomer-1', grantedById: 'p-admin' });
+  const { error } = await badge.grantBadge(ADMIN_ACTOR, { profileId: 'p1', badgeSlug: 'newcomer-1', grantedById: 'p-admin' });
   expect(error?.message).toMatch(/milestone/i);
   expect(state.upserts.length).toBe(0);
 });
 
 test('grantBadge rejects unknown and inactive badges', async () => {
   state.tables = { badges: GRANT_CATALOG };
-  const missing = await badge.grantBadge({ profileId: 'p1', badgeSlug: 'nope', grantedById: 'p-admin' });
+  const missing = await badge.grantBadge(ADMIN_ACTOR, { profileId: 'p1', badgeSlug: 'nope', grantedById: 'p-admin' });
   expect(missing.error?.message).toMatch(/not found/i);
-  const inactive = await badge.grantBadge({ profileId: 'p1', badgeSlug: 'retired', grantedById: 'p-admin' });
+  const inactive = await badge.grantBadge(ADMIN_ACTOR, { profileId: 'p1', badgeSlug: 'retired', grantedById: 'p-admin' });
   expect(inactive.error?.message).toMatch(/not found/i);
+  expect(state.upserts.length).toBe(0);
+});
+
+test('grantBadge throws AuthorizationError for a non-admin actor, never reaching the repository', async () => {
+  state.tables = { badges: GRANT_CATALOG };
+  await expect(badge.grantBadge(USER_ACTOR, { profileId: 'p1', badgeSlug: 'enclave-day-1', grantedById: 'p-admin' })).rejects.toThrow();
   expect(state.upserts.length).toBe(0);
 });
 
 test('revokeBadge deletes the award row and rejects milestones', async () => {
   state.tables = { badges: GRANT_CATALOG };
-  const ok = await badge.revokeBadge({ profileId: 'p1', badgeSlug: 'enclave-day-1' });
+  const ok = await badge.revokeBadge(ADMIN_ACTOR, { profileId: 'p1', badgeSlug: 'enclave-day-1' });
   expect(ok.error).toBeNull();
   expect(state.deletes.length).toBe(1);
   expect(state.deletes[0].table).toBe('profile_badges');
 
-  const milestone = await badge.revokeBadge({ profileId: 'p1', badgeSlug: 'newcomer-1' });
+  const milestone = await badge.revokeBadge(ADMIN_ACTOR, { profileId: 'p1', badgeSlug: 'newcomer-1' });
   expect(milestone.error?.message).toMatch(/milestone/i);
   expect(state.deletes.length).toBe(1); // unchanged
+});
+
+test('revokeBadge throws AuthorizationError for a non-admin actor, never reaching the repository', async () => {
+  state.tables = { badges: GRANT_CATALOG };
+  await expect(badge.revokeBadge(USER_ACTOR, { profileId: 'p1', badgeSlug: 'enclave-day-1' })).rejects.toThrow();
+  expect(state.deletes.length).toBe(0);
 });

--- a/models/bot-link.js
+++ b/models/bot-link.js
@@ -1,136 +1,45 @@
-const crypto = require('crypto');
-const { supabaseAdmin } = require('./_base');
+const { BotLinkService, ...botLinkConstants } = require('../services/bot-link/service');
+const botLinkRepository = require('../services/bot-link/repository');
+const { createAgentToken } = require('./agent-token');
 
-const LINK_CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-const LINK_CODE_LENGTH = 8;
-const LINK_CODE_TTL_MS = 10 * 60 * 1000;
-const LINK_CODE_MAX_PENDING_PER_DISCORD_ID = 3;
-const LINK_CODE_RATE_WINDOW_MS = 10 * 60 * 1000;
-const LINK_ROW_CLEANUP_AGE_MS = 60 * 60 * 1000;
+const {
+  LINK_CODE_TTL_MS,
+  LINK_CODE_MAX_PENDING_PER_DISCORD_ID,
+  LINK_CODE_RATE_WINDOW_MS,
+  LINK_ROW_CLEANUP_AGE_MS,
+  generateLinkCode,
+  formatLinkCode,
+  normalizeLinkCode,
+  isValidDiscordUserId
+} = botLinkConstants;
 
-const generateLinkCode = () => {
-  const bytes = crypto.randomBytes(LINK_CODE_LENGTH);
-  let out = '';
-  for (let i = 0; i < LINK_CODE_LENGTH; i++) {
-    out += LINK_CODE_ALPHABET[bytes[i] % LINK_CODE_ALPHABET.length];
-  }
-  return out;
-};
+const botLinkService = new BotLinkService(botLinkRepository, createAgentToken);
 
-const formatLinkCode = (code) => {
-  if (typeof code !== 'string' || !/^[A-Z0-9]{8}$/.test(code)) {
-    throw new Error('Invalid link code');
-  }
-  return `${code.slice(0, 4)}-${code.slice(4)}`;
-};
+// Route-facing compatibility functions. The service enforces bot-link's
+// possession-based protocol for the PUBLIC capabilities and the
+// authenticated attach policy for confirmLink; this model remains the thin
+// caller so existing route imports keep working unchanged.
 
-const normalizeLinkCode = (value) => {
-  if (typeof value !== 'string') return null;
-  const cleaned = value.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
-  if (!/^[A-Z0-9]{8}$/.test(cleaned)) return null;
-  return cleaned;
-};
+// System write (no policy) — periodic cleanup of abandoned rows.
+const cleanupStaleLinks = async () => botLinkService.cleanupStaleLinks();
 
-const isValidDiscordUserId = (value) =>
-  typeof value === 'string' && /^[0-9]{1,32}$/.test(value);
+// PUBLIC — rate-limited per discord_user_id, enforced by botLinkService.
+const createPendingLink = async (discordUserId) => botLinkService.startLink({ discordUserId });
 
-const nowIso = () => new Date().toISOString();
-const plusMsIso = (ms) => new Date(Date.now() + ms).toISOString();
-const minusMsIso = (ms) => new Date(Date.now() - ms).toISOString();
+// Plain read — no policy (used by the authenticated confirm route to render
+// link state before it decides whether to attach a token).
+const getPendingLinkByCode = async (code) => botLinkRepository.fetchPendingByCode(code);
 
-const cleanupStaleLinks = async () => {
-  await supabaseAdmin
-    .from('pending_bot_links')
-    .delete()
-    .lt('created_at', minusMsIso(LINK_ROW_CLEANUP_AGE_MS));
-};
+// authz: canAttachToken (self actor, or system), enforced by botLinkService.
+const attachTokenToPendingLink = async ({ code, agentTokenId }) =>
+  botLinkRepository.attachToken({ code, agentTokenId });
 
-const countRecentPendingForDiscordId = async (discordUserId) => {
-  const since = minusMsIso(LINK_CODE_RATE_WINDOW_MS);
-  const { count, error } = await supabaseAdmin
-    .from('pending_bot_links')
-    .select('code', { count: 'exact', head: true })
-    .eq('discord_user_id', discordUserId)
-    .gte('created_at', since)
-    .is('consumed_at', null);
-  if (error) return { count: 0, error };
-  return { count: count || 0, error: null };
-};
-
-const createPendingLink = async (discordUserId) => {
-  if (!isValidDiscordUserId(discordUserId)) {
-    return { data: null, error: new Error('Invalid discord_user_id') };
-  }
-
-  await cleanupStaleLinks();
-
-  const { count, error: countError } = await countRecentPendingForDiscordId(discordUserId);
-  if (countError) return { data: null, error: countError };
-  if (count >= LINK_CODE_MAX_PENDING_PER_DISCORD_ID) {
-    return { data: null, error: new Error('Too many pending codes') };
-  }
-
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const code = generateLinkCode();
-    const expiresAt = plusMsIso(LINK_CODE_TTL_MS);
-    const { data, error } = await supabaseAdmin
-      .from('pending_bot_links')
-      .insert({
-        code,
-        discord_user_id: discordUserId,
-        expires_at: expiresAt
-      })
-      .select('code, discord_user_id, expires_at')
-      .single();
-    if (!error) return { data, error: null };
-    if (error.code !== '23505') return { data: null, error };
-  }
-  return { data: null, error: new Error('Could not allocate unique link code') };
-};
-
-const getPendingLinkByCode = async (code) => {
-  const { data, error } = await supabaseAdmin
-    .from('pending_bot_links')
-    .select('code, discord_user_id, agent_token_id, created_at, expires_at, consumed_at')
-    .eq('code', code)
-    .maybeSingle();
-  return { data: data || null, error };
-};
-
-const attachTokenToPendingLink = async ({ code, agentTokenId }) => {
-  const { data, error } = await supabaseAdmin
-    .from('pending_bot_links')
-    .update({ agent_token_id: agentTokenId })
-    .eq('code', code)
-    .is('consumed_at', null)
-    .gt('expires_at', nowIso())
-    .is('agent_token_id', null)
-    .select('code')
-    .single();
-  return { data, error };
-};
-
-const consumePendingLink = async ({ code, discordUserId }) => {
-  const { data: row, error } = await getPendingLinkByCode(code);
-  if (error && error.code !== 'PGRST116') return { data: null, error };
-  if (!row) return { data: null, error: 'not_found' };
-  if (row.consumed_at) return { data: null, error: 'expired' };
-  if (new Date(row.expires_at).getTime() < Date.now()) {
-    return { data: null, error: 'expired' };
-  }
-  if (row.discord_user_id !== discordUserId) return { data: null, error: 'mismatch' };
-  if (!row.agent_token_id) return { data: null, error: 'pending' };
-
-  const { data: consumed, error: consumeError } = await supabaseAdmin
-    .from('pending_bot_links')
-    .update({ consumed_at: nowIso() })
-    .eq('code', code)
-    .is('consumed_at', null)
-    .select('code, agent_token_id')
-    .single();
-  if (consumeError || !consumed) return { data: null, error: 'expired' };
-  return { data: { agentTokenId: consumed.agent_token_id }, error: null };
-};
+// PUBLIC/possession — enforced by botLinkService via policy.canClaimByPossession.
+// Note: on success this also discloses-and-purges the one-time raw token
+// stash (see botLinkService.claimLink); the original model-level function
+// only returned { agentTokenId }, so this adds a `rawToken` field to a
+// successful result rather than removing anything existing callers rely on.
+const consumePendingLink = async ({ code, discordUserId }) => botLinkService.claimLink({ code, discordUserId });
 
 module.exports = {
   LINK_CODE_TTL_MS,

--- a/models/character-update.test.js
+++ b/models/character-update.test.js
@@ -133,11 +133,13 @@ mock.module('./_base', () => ({
 // an earlier test file may have already loaded it with real `_base`. Bust the
 // cache so this require re-executes with the mocked exports in place.
 delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 const { updateCharacter } = require('./character');
 
 afterAll(() => {
   mock.module('./_base', () => realBase);
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 const PRIVATE_CHARACTER = {
@@ -191,14 +193,16 @@ test('updateCharacter can flip is_public on a private character (regression)', a
 });
 
 test('updateCharacter still rejects edits from non-owners on a private character', async () => {
-  const { data, error } = await updateCharacter(
+  // As of the character service seam, ownership denials THROW an
+  // AuthorizationError (services/character/service.js) instead of returning
+  // { data: null, error: 'Unauthorized' } — mirroring the mission/class
+  // service seams.
+  await expect(updateCharacter(
     'char-private-1',
     { is_public: 'on' },
     { id: 'someone-else' }
-  );
+  )).rejects.toThrow(/not authorized/i);
 
-  expect(error).toBe('Unauthorized');
-  expect(data).toBeNull();
   // The row must not have been flipped.
   expect(adminTables.characters[0].is_public).toBe(false);
 });

--- a/models/character.js
+++ b/models/character.js
@@ -1,10 +1,10 @@
-const { supabase, supabaseAdmin } = require('./_base');
+const { supabase } = require('./_base');
 const { getClasses, getClass, buildClassContentLookupMaps } = require('./class');
 const { escapeLikePattern } = require('../util/validate');
 const { statList } = require('../util/enclave-consts');
-const { listOffscreenMissions } = require('./offscreen-mission');
 const { cloneInput } = require('../services/character/input');
 const { CharacterService } = require('../services/character/service');
+const characterRepository = require('../services/character/repository');
 
 // Resolve the rules version a character should be rendered/validated against.
 // Inherits from the linked class; falls back to 'v1' when no class is linked
@@ -87,6 +87,11 @@ const getPublicCharactersByCreator = async (creatorId) => {
   return { data, error };
 }
 
+// Reads the primary character row through `client` (RLS-scoped by default,
+// or an admin client when a caller explicitly passes one) but always reads
+// its traits/gear/abilities/ability_perks through the repository's privileged
+// helpers — mirrors the pre-refactor behavior, where those child reads always
+// bypassed RLS regardless of the caller's client.
 const getCharacter = async (id, client = supabase) => {
   const { data, error } = await client.from('characters').select('*').eq('id', id).single();
   if (error) {
@@ -94,28 +99,28 @@ const getCharacter = async (id, client = supabase) => {
     return { data: null, error };
   }
 
-  const { data: traits, error: traitsError } = await getCharacterTraits(id);
+  const { data: traits, error: traitsError } = await characterRepository.getCharacterTraits(id);
   if (traitsError) {
     console.error(traitsError);
     return { data: null, error: traitsError };
   }
   data.traits = traits.map(trait => trait.name);
 
-  const { data: gear, error: gearError } = await getCharacterGear(id, client);
+  const { data: gear, error: gearError } = await characterRepository.getCharacterGear(id, client);
   if (gearError) {
     console.error(gearError);
     return { data: null, error: gearError };
   }
   data.gear = gear;
 
-  const { data: abilities, error: abilitiesError } = await getCharacterAbilities(id, client);
+  const { data: abilities, error: abilitiesError } = await characterRepository.getCharacterAbilities(id, client);
   if (abilitiesError) {
     console.error(abilitiesError);
     return { data: null, error: abilitiesError };
   }
   data.abilities = abilities;
 
-  const { data: abilityPerks, error: perksError } = await getCharacterAbilityPerks(id);
+  const { data: abilityPerks, error: perksError } = await characterRepository.getCharacterAbilityPerks(id);
   if (perksError) {
     console.error(perksError);
     return { data: null, error: perksError };
@@ -144,130 +149,6 @@ const getCharacter = async (id, client = supabase) => {
   return { data, error };
 }
 
-const deleteCharacter = async (id, profile) => {
-  // Admin read for the ownership probe — see updateCharacter for the same
-  // reasoning. The creator_id JS check + .eq() filter still enforce authz.
-  const { data: characterData, error: characterError } = await getCharacter(id, supabaseAdmin);
-  if (characterError) return { data: null, error: characterError };
-  if (characterData.creator_id != profile.id) return { data: null, error: 'Unauthorized' };
-
-  // authz: creator_id check above + filter below
-  const { data, error } = await supabaseAdmin.from('characters').delete().eq('id', id).eq('creator_id', profile.id);
-  return { data, error };
-}
-
-// helpers
-
-const getCharacterTraits = async (id) => {
-  const { data, error } = await supabaseAdmin.from('traits').select('*').eq('character_id', id);
-  return { data, error };
-}
-
-const getCharacterGear = async (id, client = supabase) => {
-  // Fetch character gear rows
-  const { data: gear, error: gearError } = await supabaseAdmin
-    .from('class_gear')
-    .select('*')
-    .eq('character_id', id);
-  if (gearError) {
-    return { data: null, error: gearError };
-  }
-
-  if (!Array.isArray(gear) || gear.length === 0) {
-    return { data: [], error: null };
-  }
-
-  // Fetch related class definitions (non-fatal)
-  const classIds = [...new Set(gear.map(g => g.class_id).filter(Boolean))];
-  if (classIds.length === 0) {
-    return { data: gear, error: null };
-  }
-  const { data: classes, error: classesError } = await client
-    .from('classes')
-    .select('id, name, gear')
-    .in('id', classIds);
-  if (classesError) {
-    // Fallback: return raw gear rows as-is
-    return { data: gear, error: null };
-  }
-
-  // Merge class gear definition values directly onto each character gear row
-  const mergedGear = gear.map(item => {
-    const cls = classes?.find(c => c.id === item.class_id);
-    const classGear = Array.isArray(cls?.gear)
-      ? cls.gear.find(g => g && g.name === item.name)
-      : null;
-
-    if (classGear) {
-      // Prefer existing row values when overlapping keys exist
-      return { ...classGear, ...item };
-    }
-    return item;
-  });
-
-  return { data: mergedGear, error: null };
-}
-
-const getCharacterAbilities = async (id, client = supabase) => {
-  // First get the character abilities
-  const { data: abilities, error: abilitiesError } = await supabaseAdmin
-    .from('class_abilities')
-    .select('*')
-    .eq('character_id', id);
-  
-  if (abilitiesError) {
-    return { data: null, error: abilitiesError };
-  }
-
-  if (!abilities || abilities.length === 0) {
-    return { data: [], error: null };
-  }
-
-  // Get unique class IDs
-  const classIds = [...new Set(abilities.map(ability => ability.class_id).filter(Boolean))];
-  if (classIds.length === 0) {
-    return { data: abilities, error: null };
-  }
-  
-  // Get classes with their abilities JSONB (non-fatal)
-  const { data: classes, error: classesError } = await client
-    .from('classes')
-    .select('id, name, abilities')
-    .in('id', classIds);
-
-  if (classesError) {
-    // Fallback: return raw ability rows as-is
-    return { data: abilities, error: null };
-  }
-
-  // Merge class ability definition values directly onto each character ability
-  const mergedAbilities = abilities.map(ability => {
-    const cls = classes.find(c => c.id === ability.class_id);
-    const classAbility = Array.isArray(cls?.abilities)
-      ? cls.abilities.find(a => a && a.name === ability.name)
-      : null;
-
-    if (classAbility) {
-      // Prefer existing ability row values when overlapping keys exist
-      return { ...classAbility, ...ability };
-    }
-
-    return ability;
-  });
-
-  return { data: mergedAbilities, error: null };
-}
-
-const getCharacterAbilityPerks = async (id) => {
-  const { data, error } = await supabaseAdmin
-    .from('character_perks')
-    .select('*')
-    .eq('character_id', id)
-    .order('position', { ascending: true });
-  if (error) return { data: null, error };
-  return { data: Array.isArray(data) ? data : [], error: null };
-};
-
 const getCharacterRecentMissions = async (characterId, limit = 5) => {
   const { data, error } = await supabase
     .from('mission_characters')
@@ -285,7 +166,7 @@ const getCharacterRecentMissions = async (characterId, limit = 5) => {
     .eq('character_id', characterId)
     .order('missions(date)', { ascending: false })
     .limit(limit);
-  
+
   if (error) {
     console.error(error);
     return { data: null, error };
@@ -299,8 +180,8 @@ const getCharacterRecentMissions = async (characterId, limit = 5) => {
   }).map(m => m.missions);
 
   return {
-    data: filteredMissions, 
-    error 
+    data: filteredMissions,
+    error
   };
 };
 
@@ -356,72 +237,6 @@ const getCharacterRealMissionsForDerivation = async (characterId, client = supab
     data: (data || []).map(mc => mc.missions).filter(Boolean),
     error: null
   };
-};
-
-const markCharacterDeceased = async (id, profile) => {
-  // Admin read for the ownership probe — see updateCharacter for the same
-  // reasoning. The creator_id JS check + .eq() filter still enforce authz.
-  const { data: characterData, error: characterError } = await getCharacter(id, supabaseAdmin);
-  if (characterError) return { data: null, error: characterError };
-  if (characterData.creator_id != profile.id) return { data: null, error: 'Unauthorized' };
-  if (characterData.is_deceased) return { data: null, error: 'Character is already deceased' };
-
-  // authz: creator_id check above + filter below
-  const { data, error } = await supabaseAdmin
-    .from('characters')
-    .update({ is_deceased: true })
-    .eq('id', id)
-    .eq('creator_id', profile.id)
-    .select();
-
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
-  if (!data || data.length === 0) {
-    return { data: null, error: 'Character update returned no rows' };
-  }
-
-  return { data: data[0], error: null };
-};
-
-const upgradeCharacterClass = async (id, targetClassId, profile, client = supabase) => {
-  // Lean admin-client read of just what we need from the character. The default
-  // anon `supabase` would RLS-strip private characters, so we use admin here;
-  // ownership is enforced by the creator_id check below + the UPDATE's
-  // .eq('creator_id', profile.id) filter.
-  const { data: characterData, error: characterError } = await supabaseAdmin
-    .from('characters')
-    .select('id, creator_id, class_id')
-    .eq('id', id)
-    .maybeSingle();
-  if (characterError) return { data: null, error: characterError };
-  if (!characterData) return { data: null, error: 'Character not found' };
-  if (characterData.creator_id != profile.id) return { data: null, error: 'Unauthorized' };
-  if (!targetClassId) return { data: null, error: 'Missing target class id' };
-
-  // Target-class lookup uses the per-request client so RLS gates which
-  // candidates the caller can pick: admins see private forks, non-admins
-  // see only public ones. This prevents non-admins from upgrading into an
-  // unreleased private v2 by guessing its id.
-  const candidates = await findUpgradeTargetsFor(characterData.class_id, client);
-  const target = candidates.find(c => c.id === targetClassId);
-  if (!target) return { data: null, error: 'Target class is not a valid upgrade for this character' };
-
-  const { data, error } = await supabaseAdmin
-    .from('characters')
-    .update({ class_id: target.id, class: target.name })
-    .eq('id', id)
-    .eq('creator_id', profile.id)
-    .select();
-  if (error) {
-    console.error(error);
-    return { data: null, error };
-  }
-  if (!data || data.length === 0) {
-    return { data: null, error: 'Character upgrade returned no rows' };
-  }
-  return { data: data[0], error: null };
 };
 
 const searchPublicCharacters = async (q, count, options = {}) => {
@@ -550,31 +365,7 @@ const serializeCharacterForAgent = (row, actor = {}) => {
 };
 
 const searchCharactersForAgent = async (query, actor = {}) => {
-  const q = typeof query === 'string' ? query.trim() : '';
-  let builder = supabaseAdmin
-    .from('characters')
-    .select('id, name, class, level, is_public, is_deceased, creator_id, profile:creator_id(name)')
-    .order('name', { ascending: true })
-    .limit(10);
-
-  if (actor.role !== 'admin') {
-    if (actor.profileId) {
-      builder = builder.or(`is_public.eq.true,creator_id.eq.${actor.profileId}`);
-    } else {
-      builder = builder.eq('is_public', true);
-    }
-  }
-
-  if (q.length > 0) {
-    const escaped = escapeLikePattern(q);
-    builder = builder.ilike('name', `%${escaped}%`);
-  } else if (actor.profileId) {
-    builder = builder.eq('creator_id', actor.profileId).order('updated_at', { ascending: false });
-  } else {
-    return { data: [], error: null };
-  }
-
-  const { data, error } = await builder;
+  const { data, error } = await characterRepository.searchCharactersForAgent(query, actor);
   if (error) return { data: null, error };
 
   const mapped = (data || []).map((row) =>
@@ -584,24 +375,13 @@ const searchCharactersForAgent = async (query, actor = {}) => {
 };
 
 const getCharacterForAgent = async (id, actor = {}) => {
-  const { data, error } = await supabaseAdmin
-    .from('characters')
-    .select(`
-      id, name, class, class_id, level, is_public, is_deceased, creator_id,
-      ${statList.join(',')},
-      profile:creator_id(name),
-      personality:traits(name),
-      abilities:class_abilities(name,description),
-      gear:class_gear(name,description)
-    `)
-    .eq('id', id)
-    .maybeSingle();
-  if (error && error.code !== 'PGRST116') return { data: null, error };
+  const { data, error } = await characterRepository.getCharacterForAgentRow(id);
+  if (error) return { data: null, error };
   if (!data) return { data: null, error: null };
 
   const rulesVersion = await effectiveRulesVersion(data.class_id);
   if (rulesVersion === 'v2') {
-    const { data: perks } = await getCharacterAbilityPerks(data.id);
+    const { data: perks } = await characterRepository.getCharacterAbilityPerks(data.id);
     data.ability_perks = perks || [];
   }
 
@@ -612,57 +392,32 @@ const getCharacterForAgent = async (id, actor = {}) => {
   return { data: serialized, error: null };
 };
 
-// Compatibility adapter: routes and importers continue using this model's
-// public functions while the service owns write orchestration. The adapter can
-// be replaced by an RPC-backed implementation without changing those callers.
+// Application boundary: the repository owns every privileged (service-role)
+// query for the character domain (services/character/repository.js). This
+// service composes that repository with the RLS-agnostic model-local helpers
+// (class-reference resolution, rules-version lookup, catalog maps, upgrade
+// targets) that don't need the privileged client — routes and other models
+// continue using this model's exported functions while the service owns
+// validation, authorization, sequencing, and reconciliation decisions.
 const characterService = new CharacterService({
+  ...characterRepository,
   getRulesVersion: classId => effectiveRulesVersion(classId),
   resolveClassReference: resolveCharacterClassReference,
-  getCharacter: id => getCharacter(id, supabaseAdmin),
-  createCharacterRow: input => supabaseAdmin.from('characters').insert(input).select(),
-  updateCharacterRow: (id, input, actor) => supabaseAdmin
-    .from('characters')
-    .update(input)
-    .eq('id', id)
-    .eq('creator_id', actor.id)
-    .select(),
-  ...(typeof supabaseAdmin.rpc === 'function' ? {
-    saveCharacterAtomic: async ({ characterId, creatorId, character, traits, gear, abilities, perks }) => {
-      const { data, error } = await supabaseAdmin.rpc('save_character_atomic', {
-        p_character_id: characterId,
-        p_creator_id: creatorId,
-        p_character: character,
-        p_traits: traits,
-        p_gear: gear,
-        p_abilities: abilities,
-        p_perks: perks
-      });
-      return { data, error };
-    }
-  } : {}),
-  getChildRows: (table, characterId) => supabaseAdmin
-    .from(table)
-    .select('*')
-    .eq('character_id', characterId),
-  insertChildRows: (table, characterId, rows) => supabaseAdmin
-    .from(table)
-    .insert(rows.map(row => ({ character_id: characterId, ...row }))),
-  updateChildRow: (table, rowId, changes) => supabaseAdmin
-    .from(table)
-    .update(changes)
-    .eq('id', rowId),
-  deleteChildRows: (table, characterId, rowIds) => supabaseAdmin
-    .from(table)
-    .delete()
-    .in('id', rowIds)
-    .eq('character_id', characterId),
   getClassContentLookupMaps: buildClassContentLookupMaps,
-  getRealMissions: id => getCharacterRealMissionsForDerivation(id, supabaseAdmin),
-  listOffscreenMissions: id => listOffscreenMissions({ characterId: id, supabase: supabaseAdmin })
+  findUpgradeTargets: (classId, client) => findUpgradeTargetsFor(classId, client)
 });
 
 const createCharacter = (input, actor) => characterService.createCharacter(input, actor);
 const updateCharacter = (id, input, actor) => characterService.updateCharacter(id, input, actor);
+
+// Mutation capabilities. Signatures take `actor` (built by the caller via
+// actorFromLocals/actorFromProfile/SYSTEM_ACTOR) first, matching the mission/
+// class service seams; denials throw AuthorizationError.
+const deleteCharacter = (actor, id) => characterService.deleteCharacter(actor, id);
+const markCharacterDeceased = (actor, id, confirmName) => characterService.markDeceased(actor, id, confirmName);
+const upgradeCharacterClass = (actor, id, targetClassId, client) => characterService.upgradeClass(actor, id, targetClassId, client);
+const updateCharacterStats = (actor, id, fields) => characterService.updateStats(actor, id, fields);
+const levelUpCharacter = (actor, id, body) => characterService.levelUp(actor, id, body);
 
 module.exports = {
   getOwnCharacters,
@@ -673,6 +428,8 @@ module.exports = {
   deleteCharacter,
   markCharacterDeceased,
   upgradeCharacterClass,
+  updateCharacterStats,
+  levelUpCharacter,
   findUpgradeTargetsFor,
   getCharacterRecentMissions,
   getCharacterAllMissions,

--- a/models/character.test.js
+++ b/models/character.test.js
@@ -133,12 +133,14 @@ mock.module('./_base', () => ({
 // loaded it with the real `_base`. Bust the cache so this require re-executes
 // `character.js` with the mocked `_base` in place.
 delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 const { getCharacter, getCharacterForAgent } = require('./character');
 
 afterAll(() => {
   mock.module('./_base', () => realBase);
   // Restore the real character.js for any later test file that loads it.
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('getCharacter returns traits/gear/abilities even when anon client is RLS-blocked', async () => {
@@ -225,6 +227,7 @@ test('createCharacter preserves v2 fields when linked class is v2', async () => 
     createUserClient: () => fakeAdminV2
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
   const { createCharacter } = require('./character');
 
   const payload = {
@@ -252,6 +255,7 @@ test('createCharacter preserves v2 fields when linked class is v2', async () => 
     createUserClient: () => fakeAnon
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('createCharacter strips v1-only fields (perks, additional_gear) when class is v2', async () => {
@@ -262,6 +266,7 @@ test('createCharacter strips v1-only fields (perks, additional_gear) when class 
     createUserClient: () => fakeAdminV2
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
   const { createCharacter } = require('./character');
 
   const payload = {
@@ -282,6 +287,7 @@ test('createCharacter strips v1-only fields (perks, additional_gear) when class 
     anonKey: 'test-anon-key', createUserClient: () => fakeAnon
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('createCharacter keeps v1 free-text perks when class is v1', async () => {
@@ -306,6 +312,7 @@ test('createCharacter remaps create-form perks (referenced by ability name) with
     createUserClient: () => fakeAdminV2
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
   const { createCharacter } = require('./character');
 
   // No `abilities` key: classAbilities is undefined so setCharacterAbilities is
@@ -328,6 +335,7 @@ test('createCharacter remaps create-form perks (referenced by ability name) with
     anonKey: 'test-anon-key', createUserClient: () => fakeAnon
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('createCharacter rejects v2 perks that violate validation', async () => {
@@ -338,6 +346,7 @@ test('createCharacter rejects v2 perks that violate validation', async () => {
     createUserClient: () => fakeAdminV2
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
   const { createCharacter } = require('./character');
 
   const longText = Array.from({ length: 26 }, (_, i) => `w${i}`).join(' ');
@@ -357,6 +366,7 @@ test('createCharacter rejects v2 perks that violate validation', async () => {
     anonKey: 'test-anon-key', createUserClient: () => fakeAnon
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('getCharacter attaches ability_perks for v2 characters', async () => {
@@ -385,6 +395,7 @@ test('getCharacter attaches ability_perks for v2 characters', async () => {
     };
   });
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
   const { getCharacter } = require('./character');
   const { data, error } = await getCharacter('char-uuid-1');
   expect(error).toBeFalsy();
@@ -398,6 +409,7 @@ test('getCharacter attaches ability_perks for v2 characters', async () => {
     anonKey: 'test-anon-key', createUserClient: () => fakeAnon
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('getCharacter rewrites compounds_with UUIDs into position-N sentinels', async () => {
@@ -427,6 +439,7 @@ test('getCharacter rewrites compounds_with UUIDs into position-N sentinels', asy
     };
   });
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
   const { getCharacter } = require('./character');
   const { data } = await getCharacter('char-uuid-1');
   const perks = data.ability_perks;
@@ -441,6 +454,7 @@ test('getCharacter rewrites compounds_with UUIDs into position-N sentinels', asy
     anonKey: 'test-anon-key', createUserClient: () => fakeAnon
   }));
   delete require.cache[require.resolve('./character')];
+delete require.cache[require.resolve('../services/character/repository')];
 });
 
 test('serializeCharacterForAgent omits v2 fields on v1 characters', () => {

--- a/models/class.js
+++ b/models/class.js
@@ -1,33 +1,9 @@
-const { supabase, supabaseAdmin } = require('./_base');
+const { supabase } = require('./_base');
 const crypto = require('crypto');
 const { computeVersionFamily, expandIdsToFamilies } = require('../util/class-family');
+const { applyClassFilters } = require('../util/class-filters');
 const { ClassService } = require('../services/class/service');
-
-const applyClassFilters = (query, filters = {}) => {
-    if (filters.name) {
-        query = query.eq('name', filters.name);
-    }
-    if (filters.is_public !== undefined) {
-        query = query.eq('is_public', filters.is_public);
-    }
-    if (filters.created_by) {
-        query = query.eq('created_by', filters.created_by);
-    }
-    if (filters.rules_edition) {
-        query = query.eq('rules_edition', filters.rules_edition);
-    }
-    if (filters.rules_version) {
-        query = query.eq('rules_version', filters.rules_version);
-    }
-    if (filters.status) {
-        query = query.eq('status', filters.status);
-    }
-    if (filters.is_player_created !== undefined) {
-        query = query.eq('is_player_created', filters.is_player_created);
-    }
-
-    return query.order('name', { ascending: true });
-};
+const classRepository = require('../services/class/repository');
 
 const getClasses = async (filters = {}, client = supabase) => {
     const query = applyClassFilters(
@@ -45,7 +21,11 @@ const getClasses = async (filters = {}, client = supabase) => {
     return { data, error };
 };
 
-const createUnlockCodes = async ({ classId, createdByProfileId, expiresAt = null, maxUses = 1, amount = 1 }) => {
+// Route-facing compatibility function. The service enforces the
+// mint-unlock-codes policy (admin/system only); this model builds the
+// code rows (the non-privileged logic) and delegates the privileged
+// insert to the service/repository.
+const createUnlockCodes = async (actor, { classId, createdByProfileId, expiresAt = null, maxUses = 1, amount = 1 }) => {
     const inserts = Array.from({ length: amount }, () => ({
         code: crypto.randomBytes(12).toString('base64url'),
         class_id: classId,
@@ -54,17 +34,7 @@ const createUnlockCodes = async ({ classId, createdByProfileId, expiresAt = null
         max_uses: maxUses
     }));
 
-    // authz: callers (admin-only route) gate access; createdByProfileId is set server-side
-    const { data, error } = await supabaseAdmin
-        .from('class_unlock_codes')
-        .insert(inserts)
-        .select();
-
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error: null };
+    return classService.mintUnlockCodes(actor, inserts);
 };
 
 const listUnlockCodes = async (classId, client = supabase) => {
@@ -91,24 +61,10 @@ const redeemUnlockCode = async (code, userId) => {
     return { data, error: null };
 };
 
-// Lean projection of all classes for version-family resolution. Admin client
-// so private forks don't break chain links. Returns null on any failure so
-// callers can degrade to exact-id behavior.
-const fetchClassFamilyRows = async () => {
-    try {
-        const { data, error } = await supabaseAdmin
-            .from('classes')
-            .select('id, base_class_id, rules_edition');
-        if (error || !Array.isArray(data)) {
-            if (error) console.error(error);
-            return null;
-        }
-        return data;
-    } catch (e) {
-        console.error(e);
-        return null;
-    }
-};
+// Lean projection of all classes for version-family resolution. Admin
+// client so private forks don't break chain links. Returns null on any
+// failure so callers can degrade to exact-id behavior.
+const fetchClassFamilyRows = () => classRepository.fetchClassFamilyRows();
 
 // Resolve the same-edition version family of a class (see util/class-family).
 // Falls back to a singleton set on error: unlock checks degrade to exact-id.
@@ -127,16 +83,13 @@ const isClassUnlocked = async (userId, classId) => {
     const familyIds = await getVersionFamilyIds(classId);
 
     const now = new Date().toISOString();
-    const { data, error } = await supabaseAdmin
-        .from('class_unlocks')
-        .select('class_id, expires_at')
-        .eq('user_id', userId)
-        .in('class_id', [...familyIds])
-        .or(`expires_at.is.null,expires_at.gt.${now}`)
-        .limit(1);
+    const { data, error } = await classRepository.activeUnlockRows({
+        userId,
+        classIds: [...familyIds],
+        nowIso: now
+    });
 
     if (error) {
-        console.error(error);
         return { data: false, error };
     }
     return { data: Array.isArray(data) && data.length > 0, error: null };
@@ -148,7 +101,7 @@ const getClass = async (id, client = supabase) => {
         .select('*')
         .eq('id', id)
         .single();
-    
+
     // // unpack jsonb fields: abilities and gear
     // data.abilities = JSON.parse(data.abilities);
     // data.gear = JSON.parse(data.gear);
@@ -160,11 +113,12 @@ const getClass = async (id, client = supabase) => {
     return { data, error };
 };
 
-// Route-facing compatibility functions. The service owns input preparation and
-// write orchestration while this model remains the Supabase adapter.
+// Route-facing compatibility functions. The service owns input preparation,
+// authorization, and write orchestration; this model remains the thin
+// caller that threads the actor through.
 let classService;
-const createClass = async (classData) => classService.createClass(classData);
-const updateClass = async (id, updates) => classService.updateClass(id, updates);
+const createClass = async (actor, classData) => classService.createClass(actor, classData);
+const updateClass = async (actor, id, updates) => classService.updateClass(actor, id, updates);
 
 const duplicateClass = async (baseId, newVersion, newEdition = null) => {
     const params = {
@@ -184,24 +138,19 @@ const duplicateClass = async (baseId, newVersion, newEdition = null) => {
     return { data, error };
 };
 
-const saveClassPdfMetadata = async (classId, storagePath) =>
-    classService.savePdfMetadata(classId, storagePath);
+const saveClassPdfMetadata = async (actor, classId, storagePath) =>
+    classService.savePdfMetadata(actor, classId, storagePath);
 
 const getUnlockedClasses = async (userId) => {
     const now = new Date().toISOString();
-    const { data, error } = await supabaseAdmin
-        .from('class_unlocks')
-        .select('class:classes(*), expires_at')
-        .eq('user_id', userId)
-        .or(`expires_at.is.null,expires_at.gt.${now}`);
+    const { data, error } = await classRepository.unlockedClassRows({ userId, nowIso: now });
 
     if (error) {
-        console.error(error);
         return { data: null, error };
     }
-    return { 
+    return {
         data: data.map(entry => entry.class),
-        error 
+        error: null
     };
 };
 
@@ -211,14 +160,9 @@ const getUnlockedClassIdsForUser = async (userId) => {
     }
 
     const now = new Date().toISOString();
-    const { data, error } = await supabaseAdmin
-        .from('class_unlocks')
-        .select('class_id')
-        .eq('user_id', userId)
-        .or(`expires_at.is.null,expires_at.gt.${now}`);
+    const { data, error } = await classRepository.unlockedClassIdRows({ userId, nowIso: now });
 
     if (error) {
-        console.error(error);
         return { data: null, error };
     }
 
@@ -308,23 +252,8 @@ const serializeClassForAgent = ({ classData, actor = {}, unlockedClassIds = new 
 };
 
 const listClassesForAgent = async (filters = {}, actor = {}) => {
-    let query = supabaseAdmin
-        .from('classes')
-        .select('*');
-
-    query = applyClassFilters(query, filters);
-
-    if (actor.role !== 'admin') {
-        if (actor.profileId) {
-            query = query.or(`is_public.eq.true,created_by.eq.${actor.profileId}`);
-        } else {
-            query = query.eq('is_public', true);
-        }
-    }
-
-    const { data, error } = await query;
+    const { data, error } = await classRepository.fetchClassesForAgentAdmin(filters, actor);
     if (error) {
-        console.error(error);
         return { data: null, error };
     }
 
@@ -342,14 +271,9 @@ const listClassesForAgent = async (filters = {}, actor = {}) => {
 };
 
 const getClassForAgent = async (id, actor = {}) => {
-    const { data: classData, error } = await supabaseAdmin
-        .from('classes')
-        .select('*')
-        .eq('id', id)
-        .single();
+    const { data: classData, error } = await classRepository.fetchClassByIdAdmin(id);
 
     if (error) {
-        console.error(error);
         return { data: null, error };
     }
 
@@ -403,17 +327,12 @@ const unlockClass = async (userId, classId, expiresAt = null) => {
     }
 
     // authz: caller route verifies eligibility before calling (e.g. /unlock/self, redeem code)
-    const { data, error } = await supabaseAdmin
-        .from('class_unlocks')
-        .insert([payload])
-        .select()
-        .single();
+    const { data, error } = await classRepository.insertUnlock(payload);
 
     if (error) {
-        console.error(error);
         return { data: null, error };
     }
-    return { data, error };
+    return { data, error: null };
 };
 
 const getVersionHistory = async (classId) => {
@@ -430,7 +349,7 @@ const getVersionHistory = async (classId) => {
     return { data, error };
 };
 
-const deleteClass = async (id) => classService.deleteClass(id);
+const deleteClass = async (actor, id) => classService.deleteClass(actor, id);
 
 // Build lookup maps from gear/ability name -> class_id and description
 const buildClassContentLookupMaps = async () => {
@@ -440,17 +359,17 @@ const buildClassContentLookupMaps = async () => {
         getClasses({ is_public: true, is_player_created: false, rules_edition: 'aspirant' }),
         getClasses({ is_public: true, is_player_created: true })
       ]);
-  
+
       const advent = Array.isArray(adventRes?.data) ? adventRes.data : [];
       const aspirant = Array.isArray(aspirantRes?.data) ? aspirantRes.data : [];
       const pcc = Array.isArray(pccRes?.data) ? pccRes.data : [];
-  
+
       const allClasses = [...advent, ...aspirant, ...pcc];
       const gearNameToClassId = new Map();
       const abilityNameToClassId = new Map();
       const gearNameToDescription = new Map();
       const abilityNameToDescription = new Map();
-  
+
       for (const cls of allClasses) {
         if (Array.isArray(cls?.gear)) {
           for (const g of cls.gear) {
@@ -475,38 +394,14 @@ const buildClassContentLookupMaps = async () => {
           }
         }
       }
-  
+
       return { gearNameToClassId, abilityNameToClassId, gearNameToDescription, abilityNameToDescription };
     } catch (error) {
       throw error;
     }
 };
 
-const withClassWriteResult = async (query) => {
-    const { data, error } = await query;
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error: null };
-};
-
-classService = new ClassService({
-    createClassRow: data => withClassWriteResult(
-        supabaseAdmin.from('classes').insert([data]).select().single()
-    ),
-    updateClassRow: (id, data) => withClassWriteResult(
-        supabaseAdmin.from('classes').update(data).eq('id', id).select().single()
-    ),
-    deleteClassRow: async id => {
-        const { error } = await supabaseAdmin.from('classes').delete().eq('id', id);
-        if (error) console.error(error);
-        return { error: error || null };
-    },
-    savePdfMetadataRow: (id, data) => withClassWriteResult(
-        supabaseAdmin.from('classes').update(data).eq('id', id).select().single()
-    )
-});
+classService = new ClassService(classRepository);
 
 module.exports = {
     getClasses,

--- a/models/lfg-agent.test.js
+++ b/models/lfg-agent.test.js
@@ -528,6 +528,33 @@ describe('closeForAgent', () => {
   });
 });
 
+// ─── updateForAgent (agent surface must not grant an admin-role bypass) ──────
+
+describe('updateForAgent', () => {
+  test('an admin-role agent profile acting on another profile\'s post is blocked, same as delete/close', async () => {
+    const adminAuthId = await createAuthUser(`lfg-test-admin-${Date.now()}@test.invalid`);
+    const adminProfile = await createProfile(adminAuthId, 'Admin Agent');
+    await supabaseAdmin.from('profiles').update({ role: 'admin' }).eq('id', adminProfile.id);
+    try {
+      const { data, error } = await updateForAgent({
+        agentProfile: { ...adminProfile, role: 'admin' },
+        postId: openPost.id,
+        body: { title: 'Hijacked title' }
+      });
+      expect(data).toBeNull();
+      expect(error.status).toBe(403);
+      expect(error.code).toBe('not_host');
+
+      const { data: row } = await supabaseAdmin
+        .from('lfg_posts').select('title').eq('id', openPost.id).single();
+      expect(row.title).not.toBe('Hijacked title');
+    } finally {
+      await supabaseAdmin.from('profiles').delete().eq('id', adminProfile.id);
+      await deleteAuthUser(adminAuthId);
+    }
+  });
+});
+
 // ─── updateRequestForAgent ────────────────────────────────────────────────────
 
 describe('updateRequestForAgent', () => {

--- a/models/lfg-agent.test.js
+++ b/models/lfg-agent.test.js
@@ -4,6 +4,12 @@
 const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
 const { Client } = require('pg');
 const { supabaseAdmin } = require('./_base');
+const { actorFromProfile } = require('../util/actor');
+
+// createLfgPost/updateLfgPost now take an actor (built by the caller via
+// actorFromLocals/actorFromProfile) rather than a bare profile row, extended
+// with `timezone` since normalizeLfgInput needs it for date conversion.
+const actorFor = (profile) => ({ ...actorFromProfile(profile), timezone: profile.timezone });
 
 const {
   listPostsForAgent,
@@ -368,13 +374,13 @@ describe('self-join auto-approve', () => {
 describe('createLfgPost host-flag flow', () => {
   test('host_id=on creates+approves a conduit join_request and syncs host_id', async () => {
     const { createLfgPost } = require('./lfg');
-    const { data: post, error } = await createLfgPost({
+    const { data: post, error } = await createLfgPost(actorFor(hostProfile), {
       title: 'Host-flag post',
       description: 'test',
       date: new Date(Date.now() + 86400000).toISOString(),
       max_characters: 4,
       host_id: 'on'
-    }, hostProfile);
+    });
     expect(error).toBeNull();
     expect(post).toBeTruthy();
     try {
@@ -398,12 +404,12 @@ describe('createLfgPost host-flag flow', () => {
 
   test('no host_id flag leaves post with no conduit', async () => {
     const { createLfgPost } = require('./lfg');
-    const { data: post, error } = await createLfgPost({
+    const { data: post, error } = await createLfgPost(actorFor(hostProfile), {
       title: 'No-host post',
       description: 'test',
       date: new Date(Date.now() + 86400000).toISOString(),
       max_characters: 4
-    }, hostProfile);
+    });
     expect(error).toBeNull();
     try {
       const { data: row } = await supabaseAdmin
@@ -427,13 +433,13 @@ describe('updateLfgPost role reconciliation', () => {
 
   test('setting host_id=on when not yet conduit creates+approves the conduit request', async () => {
     const { updateLfgPost } = require('./lfg');
-    const { error } = await updateLfgPost(openPost.id, {
+    const { error } = await updateLfgPost(actorFor(hostProfile), openPost.id, {
       title: openPost.title,
       description: openPost.description,
       date: new Date(Date.now() + 86400000).toISOString(),
       max_characters: 4,
       host_id: 'on'
-    }, hostProfile);
+    });
     expect(error).toBeNull();
 
     const { data: req } = await supabaseAdmin
@@ -456,13 +462,13 @@ describe('updateLfgPost role reconciliation', () => {
     await supabaseAdmin.from('lfg_posts').update({ host_id: hostProfile.id }).eq('id', openPost.id);
 
     const { updateLfgPost } = require('./lfg');
-    const { error } = await updateLfgPost(openPost.id, {
+    const { error } = await updateLfgPost(actorFor(hostProfile), openPost.id, {
       title: 'Edited title',
       description: openPost.description,
       date: new Date(Date.now() + 86400000).toISOString(),
       max_characters: 4
       // note: no host_id field at all
-    }, hostProfile);
+    });
     expect(error).toBeNull();
 
     const { data: req } = await supabaseAdmin

--- a/models/lfg.js
+++ b/models/lfg.js
@@ -167,6 +167,11 @@ const toAgentError = (err) => {
   return { status: 500, code: 'internal_error', message: (err && err.message) || 'Unexpected error' };
 };
 
+// role is intentionally always null here (never the profile's real role):
+// the lfg agent surface authorizes purely on ownership/host checks, with no
+// admin bypass. This is a deliberate divergence from the class/character
+// agent-read actor (routes/agent.js getActorContext), which preserves the
+// real role to honor that domain's per-role read-visibility contract.
 const buildAgentActor = (profileId) => ({ profileId, role: null });
 
 const createLfgPost = async (actor, postReq) => lfgService.createPost(actor, postReq, { timezone: actor?.timezone });

--- a/models/lfg.js
+++ b/models/lfg.js
@@ -3,7 +3,6 @@ const { statList } = require('../util/enclave-consts');
 const moment = require('moment-timezone');
 const { LfgService } = require('../services/lfg/service');
 const lfgRepository = require('../services/lfg/repository');
-const { actorFromProfile } = require('../util/actor');
 const { AuthorizationError } = require('../util/errors');
 moment.tz.setDefault('UTC');
 
@@ -149,7 +148,9 @@ const getLfgPost = async (id, client = supabase) => {
 // repository (services/lfg/repository.js) is the only lfg consumer of the
 // service-role client. The compatibility functions below remain the
 // route-facing API; mutations take `actor` (built by the caller via
-// actorFromLocals/actorFromProfile, optionally extended with `timezone`).
+// actorFromLocals/buildAgentActor, optionally extended with `timezone`).
+// The agent surface always uses the role-stripped buildAgentActor (no
+// role-based bypass), consistent across all six agent capabilities.
 // Denials throw AuthorizationError.
 const lfgService = new LfgService(lfgRepository);
 
@@ -280,7 +281,7 @@ const getPostForAgent = async ({ agentProfileId, postId }) => {
 
 const createForAgent = async ({ agentProfile, body }) => {
   try {
-    const actor = { ...actorFromProfile(agentProfile), timezone: agentProfile.timezone };
+    const actor = { ...buildAgentActor(agentProfile.id), timezone: agentProfile.timezone };
     const { data, error } = await createLfgPost(actor, body);
     if (error) return { data: null, error };
     return getPostForAgent({ agentProfileId: agentProfile.id, postId: data.id });
@@ -291,7 +292,7 @@ const createForAgent = async ({ agentProfile, body }) => {
 
 const updateForAgent = async ({ agentProfile, postId, body }) => {
   try {
-    const actor = { ...actorFromProfile(agentProfile), timezone: agentProfile.timezone };
+    const actor = { ...buildAgentActor(agentProfile.id), timezone: agentProfile.timezone };
     const { data, error } = await updateLfgPost(actor, postId, body);
     if (error) return { data: null, error };
     return getPostForAgent({ agentProfileId: agentProfile.id, postId });

--- a/models/lfg.js
+++ b/models/lfg.js
@@ -1,7 +1,10 @@
-const { supabase, supabaseAdmin } = require('./_base');
+const { supabase } = require('./_base');
 const { statList } = require('../util/enclave-consts');
 const moment = require('moment-timezone');
 const { LfgService } = require('../services/lfg/service');
+const lfgRepository = require('../services/lfg/repository');
+const { actorFromProfile } = require('../util/actor');
+const { AuthorizationError } = require('../util/errors');
 moment.tz.setDefault('UTC');
 
 const fetchProfileById = async (profileId, client = supabase) => {
@@ -141,68 +144,41 @@ const getLfgPost = async (id, client = supabase) => {
   return { data: post, error };
 }
 
-// The service instance is constructed after the low-level helpers below. The
-// compatibility functions remain the route-facing API while write decisions
-// live in services/lfg.
-let lfgService;
-const createLfgPost = async (postReq, profile) => lfgService.createPost(postReq, profile);
-const updateLfgPost = async (id, postReq, profile) => lfgService.updatePost(id, postReq, profile);
+// The service instance owns every write decision (authorization, role
+// reconciliation, join-request moderation) independently of Supabase; the
+// repository (services/lfg/repository.js) is the only lfg consumer of the
+// service-role client. The compatibility functions below remain the
+// route-facing API; mutations take `actor` (built by the caller via
+// actorFromLocals/actorFromProfile, optionally extended with `timezone`).
+// Denials throw AuthorizationError.
+const lfgService = new LfgService(lfgRepository);
 
-const deleteLfgPost = async (id, profile) => {
-  const { data: post, error: postError } = await getLfgPost(id, supabaseAdmin);
-  if (postError || !post) return { data: null, error: postError || 'LFG post not found' };
-  if (post.creator_id !== profile.id) return { data: null, error: 'Unauthorized' };
-
-  // authz: creator_id check above + filter below
-  const { data, error } = await supabaseAdmin.from('lfg_posts').delete().eq('id', id).eq('creator_id', profile.id);
-  return { data, error };
-}
-
-const joinLfgPost = async (postId, profileId, joinType, characterId = null, client = supabase) => {
-  if (joinType == 'player' && !characterId) return { data: null, error: 'Character is required for player join' };
-  if (joinType == 'player') {
-    const { data: character, error: characterError } = await client.from('characters').select('*').eq('id', characterId).single();
-    if (characterError) return { data: null, error: characterError };
-    if (character.creator_id !== profileId) return { data: null, error: 'You can only join with your own character' };
-    if (character.is_deceased) return { data: null, error: 'Deceased characters cannot join games' };
+// Converts a thrown AuthorizationError (or any other thrown error) into the
+// same {status, code, message} shape the agent-scoped wrappers have always
+// returned, so agent routes/tests never observe an unhandled rejection.
+const toAgentError = (err) => {
+  if (err instanceof AuthorizationError) {
+    return { status: err.status, code: err.reason || 'forbidden', message: err.message };
   }
-  if (joinType == 'conduit') characterId = null;
-
-  if (joinType === 'conduit') {
-    const { data: approvedConduit } = await supabaseAdmin
-      .from('lfg_join_requests')
-      .select('id')
-      .eq('lfg_post_id', postId)
-      .eq('join_type', 'conduit')
-      .eq('status', 'approved')
-      .limit(1);
-    if (approvedConduit && approvedConduit.length > 0) {
-      return { data: null, error: 'Conduit slot is already filled' };
-    }
+  if (err && typeof err === 'object' && err.status) {
+    return { status: err.status, code: err.code, message: err.message };
   }
+  return { status: 500, code: 'internal_error', message: (err && err.message) || 'Unexpected error' };
+};
 
-  // Auto-approve when the joiner is the post's creator — they're picking a role for their own post.
-  const { data: postRow } = await supabaseAdmin
-    .from('lfg_posts')
-    .select('creator_id')
-    .eq('id', postId)
-    .maybeSingle();
-  const status = postRow?.creator_id === profileId ? 'approved' : 'pending';
+const buildAgentActor = (profileId) => ({ profileId, role: null });
 
-  const joinRequest = {
-    lfg_post_id: postId,
-    profile_id: profileId,
-    join_type: joinType,
-    character_id: characterId,
-    status
-  };
+const createLfgPost = async (actor, postReq) => lfgService.createPost(actor, postReq, { timezone: actor?.timezone });
+const updateLfgPost = async (actor, id, postReq) => lfgService.updatePost(actor, id, postReq, { timezone: actor?.timezone });
+const deleteLfgPost = async (actor, id) => lfgService.deletePost(actor, id);
 
-  // authz: profile_id comes from authenticated session; character ownership verified above for player joins.
-  const { data, error } = await supabaseAdmin.from('lfg_join_requests').insert(joinRequest).select();
-  if (error) return { data, error };
-  if (status === 'approved' && joinType === 'conduit') await syncConduitHostId(postId);
-  return { data, error };
-}
+// Preserves the exact positional signature relied on by routes/lfg.js (which
+// passes the caller's own RLS-scoped `client` for the character-ownership
+// read) and by models/lfg.test.js / models/lfg-agent.test.js. `profileId` is
+// intentionally a bare id here, not an actor object; internally this builds
+// the lightweight actor the policy layer needs.
+const joinLfgPost = async (postId, profileId, joinType, characterId = null, client = supabase) =>
+  lfgService.join(buildAgentActor(profileId), { postId, joinType, characterId, client });
 
 const getLfgJoinRequests = async (postId, client = supabase) => {
   const { data, error } = await client
@@ -230,74 +206,17 @@ const getLfgJoinRequestForUserAndPost = async (profileId, postId, client = supab
 // host_id is treated as a denormalized cache of "who is the approved conduit", needed by
 // RLS policies (schema.sql) and by the character-view helper (routes/characters.js).
 // All conduit state changes go through lfg_join_requests; this helper mirrors the result.
-const syncConduitHostId = async (postId) => {
-  const { data: approved } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('profile_id')
-    .eq('lfg_post_id', postId)
-    .eq('join_type', 'conduit')
-    .eq('status', 'approved')
-    .maybeSingle();
-  const newHostId = approved?.profile_id || null;
-  const { error } = await supabaseAdmin
-    .from('lfg_posts')
-    .update({ host_id: newHostId })
-    .eq('id', postId);
-  return { error };
-};
+// Internal denormalization only — no policy check applies (see LfgService.syncConduitHostId).
+const syncConduitHostId = (postId) => lfgService.syncConduitHostId(postId);
 
-const updateJoinRequest = async (requestId, status, postId = null) => {
-  // authz: caller scopes by postId when mutating cross-user requests;
-  // internal callers (createLfgPost/updateLfgPost auto-approve) pass null because they just inserted the request.
-  let query = supabaseAdmin
-    .from('lfg_join_requests')
-    .update({ status })
-    .eq('id', requestId);
-  if (postId) query = query.eq('lfg_post_id', postId);
-  const { data, error } = await query;
-  if (error) return { data, error };
+// Approve/reject a join request. Previously caller-enforced (routes/models
+// checked host-ness before calling); the capability now verifies it itself.
+const updateJoinRequest = async (actor, requestId, status, postId = null) =>
+  lfgService.updateJoinRequest(actor, { requestId, status, postId });
 
-  let resolvedPostId = postId;
-  if (!resolvedPostId) {
-    const { data: row } = await supabaseAdmin
-      .from('lfg_join_requests')
-      .select('lfg_post_id')
-      .eq('id', requestId)
-      .maybeSingle();
-    resolvedPostId = row?.lfg_post_id;
-  }
-  if (resolvedPostId) await syncConduitHostId(resolvedPostId);
-  return { data, error };
-}
-
-const deleteJoinRequest = async (requestId) => {
-  // authz: caller (routes/lfg.js DELETE /:id/join) scopes requestId to the authenticated profile;
-  // also called internally by createLfgPost/updateLfgPost (creator-gated) to clear prior requests.
-  const { data: existing } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('lfg_post_id')
-    .eq('id', requestId)
-    .maybeSingle();
-  const { data, error } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .delete()
-    .eq('id', requestId);
-  if (!error && existing?.lfg_post_id) await syncConduitHostId(existing.lfg_post_id);
-  return { data, error };
-}
-
-// Initial Supabase adapter for the LFG service. Keeping this thin makes the
-// service independently testable and leaves existing model exports intact.
-lfgService = new LfgService({
-  getPost: id => getLfgPost(id, supabaseAdmin),
-  createPost: data => supabaseAdmin.from('lfg_posts').insert(data).select(),
-  updatePost: (id, creatorId, data) => supabaseAdmin
-    .from('lfg_posts').update(data).eq('id', id).eq('creator_id', creatorId).select(),
-  getCreatorRequest: (profileId, postId) => getLfgJoinRequestForUserAndPost(profileId, postId, supabaseAdmin),
-  deleteJoinRequest,
-  joinPost: (postId, profileId, joinType, characterId) =>
-    joinLfgPost(postId, profileId, joinType, characterId, supabaseAdmin)
-});
+// Withdraw/remove a join request (self-leave, or host moderation). Previously
+// caller-enforced; the capability now verifies ownership/moderation itself.
+const deleteJoinRequest = async (actor, requestId) => lfgService.leave(actor, requestId);
 
 const getLfgJoinedPosts = async (profileId, client = supabase) => {
   const { data, error } = await client
@@ -326,6 +245,7 @@ const getLfgJoinedPosts = async (profileId, client = supabase) => {
   return { data: joinedPosts, error: null };
 }
 
+// Not admin: called by util/auth.js with the request's own RLS client.
 const getPendingJoinRequestCount = async (profileId, client = supabase) => {
   const { count, error } = await client
     .from('lfg_join_requests')
@@ -336,347 +256,100 @@ const getPendingJoinRequestCount = async (profileId, client = supabase) => {
 }
 
 // ─── Agent-scoped LFG wrappers ────────────────────────────────────────────────
-
-const closeLfgPost = async (id, profile) => {
-  // I1: Distinguish not-found vs not-host by probing existence first.
-  const { data: existing, error: fetchErr } = await supabaseAdmin
-    .from('lfg_posts')
-    .select('id, creator_id')
-    .eq('id', id)
-    .maybeSingle();
-  if (fetchErr) return { data: null, error: fetchErr };
-  if (!existing) return { data: null, error: { status: 404, code: 'not_found', message: 'Post not found' } };
-  if (existing.creator_id !== profile.id) {
-    return { data: null, error: { status: 403, code: 'not_host', message: 'Only the host can close this post' } };
-  }
-  const { data, error } = await supabaseAdmin
-    .from('lfg_posts')
-    .update({ status: 'closed', updated_at: new Date().toISOString() })
-    .eq('id', id)
-    .eq('creator_id', profile.id)
-    .select()
-    .maybeSingle();
-  if (error) return { data: null, error };
-  if (!data) return { data: null, error: { status: 403, code: 'not_host', message: 'Only the host can close this post' } };
-  return { data, error: null };
-};
-
-const serializePostForAgent = (post, { agentProfileId, includePending }) => {
-  const host = post.creator || post.host || {};
-  const roster = (post.join_requests || [])
-    .filter((r) => r.status === 'approved' && r.join_type === 'player')
-    .map((r) => ({
-      character_id: r.character_id,
-      name: r.character?.name || null,
-      class_name: r.character?.class || null,
-      level: r.character?.level || null,
-      profile_id: r.profile_id,
-      profile_display_name: r.profile?.name || null
-    }));
-  const conduit = (post.join_requests || []).find(
-    (r) => r.status === 'approved' && r.join_type === 'conduit'
-  );
-  const myRequest = (post.join_requests || []).find(
-    (r) => r.profile_id === agentProfileId && r.status !== 'rejected'
-  );
-  const base = {
-    id: post.id,
-    title: post.title,
-    description: post.description,
-    date: post.date,
-    host: { id: host.id, display_name: host.name },
-    max_characters: post.max_characters,
-    is_public: post.is_public,
-    status: post.status,
-    player_count: roster.length,
-    has_conduit: !!conduit,
-    roster,
-    conduit: conduit
-      ? { profile_id: conduit.profile_id, display_name: conduit.profile?.name || null }
-      : null,
-    my_request: myRequest
-      ? { id: myRequest.id, join_type: myRequest.join_type, status: myRequest.status }
-      : null
-  };
-  if (includePending && host.id === agentProfileId) {
-    base.pending_requests = (post.join_requests || [])
-      .filter((r) => r.status === 'pending')
-      .map((r) => ({
-        id: r.id,
-        profile_id: r.profile_id,
-        profile_display_name: r.profile?.name || null,
-        join_type: r.join_type,
-        character: r.character
-          ? { id: r.character.id, name: r.character.name, class_name: r.character.class, level: r.character.level }
-          : null
-      }));
-  }
-  return base;
-};
-
-// I3: Shared helper to rename lfg_join_requests -> join_requests on result rows.
-const normalizeJoinRequests = (rows) => {
-  for (const row of rows) {
-    row.join_requests = row.lfg_join_requests || [];
-    delete row.lfg_join_requests;
-  }
-  return rows;
-};
-
-// Internal: fetch lfg_posts with full joins, filtered by arbitrary column equality + optional status
-const AGENT_POST_SELECT = '*, creator:creator_id(id,name), lfg_join_requests(*, profile:profile_id(id,name), character:character_id(*))';
-
-const getPostsWithRequestsBy = async (filters, { status, dateFrom } = {}) => {
-  let query = supabaseAdmin
-    .from('lfg_posts')
-    .select(AGENT_POST_SELECT);
-  for (const [key, value] of Object.entries(filters)) {
-    query = query.eq(key, value);
-  }
-  if (status && status !== 'all') {
-    query = query.eq('status', status);
-  }
-  if (dateFrom) {
-    query = query.gte('date', dateFrom);
-  }
-  const { data, error } = await query;
-  if (data) normalizeJoinRequests(data);
-  return { data, error };
-};
-
-// Internal: fetch lfg_posts where the given profile has a non-rejected join request
-const getPostsByJoiner = async (profileId, { status } = {}) => {
-  const { data: requests, error: reqError } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('lfg_post_id')
-    .eq('profile_id', profileId)
-    .neq('status', 'rejected');
-  if (reqError) return { data: null, error: reqError };
-  const ids = (requests || []).map((r) => r.lfg_post_id);
-  if (ids.length === 0) return { data: [], error: null };
-
-  let query = supabaseAdmin
-    .from('lfg_posts')
-    .select(AGENT_POST_SELECT)
-    .in('id', ids);
-  if (status && status !== 'all') {
-    query = query.eq('status', status);
-  }
-  const { data, error } = await query;
-  if (data) normalizeJoinRequests(data);
-  return { data, error };
-};
+// Every wrapper here keeps its historical {data, error} contract (never
+// throws): the underlying service capabilities may throw AuthorizationError
+// on a policy denial, so each wrapper catches and translates via
+// toAgentError, preserving the exact status/code combinations the agent
+// routes and models/lfg-agent.test.js depend on.
 
 const listPostsForAgent = async ({ agentProfileId, scope = 'public', status = 'open' }) => {
-  let rows;
-  let error;
-  if (scope === 'mine') {
-    ({ data: rows, error } = await getPostsWithRequestsBy(
-      { creator_id: agentProfileId },
-      { status }
-    ));
-  } else if (scope === 'joined') {
-    ({ data: rows, error } = await getPostsByJoiner(agentProfileId, { status }));
-  } else {
-    const cutoff = new Date();
-    cutoff.setUTCHours(0, 0, 0, 0);
-    cutoff.setUTCDate(cutoff.getUTCDate() - 14);
-    ({ data: rows, error } = await getPostsWithRequestsBy(
-      { is_public: true },
-      { status, dateFrom: cutoff.toISOString() }
-    ));
+  try {
+    return await lfgService.listForAgent(buildAgentActor(agentProfileId), { scope, status });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
   }
-  if (error) return { data: null, error };
-  const projected = (rows || []).map((p) => {
-    const full = serializePostForAgent(p, { agentProfileId, includePending: false });
-    return {
-      id: full.id,
-      title: full.title,
-      date: full.date,
-      host: full.host,
-      max_characters: full.max_characters,
-      is_public: full.is_public,
-      status: full.status,
-      player_count: full.player_count,
-      has_conduit: full.has_conduit,
-      my_request_status: full.my_request?.status || null
-    };
-  });
-  return { data: projected, error: null };
 };
 
 const getPostForAgent = async ({ agentProfileId, postId }) => {
-  const { data: raw, error } = await supabaseAdmin
-    .from('lfg_posts')
-    .select(AGENT_POST_SELECT)
-    .eq('id', postId)
-    .maybeSingle();
-  if (error) return { data: null, error };
-  if (!raw) return { data: null, error: { status: 404, code: 'not_found', message: 'Post not found' } };
-  // Normalize lfg_join_requests -> join_requests
-  raw.join_requests = raw.lfg_join_requests || [];
-  delete raw.lfg_join_requests;
-  return {
-    data: serializePostForAgent(raw, { agentProfileId, includePending: true }),
-    error: null
-  };
+  try {
+    return await lfgService.getForAgent(buildAgentActor(agentProfileId), { postId });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
+  }
 };
 
 const createForAgent = async ({ agentProfile, body }) => {
-  const { data, error } = await createLfgPost(body, agentProfile);
-  if (error) return { data: null, error };
-  return getPostForAgent({ agentProfileId: agentProfile.id, postId: data.id });
+  try {
+    const actor = { ...actorFromProfile(agentProfile), timezone: agentProfile.timezone };
+    const { data, error } = await createLfgPost(actor, body);
+    if (error) return { data: null, error };
+    return getPostForAgent({ agentProfileId: agentProfile.id, postId: data.id });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
+  }
 };
 
 const updateForAgent = async ({ agentProfile, postId, body }) => {
-  const { data, error } = await updateLfgPost(postId, body, agentProfile);
-  if (error) {
-    // C2: updateLfgPost returns string errors, not Supabase objects.
-    const msg = typeof error === 'string' ? error : (error.message || '');
-    if (/not found/i.test(msg)) {
-      return { data: null, error: { status: 404, code: 'not_found', message: 'Post not found' } };
-    }
-    if (/unauthori[sz]ed/i.test(msg)) {
-      return { data: null, error: { status: 403, code: 'not_host', message: 'Only the host can edit this post' } };
-    }
-    return { data: null, error: { status: 500, code: 'update_failed', message: msg || 'Update failed' } };
+  try {
+    const actor = { ...actorFromProfile(agentProfile), timezone: agentProfile.timezone };
+    const { data, error } = await updateLfgPost(actor, postId, body);
+    if (error) return { data: null, error };
+    return getPostForAgent({ agentProfileId: agentProfile.id, postId });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
   }
-  return getPostForAgent({ agentProfileId: agentProfile.id, postId });
 };
 
 const closeForAgent = async ({ agentProfileId, postId }) => {
-  const profile = { id: agentProfileId };
-  const { data, error } = await closeLfgPost(postId, profile);
-  if (error) return { data: null, error };
-  return getPostForAgent({ agentProfileId, postId: data.id });
+  try {
+    const { data, error } = await lfgService.closePost(buildAgentActor(agentProfileId), postId);
+    if (error) return { data: null, error };
+    return getPostForAgent({ agentProfileId, postId: data.id });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
+  }
 };
 
 const deleteForAgent = async ({ agentProfile, postId }) => {
-  const { error } = await deleteLfgPost(postId, agentProfile);
-  if (error) {
-    // C2: deleteLfgPost returns string errors, not Supabase objects.
-    const msg = typeof error === 'string' ? error : (error.message || '');
-    if (/not found/i.test(msg)) {
-      return { data: null, error: { status: 404, code: 'not_found', message: 'Post not found' } };
-    }
-    if (/unauthori[sz]ed/i.test(msg)) {
-      return { data: null, error: { status: 403, code: 'not_host', message: 'Only the host can delete this post' } };
-    }
-    return { data: null, error: { status: 500, code: 'delete_failed', message: msg || 'Delete failed' } };
+  try {
+    const { error } = await lfgService.deletePost(buildAgentActor(agentProfile.id), postId);
+    if (error) return { data: null, error };
+    return { data: { deleted: true }, error: null };
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
   }
-  return { data: { deleted: true }, error: null };
 };
 
 const joinForAgent = async ({ agentProfileId, postId, joinType, characterId }) => {
-  if (joinType === 'player') {
-    if (!characterId) {
-      return { data: null, error: { status: 400, code: 'character_required', message: 'Player joins require a character' } };
-    }
-    const { data: character, error: charErr } = await supabaseAdmin
-      .from('characters')
-      .select('id, creator_id, is_deceased')
-      .eq('id', characterId)
-      .maybeSingle();
-    if (charErr) return { data: null, error: charErr };
-    if (!character || character.creator_id !== agentProfileId || character.is_deceased) {
-      return { data: null, error: { status: 400, code: 'character_ineligible', message: 'Character is deceased or not yours' } };
-    }
+  try {
+    return await lfgService.joinForAgent(buildAgentActor(agentProfileId), { postId, joinType, characterId });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
   }
-
-  const { data: existing, error: existingErr } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('id, status')
-    .eq('lfg_post_id', postId)
-    .eq('profile_id', agentProfileId)
-    .maybeSingle();
-  if (existingErr) return { data: null, error: existingErr };
-  if (existing && existing.status !== 'rejected') {
-    return { data: null, error: { status: 409, code: 'duplicate_request', message: 'You already have a request on this post' } };
-  }
-
-  if (joinType === 'conduit') {
-    const { data: conduitRequests, error: conduitErr } = await supabaseAdmin
-      .from('lfg_join_requests')
-      .select('id')
-      .eq('lfg_post_id', postId)
-      .eq('status', 'approved')
-      .eq('join_type', 'conduit')
-      .limit(1);
-    if (conduitErr) return { data: null, error: conduitErr };
-    if (conduitRequests && conduitRequests.length > 0) {
-      return { data: null, error: { status: 409, code: 'conduit_taken', message: 'Conduit slot is already filled' } };
-    }
-  }
-
-  const { data: request, error } = await joinLfgPost(postId, agentProfileId, joinType, characterId || null);
-  if (error) return { data: null, error };
-  const { data: post } = await getPostForAgent({ agentProfileId, postId });
-  return { data: { request, post }, error: null };
 };
 
 const leaveForAgent = async ({ agentProfileId, postId }) => {
-  const { data: existing, error: probeErr } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('id, status')
-    .eq('lfg_post_id', postId)
-    .eq('profile_id', agentProfileId)
-    .maybeSingle();
-  if (probeErr) return { data: null, error: probeErr };
-  if (!existing) {
-    // I2: propagate errors from getPostForAgent
-    const { data: post, error: postErr } = await getPostForAgent({ agentProfileId, postId });
-    if (postErr) return { data: null, error: postErr };
-    return { data: { deleted: false, post }, error: null };
+  try {
+    return await lfgService.leaveForAgent(buildAgentActor(agentProfileId), { postId });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
   }
-  const { error } = await deleteJoinRequest(existing.id);
-  if (error) return { data: null, error };
-  // I2: propagate errors from getPostForAgent
-  const { data: post, error: postErr } = await getPostForAgent({ agentProfileId, postId });
-  if (postErr) return { data: null, error: postErr };
-  return { data: { deleted: true, post }, error: null };
 };
 
 const updateRequestForAgent = async ({ agentProfileId, requestId, status }) => {
-  if (status !== 'approved' && status !== 'rejected') {
-    return { data: null, error: { status: 400, code: 'invalid_status', message: 'status must be approved or rejected' } };
+  try {
+    return await lfgService.updateRequestForAgent(buildAgentActor(agentProfileId), { requestId, status });
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
   }
-  const { data: req, error: probeErr } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('id, lfg_post_id, post:lfg_post_id(creator_id)')
-    .eq('id', requestId)
-    .maybeSingle();
-  if (probeErr) return { data: null, error: probeErr };
-  if (!req) return { data: null, error: { status: 404, code: 'not_found', message: 'Request not found' } };
-  if (req.post?.creator_id !== agentProfileId) {
-    return { data: null, error: { status: 403, code: 'not_host', message: 'Only the host can update requests on this post' } };
-  }
-  // C1: updateJoinRequest does not .select(), so data is always null on success.
-  // Re-fetch the updated request row directly instead of relying on the update return value.
-  const { error: updateErr } = await updateJoinRequest(requestId, status, req.lfg_post_id);
-  if (updateErr) return { data: null, error: updateErr };
-  const { data: updatedRequest, error: fetchErr } = await supabaseAdmin
-    .from('lfg_join_requests')
-    .select('id, lfg_post_id, profile_id, character_id, join_type, status')
-    .eq('id', requestId)
-    .single();
-  if (fetchErr) return { data: null, error: fetchErr };
-  const { data: post, error: postErr } = await getPostForAgent({ agentProfileId, postId: req.lfg_post_id });
-  if (postErr) return { data: null, error: postErr };
-  return { data: { request: updatedRequest, post }, error: null };
 };
 
 const listEligibleCharactersForAgent = async ({ agentProfileId }) => {
-  const { data, error } = await supabaseAdmin
-    .from('characters')
-    .select('id, name, class, level')
-    .eq('creator_id', agentProfileId)
-    .eq('is_deceased', false)
-    .order('name', { ascending: true });
-  if (error) return { data: null, error };
-  return {
-    data: (data || []).map((c) => ({ id: c.id, name: c.name, class_name: c.class, level: c.level })),
-    error: null
-  };
+  try {
+    return await lfgService.listEligibleCharactersForAgent(buildAgentActor(agentProfileId));
+  } catch (err) {
+    return { data: null, error: toAgentError(err) };
+  }
 };
 
 module.exports = {

--- a/models/lfg.test.js
+++ b/models/lfg.test.js
@@ -166,3 +166,36 @@ test('joinLfgPost uses the passed client to read the character', async () => {
   // read failing.
   expect(error).toBeFalsy();
 });
+
+// ─── agent actor construction consistency (no admin bypass on the agent surface) ───
+
+test('updateForAgent does not grant an admin-role bypass: an admin-role agent profile acting on another profile\'s post is blocked, same as delete/close', async () => {
+  mock.module('./_base', () => ({
+    supabase: defaultAnon,
+    supabaseAdmin: makeSpyClient({ lfg_posts: [{ id: 'post-1', creator_id: 'host-1' }] }),
+    anonKey: 'x',
+    createUserClient: () => defaultAnon
+  }));
+  delete require.cache[require.resolve('./lfg')];
+  delete require.cache[require.resolve('../services/lfg/repository')];
+  const { updateForAgent } = require('./lfg');
+
+  const { data, error } = await updateForAgent({
+    agentProfile: { id: 'admin-1', role: 'admin', timezone: 'UTC' },
+    postId: 'post-1',
+    body: { title: 'Hijacked title' }
+  });
+  expect(data).toBeNull();
+  expect(error.status).toBe(403);
+  expect(error.code).toBe('not_host');
+
+  // Restore the original module mock for subsequent tests.
+  mock.module('./_base', () => ({
+    supabase: defaultAnon,
+    supabaseAdmin: makeSpyClient(),
+    anonKey: 'x',
+    createUserClient: () => defaultAnon
+  }));
+  delete require.cache[require.resolve('./lfg')];
+  delete require.cache[require.resolve('../services/lfg/repository')];
+});

--- a/models/mission-badges.test.js
+++ b/models/mission-badges.test.js
@@ -90,15 +90,18 @@ beforeEach(() => {
   state.tables = {};
 });
 
-const PROFILE = { id: 'p-creator' };
+// Actor shape consumed by the service layer (see util/actor.js). p-creator
+// is used throughout so the authorization gate (creator/host/editor/admin/
+// system) added in the ar-ezes mission refactor passes for these mutations.
+const ACTOR = { profileId: 'p-creator', role: 'user' };
 
 test('createMission recalcs the host', async () => {
-  await mission.createMission({ name: 'M', date: '2026-06-06', host_id: 'p-host' }, PROFILE);
+  await mission.createMission(ACTOR, { name: 'M', date: '2026-06-06', host_id: 'p-host' });
   expect(recalcCalls).toEqual([['p-host']]);
 });
 
 test('createMission without a host does not recalc', async () => {
-  await mission.createMission({ name: 'M', date: '2026-06-06' }, PROFILE);
+  await mission.createMission(ACTOR, { name: 'M', date: '2026-06-06' });
   expect(recalcCalls).toEqual([]);
 });
 
@@ -106,26 +109,33 @@ test('updateMission recalcs old and new host', async () => {
   state.tables = {
     missions: [{ id: 'm1', creator_id: 'p-creator', host_id: 'p-old-host' }]
   };
-  await mission.updateMission('m1', { host_id: 'p-new-host' }, PROFILE);
+  await mission.updateMission(ACTOR, 'm1', { host_id: 'p-new-host' });
   expect(recalcCalls).toEqual([['p-old-host', 'p-new-host']]);
 });
 
 test('deleteMission recalcs profiles captured before the delete', async () => {
   missionProfileIds = { m1: ['p-host', 'p-a'] };
   state.tables = { missions: [{ id: 'm1', creator_id: 'p-creator' }] };
-  await mission.deleteMission('m1', PROFILE);
+  await mission.deleteMission(ACTOR, 'm1');
   expect(recalcCalls).toEqual([['p-host', 'p-a']]);
 });
 
 test("addCharacterToMission recalcs the character's creator", async () => {
-  state.tables = { characters: [{ id: 'c1', creator_id: 'p-owner' }] };
-  await mission.addCharacterToMission('m1', 'c1');
+  state.tables = {
+    // canEditMission (now enforced by the service) must find the mission.
+    missions: [{ id: 'm1', creator_id: 'p-creator', host_id: null }],
+    characters: [{ id: 'c1', creator_id: 'p-owner' }]
+  };
+  await mission.addCharacterToMission(ACTOR, 'm1', 'c1');
   expect(recalcCalls).toEqual([['p-owner']]);
 });
 
 test("removeCharacterFromMission recalcs the character's creator", async () => {
-  state.tables = { characters: [{ id: 'c1', creator_id: 'p-owner' }] };
-  await mission.removeCharacterFromMission('m1', 'c1');
+  state.tables = {
+    missions: [{ id: 'm1', creator_id: 'p-creator', host_id: null }],
+    characters: [{ id: 'c1', creator_id: 'p-owner' }]
+  };
+  await mission.removeCharacterFromMission(ACTOR, 'm1', 'c1');
   expect(recalcCalls).toEqual([['p-owner']]);
 });
 
@@ -139,6 +149,6 @@ test('mergeMissions recalcs profiles from both missions captured before the merg
     ],
     mission_editors: []
   };
-  await mission.mergeMissions('m-primary', 'm-secondary', PROFILE);
+  await mission.mergeMissions(ACTOR, 'm-primary', 'm-secondary');
   expect(recalcCalls).toEqual([['p-a', 'p-b', 'p-b', 'p-c']]); // recalcSafely dedupes internally
 });

--- a/models/mission.js
+++ b/models/mission.js
@@ -1,7 +1,9 @@
-const { supabase, supabaseAdmin } = require('./_base');
+const { supabase } = require('./_base');
 const { escapeLikePattern } = require('../util/validate');
 const { recalcMilestoneBadgesSafely, getMissionProfileIds } = require('./badge');
 const { MissionService } = require('../services/mission/service');
+const missionRepository = require('../services/mission/repository');
+const { actorFromProfile } = require('../util/actor');
 
 const getMissions = async () => {
   const { data, error } = await supabase
@@ -97,13 +99,17 @@ const getOwnMissions = async (profile, client = supabase) => {
 }
 
 // Compatibility functions are deliberately kept at the model boundary for
-// routes and imports; their write decisions live in services/mission.
+// routes and imports; their write decisions and authorization live in
+// services/mission. Mutations take `actor` (built by the caller via
+// actorFromLocals/actorFromProfile/SYSTEM_ACTOR); denials throw AuthorizationError.
 let missionService;
-const createMission = async (missionData, profile) => missionService.createMission(missionData, profile);
-const updateMission = async (id, missionData, profile) => missionService.updateMission(id, missionData, profile);
-const deleteMission = async (id, profile) => missionService.deleteMission(id, profile);
-const addCharacterToMission = async (missionId, characterId) => missionService.addCharacter(missionId, characterId);
-const removeCharacterFromMission = async (missionId, characterId) => missionService.removeCharacter(missionId, characterId);
+const createMission = async (actor, missionData) => missionService.createMission(actor, missionData);
+const updateMission = async (actor, id, missionData) => missionService.updateMission(actor, id, missionData);
+const deleteMission = async (actor, id) => missionService.deleteMission(actor, id);
+const addCharacterToMission = async (actor, missionId, characterId) =>
+  missionService.addCharacter(actor, { missionId, characterId });
+const removeCharacterFromMission = async (actor, missionId, characterId) =>
+  missionService.removeCharacter(actor, { missionId, characterId });
 
 const getMissionCharacters = async (missionId, client = supabase) => {
   const { data, error } = await client
@@ -113,26 +119,8 @@ const getMissionCharacters = async (missionId, client = supabase) => {
   return { data, error };
 }
 
-const setUnregisteredCharacterNames = async (missionId, names, profile) => {
-  // Check if profile can edit this mission (creator, host, or editor)
-  const canEdit = await canEditMission(missionId, profile);
-  if (!canEdit) {
-    return { data: null, error: 'Unauthorized: You do not have permission to edit this mission' };
-  }
-
-  // Filter and clean names
-  const cleanedNames = (Array.isArray(names) ? names : [])
-    .map(n => (typeof n === 'string' ? n.trim() : ''))
-    .filter(n => n.length > 0);
-  
-  const { data, error } = await supabaseAdmin
-    .from('missions')
-    .update({ unregistered_character_names: cleanedNames })
-    .eq('id', missionId)
-    .select();
-  
-  return { data, error };
-}
+const setUnregisteredCharacterNames = async (actor, missionId, names) =>
+  missionService.setUnregisteredNames(actor, missionId, names);
 
 const searchPublicMissions = async (q, count = 12, hasVideo = false, characterName = null, characterClass = null, conduitName = null) => {
   try {
@@ -400,96 +388,37 @@ const getMissionEditors = async (missionId, client = supabase) => {
 };
 
 /**
- * Add an editor to a mission
+ * Add an editor to a mission. Only the mission creator (or admin/system)
+ * may add editors; addedBy is derived from the actor.
  */
-const addMissionEditor = async (missionId, profileId, addedBy) => {
-  const { data, error } = await supabaseAdmin
-    .from('mission_editors')
-    .upsert({
-      mission_id: missionId,
-      profile_id: profileId,
-      added_by: addedBy
-    })
-    .select();
-  return { data, error };
-};
+const addMissionEditor = async (actor, missionId, profileId) =>
+  missionService.addEditor(actor, { missionId, profileId });
 
 /**
- * Remove an editor from a mission
+ * Remove an editor from a mission. Only the mission creator (or admin/system)
+ * may remove editors.
  */
-const removeMissionEditor = async (missionId, profileId) => {
-  const { data, error } = await supabaseAdmin
-    .from('mission_editors')
-    .delete()
-    .eq('mission_id', missionId)
-    .eq('profile_id', profileId);
-  return { data, error };
-};
+const removeMissionEditor = async (actor, missionId, profileId) =>
+  missionService.removeEditor(actor, { missionId, profileId });
 
 /**
- * Check if a profile can edit a mission
- * Returns true if profile is creator, host, or an editor
- *
- * Uses supabaseAdmin to bypass RLS — this is a permission check in
- * application code, not a data-visibility read. Without admin, the
- * anon client (no JWT) would fail-closed for private missions and
- * lock creators out of their own mission edit pages.
+ * Check if a profile can edit a mission.
+ * Returns true if profile is creator, host, or an editor (or admin/system).
+ * Signature preserved for existing (read/render) callers; the decision is
+ * now made by the service against repository-loaded rows.
  */
 const canEditMission = async (missionId, profile) => {
   if (!profile || !profile.id) return false;
-
-  // First check if user is creator or host
-  const { data: mission, error: missionError } = await supabaseAdmin
-    .from('missions')
-    .select('creator_id, host_id')
-    .eq('id', missionId)
-    .single();
-
-  if (missionError || !mission) {
-    console.error('Error checking mission permissions:', missionError);
-    return false;
-  }
-
-  // Check if user is creator or host
-  if (mission.creator_id === profile.id || (mission.host_id && mission.host_id === profile.id)) {
-    return true;
-  }
-
-  // Check if user is an editor
-  const { data: editor, error: editorError } = await supabaseAdmin
-    .from('mission_editors')
-    .select('profile_id')
-    .eq('mission_id', missionId)
-    .eq('profile_id', profile.id)
-    .single();
-
-  if (editorError && editorError.code !== 'PGRST116') {
-    // PGRST116 is "not found" which is fine - means user is not an editor
-    // Other errors are logged but don't necessarily mean no access
-    if (editorError.code !== 'PGRST116') {
-      console.error('Error checking editor permissions:', editorError);
-    }
-    return false;
-  }
-
-  return !!editor;
+  return missionService.canEditMission(actorFromProfile(profile), missionId);
 };
 
 /**
- * Check if a profile is the creator of a mission.
- * Uses supabaseAdmin for the same reason as canEditMission.
+ * Check if a profile is the creator of a mission (or admin/system).
+ * Signature preserved for existing callers.
  */
 const isCreator = async (missionId, profile) => {
   if (!profile || !profile.id) return false;
-
-  const { data: mission, error } = await supabaseAdmin
-    .from('missions')
-    .select('creator_id')
-    .eq('id', missionId)
-    .single();
-
-  if (error || !mission) return false;
-  return mission.creator_id === profile.id;
+  return missionService.isCreator(actorFromProfile(profile), missionId);
 };
 
 /**
@@ -641,8 +570,8 @@ const searchSimilarMissions = async (date, name, excludeId = null, daysRange = 3
  * - Adds editors from secondary to primary
  * - Deletes secondary mission
  */
-const mergeMissions = async (primaryId, secondaryId, profile) =>
-  missionService.mergeMissions(primaryId, secondaryId, profile);
+const mergeMissions = async (actor, primaryId, secondaryId) =>
+  missionService.mergeMissions(actor, primaryId, secondaryId);
 
 /**
  * Preview what a merge would look like without actually performing it
@@ -702,26 +631,13 @@ const previewMergeMissions = async (primaryId, secondaryId) => {
   }
 };
 
-// Initial Supabase adapter. It intentionally contains only persistence and
-// lookup details; authorization, input handling, sequencing, and badge
-// decisions are testable in MissionService.
+// Repository holds every privileged (service-role) mission query; this
+// object layers in the badge/read dependencies the service also needs.
+// Authorization, input handling, sequencing, and badge decisions are
+// testable in MissionService.
 missionService = new MissionService({
-  canEdit: canEditMission,
-  getHost: id => supabaseAdmin.from('missions').select('host_id').eq('id', id).maybeSingle(),
-  createMissionRow: data => supabaseAdmin.from('missions').insert(data).select(),
-  updateMissionRow: (id, data) => supabaseAdmin.from('missions').update(data).eq('id', id).select(),
-  deleteMissionRow: (id, creatorId) => supabaseAdmin
-    .from('missions').delete().eq('id', id).eq('creator_id', creatorId),
+  ...missionRepository,
   getMissionProfileIds,
-  getCharacterCreator: id => supabaseAdmin
-    .from('characters').select('creator_id').eq('id', id).maybeSingle(),
-  upsertMissionCharacter: (missionId, characterId) => supabaseAdmin
-    .from('mission_characters').upsert({ mission_id: missionId, character_id: characterId }).select(),
-  deleteMissionCharacter: (missionId, characterId) => supabaseAdmin
-    .from('mission_characters').delete().eq('mission_id', missionId).eq('character_id', characterId),
-  mergeMissions: (primaryId, secondaryId, actorId) => supabaseAdmin.rpc('merge_missions', {
-    primary_id: primaryId, secondary_id: secondaryId, actor_profile_id: actorId
-  }),
   getMission,
   recalcBadges: recalcMilestoneBadgesSafely
 });

--- a/models/pdf.js
+++ b/models/pdf.js
@@ -1,5 +1,5 @@
-const { supabaseAdmin } = require('./_base');
 const path = require('path');
+const pdfRepository = require('../services/pdf/repository');
 
 const CLASS_PDF_BUCKET = process.env.SUPABASE_CLASS_PDF_BUCKET || 'class-pdfs';
 const RULES_PDF_BUCKET = process.env.SUPABASE_RULES_PDF_BUCKET || 'rules-pdfs';
@@ -30,13 +30,11 @@ const uploadToBucket = async (bucket, storagePath, file, { cacheControl = '3600'
   if (!looksLikePdf(file.buffer)) {
     return { data: null, error: new Error('Uploaded file is not a valid PDF') };
   }
-  const { error } = await supabaseAdmin.storage
-    .from(bucket)
-    .upload(storagePath, file.buffer, {
-      contentType: 'application/pdf',
-      cacheControl,
-      upsert: true
-    });
+  const { error } = await pdfRepository.uploadObject(bucket, storagePath, file.buffer, {
+    contentType: 'application/pdf',
+    cacheControl,
+    upsert: true
+  });
   if (error) {
     return { data: null, error };
   }
@@ -46,7 +44,7 @@ const uploadToBucket = async (bucket, storagePath, file, { cacheControl = '3600'
 const removeIfExists = async (bucket, storagePath) => {
   if (!storagePath) return;
   try {
-    await supabaseAdmin.storage.from(bucket).remove([storagePath]);
+    await pdfRepository.removeObject(bucket, storagePath);
   } catch (error) {
     // noop – deletion failures should not block upload flows
     console.error('Failed to remove storage object', bucket, storagePath, error.message);
@@ -90,9 +88,7 @@ const getSignedPdfUrl = async ({ bucket, path: storagePath, expiresIn } = {}) =>
     return { data: null, error: new Error('Missing bucket or storage path') };
   }
   const ttl = Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : DEFAULT_SIGNED_URL_TTL;
-  const { data, error } = await supabaseAdmin.storage
-    .from(bucket)
-    .createSignedUrl(storagePath, ttl);
+  const { data, error } = await pdfRepository.createSignedUrl(bucket, storagePath, ttl);
   if (error) {
     return { data: null, error };
   }
@@ -103,7 +99,7 @@ const deletePdfObject = async ({ bucket, path: storagePath } = {}) => {
   if (!bucket || !storagePath) {
     return { error: new Error('Missing bucket or storage path') };
   }
-  const { error } = await supabaseAdmin.storage.from(bucket).remove([storagePath]);
+  const { error } = await pdfRepository.removeObject(bucket, storagePath);
   if (error) {
     console.error('Failed to delete PDF from storage', bucket, storagePath, error.message);
     return { error };

--- a/models/profile.js
+++ b/models/profile.js
@@ -1,6 +1,8 @@
-const { supabase, supabaseAdmin } = require('./_base');
-const { sanitizeUrlFields } = require('../util/url');
+const { supabase } = require('./_base');
 const { escapeLikePattern } = require('../util/validate');
+const { SYSTEM_ACTOR } = require('../util/actor');
+const { ProfileService } = require('../services/profile/service');
+const profileRepository = require('../services/profile/repository');
 
 const PROFILE_NOT_FOUND_ERROR = 'PGRST116';
 
@@ -16,18 +18,20 @@ const STARTER_CLASS_IDS = [
 ];
 const STARTER_UNLOCK_DAYS = 30;
 
+const profileService = new ProfileService(profileRepository);
+
 const getProfile = async (user) => {
   if (!user) {
     throw new Error('User not found');
   }
 
   // authz: self-read; user.id comes from the verified auth session (see util/auth.js isAuthenticated)
-  const { data, error } = await supabaseAdmin.from('profiles').select('*').eq('user_id', user.id).single();
+  const { data, error } = await profileRepository.fetchOwnProfile(user.id);
 
   if (error) {
     if (PROFILE_NOT_FOUND_ERROR === error.code) {
       if (user.confirmed_at) {
-        const { data, error } = await createProfile(user.id);
+        const { data, error } = await provisionProfile(SYSTEM_ACTOR, user);
         if (error) {
           console.error(error);
           return false;
@@ -42,11 +46,7 @@ const getProfile = async (user) => {
 
   // Profile exists - check if user has any class unlocks, grant starter unlocks if missing
   if (data && user.confirmed_at) {
-    const { data: unlockData, error: unlockError } = await supabaseAdmin
-      .from('class_unlocks')
-      .select('class_id')
-      .eq('user_id', user.id)
-      .limit(1);
+    const { data: unlockData, error: unlockError } = await profileRepository.fetchStarterUnlockRows(user.id);
 
     // If no unlocks exist, grant starter unlocks (handles existing profiles created before feature)
     if (!unlockError && (!unlockData || unlockData.length === 0)) {
@@ -68,31 +68,26 @@ const getProfileByName = async (name) => {
 }
 
 // Admin variants bypass RLS — only call from routes already gated by requireAdmin.
-const getProfileByIdAdmin = async (id) => {
-  const { data, error } = await supabaseAdmin.from('profiles').select('*').eq('id', id).single();
-  return { data, error };
-}
+const getProfileByIdAdmin = async (id) => profileRepository.fetchProfileByIdAdmin(id);
 
-const getProfileByNameAdmin = async (name) => {
-  const { data, error } = await supabaseAdmin.from('profiles').select('*').eq('name', name).single();
-  return { data, error };
-}
+const getProfileByNameAdmin = async (name) => profileRepository.fetchProfileByNameAdmin(name);
 
-const createProfile = async (user_id) => {
-  // authz: self-write; user_id comes from the verified auth session via getProfile(user)
-  const { data, error } = await supabaseAdmin
-    .from('profiles')
-    .insert({ user_id, name: `Agent #${user_id}`, role: 'user' })
-    .select();
+// Self-provisioning on first sign-in: inserts the profile row and grants the
+// starter (trial) unlocks. `actor` gates the service's self-authz check;
+// `user` is the just-verified auth user (only .id is used for the insert).
+const provisionProfile = async (actor, user) => {
+  const { data, error } = await profileService.createProfileForUser(actor, user);
 
   if (!error && data && data.length > 0) {
-    // Grant starter unlocks (30-day trial) for new accounts
     const profile = data[0];
-    await grantStarterUnlocks(user_id, profile.id);
+    await grantStarterUnlocks(user.id, profile.id);
   }
 
   return { data, error };
 }
+
+// Not route-triggered; kept for API compatibility with existing callers.
+const createProfile = async (user_id) => provisionProfile(SYSTEM_ACTOR, { id: user_id });
 
 const grantStarterUnlocks = async (userId, profileId) => {
   const expiresAt = new Date();
@@ -123,32 +118,13 @@ const grantStarterUnlocks = async (userId, profileId) => {
   }
 }
 
-const updateUser = async (userId, email, password, profile) => {
-  if (password === '') password = null;
-  const attrs = {};
-  if (email) attrs.email = email;
-  if (password) attrs.password = password;
+// authz: self-write, enforced by profileService (throws AuthorizationError on
+// denial); userId is the authenticated caller (res.locals.user.id).
+const updateUser = async (actor, userId, email, password, profile) => profileService.updateUser(actor, userId, email, password, profile);
 
-  // authz: self-write; userId is the authenticated caller (res.locals.user.id from isAuthenticated)
-  if (attrs.email || attrs.password) {
-    const { error } = await supabaseAdmin.auth.admin.updateUserById(userId, attrs);
-    if (error) return { data: null, error };
-  }
-
-  sanitizeUrlFields(profile, ['image_url']);
-  const { data: profileData, error: profileError } = await supabaseAdmin.from('profiles').update(profile).eq('user_id', userId);
-  return { data: profileData, error: profileError };
-}
-
-const setDiscordId = async (user_id, discord_id, discord_email = null) => {
-  // authz: self-write; user_id is the authenticated caller's auth user id (passed from route res.locals.user.id)
-  const { data, error } = await supabaseAdmin
-    .from('profiles')
-    .update({ discord_id, discord_email })
-    .eq('user_id', user_id)
-    .select();
-  return { data, error };
-}
+// authz: self-write, enforced by profileService; user_id is the authenticated
+// caller's auth user id (passed from route res.locals.user.id).
+const setDiscordId = async (actor, user_id, discord_id, discord_email = null) => profileService.setDiscordId(actor, user_id, discord_id, discord_email);
 
 /**
  * Search for profiles by name (for adding editors, etc.)
@@ -176,13 +152,7 @@ const searchProfilesAdmin = async (query, limit = 10) => {
     return { data: [], error: null };
   }
 
-  const { data, error } = await supabaseAdmin
-    .from('profiles')
-    .select('id, name, image_url')
-    .ilike('name', `%${escapeLikePattern(query.trim())}%`)
-    .limit(limit);
-
-  return { data, error };
+  return profileRepository.searchProfilesAdmin(`%${escapeLikePattern(query.trim())}%`, limit);
 }
 
 const getProfileConduitCredits = async ({ profileId, supabase: client = supabase }) => {

--- a/models/rules-codes.test.js
+++ b/models/rules-codes.test.js
@@ -54,7 +54,7 @@ afterAll(() => {
 
 test('createRulesPdfUnlockCodes inserts amount rows with unique base64url codes', async () => {
     inserted.length = 0;
-    const { data, error } = await createRulesPdfUnlockCodes({
+    const { data, error } = await createRulesPdfUnlockCodes({ profileId: 'admin-1', role: 'admin' }, {
         rulesPdfId: 'pdf-1',
         createdByProfileId: 'profile-1',
         expiresAt: null,

--- a/models/rules.js
+++ b/models/rules.js
@@ -1,5 +1,9 @@
-const { supabase, supabaseAdmin } = require('./_base');
+const { supabase } = require('./_base');
 const crypto = require('crypto');
+const { RulesService } = require('../services/rules/service');
+const rulesRepository = require('../services/rules/repository');
+
+const rulesService = new RulesService(rulesRepository);
 
 const getRulesPdfs = async ({ includeInactive = false } = {}) => {
     let query = supabase
@@ -62,26 +66,7 @@ const updateRulesPdf = async (id, updates) => {
 
 // Admin-only: embedded profile/granter joins require bypassing RLS so
 // non-public grantee profiles still resolve in the manage UI.
-const listRulesPdfUnlocks = async (rulesPdfId) => {
-    const { data, error } = await supabaseAdmin
-        .from('rules_pdf_unlocks')
-        .select(`
-            user_id,
-            profile_id,
-            granted_by,
-            unlocked_at,
-            expires_at,
-            profile:profiles!rules_pdf_unlocks_profile_id_fkey(id, name),
-            granter:profiles!rules_pdf_unlocks_granted_by_fkey(id, name)
-        `)
-        .eq('rules_pdf_id', rulesPdfId)
-        .order('unlocked_at', { ascending: false });
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error: null };
-};
+const listRulesPdfUnlocks = (rulesPdfId) => rulesRepository.listUnlockGrantsAdmin(rulesPdfId);
 
 const upsertRulesPdfUnlock = async ({ userId, profileId, rulesPdfId, expiresAt, grantedBy }) => {
     const payload = {
@@ -130,7 +115,11 @@ const listRulesPdfUnlocksForUser = async (userId) => {
     return { data, error: null };
 };
 
-const createRulesPdfUnlockCodes = async ({ rulesPdfId, createdByProfileId, expiresAt = null, maxUses = 1, amount = 1 }) => {
+// Route-facing compatibility function. The service enforces the
+// mint-unlock-codes policy (admin/system only); this model builds the
+// code rows (the non-privileged logic) and delegates the privileged
+// insert to the service/repository.
+const createRulesPdfUnlockCodes = async (actor, { rulesPdfId, createdByProfileId, expiresAt = null, maxUses = 1, amount = 1 }) => {
     const inserts = Array.from({ length: amount }, () => ({
         code: crypto.randomBytes(12).toString('base64url'),
         rules_pdf_id: rulesPdfId,
@@ -139,17 +128,7 @@ const createRulesPdfUnlockCodes = async ({ rulesPdfId, createdByProfileId, expir
         max_uses: maxUses
     }));
 
-    // authz: callers (admin-only route) gate access; createdByProfileId is set server-side
-    const { data, error } = await supabaseAdmin
-        .from('rules_pdf_unlock_codes')
-        .insert(inserts)
-        .select();
-
-    if (error) {
-        console.error(error);
-        return { data: null, error };
-    }
-    return { data, error: null };
+    return rulesService.mintUnlockCodes(actor, inserts);
 };
 
 const listRulesPdfUnlockCodes = async (rulesPdfId, client = supabase) => {
@@ -182,10 +161,7 @@ const redeemRulesPdfUnlockCode = async (code, userId) => {
 // failure so access checks degrade to current behavior.
 const getRulesPdfFamilyIds = async (rulesPdf) => {
     try {
-        const { data, error } = await supabaseAdmin
-            .from('rules_pdfs')
-            .select('id')
-            .eq('title', rulesPdf.title);
+        const { data, error } = await rulesRepository.fetchPdfFamilyIdsByTitle(rulesPdf.title);
         if (error || !Array.isArray(data) || data.length === 0) {
             if (error) console.error(error);
             return [rulesPdf.id];
@@ -216,14 +192,7 @@ const canViewRulesPdf = async (userContext = {}, rulesPdf) => {
     // Admin read mirrors isClassUnlocked: the shared anon client carries no
     // JWT, so RLS would hide the user's own unlock rows.
     const familyIds = await getRulesPdfFamilyIds(rulesPdf);
-    const now = new Date().toISOString();
-    const { data, error } = await supabaseAdmin
-        .from('rules_pdf_unlocks')
-        .select('rules_pdf_id, expires_at')
-        .eq('user_id', userId)
-        .in('rules_pdf_id', familyIds)
-        .or(`expires_at.is.null,expires_at.gt.${now}`)
-        .limit(1);
+    const { data, error } = await rulesRepository.fetchActiveUnlockForUser({ userId, familyIds });
 
     if (error) {
         console.error(error);

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -12,14 +12,16 @@ const {
   normalizeLinkCode,
   isValidDiscordUserId,
   formatLinkCode,
-  createPendingLink,
-  consumePendingLink,
   cleanupStaleLinks
 } = require('../models/bot-link');
-const { supabaseAdmin } = require('../models/_base');
-const { revokeAgentToken } = require('../models/agent-token');
+const { BotLinkService } = require('../services/bot-link/service');
+const botLinkRepository = require('../services/bot-link/repository');
+const { revokeAgentToken, createAgentToken } = require('../models/agent-token');
+const agentTokenRepository = require('../services/agent-token/repository');
 const { actorFromLocals } = require('../util/actor');
 const { asyncHandler } = require('../util/async-handler');
+
+const botLinkService = new BotLinkService(botLinkRepository, createAgentToken);
 const {
   listPostsForAgent,
   getPostForAgent,
@@ -61,7 +63,7 @@ router.post('/bot-link/start', express.json(), async (req, res) => {
   if (!isValidDiscordUserId(discordUserId)) {
     return res.status(400).json({ error: 'Invalid discord_user_id' });
   }
-  const { data, error } = await createPendingLink(discordUserId);
+  const { data, error } = await botLinkService.startLink({ discordUserId });
   if (error) {
     if (error.message === 'Too many pending codes') {
       return res.status(429).json({ error: error.message });
@@ -83,7 +85,7 @@ router.post('/bot-link/claim', express.json(), async (req, res) => {
     return res.status(400).json({ error: 'Invalid code or discord_user_id' });
   }
 
-  const { data, error } = await consumePendingLink({
+  const { data, error } = await botLinkService.claimLink({
     code: normalized,
     discordUserId
   });
@@ -93,31 +95,13 @@ router.post('/bot-link/claim', express.json(), async (req, res) => {
   if (error === 'pending') return res.status(202).json({ status: 'pending' });
   if (error) return res.status(500).json({ error: error.message || 'Internal error' });
 
-  const { data: tokenRow, error: tokenError } = await supabaseAdmin
-    .from('agent_api_tokens')
-    .select('id, profile:profile_id(id, name)')
-    .eq('id', data.agentTokenId)
-    .single();
+  const { data: tokenRow, error: tokenError } = await agentTokenRepository.fetchTokenWithProfile(data.agentTokenId);
   if (tokenError || !tokenRow) {
     return res.status(500).json({ error: 'Token lookup failed' });
   }
 
-  const { data: rawTokenRow, error: rawError } = await supabaseAdmin
-    .from('pending_bot_links_raw_tokens')
-    .select('raw_token')
-    .eq('agent_token_id', data.agentTokenId)
-    .maybeSingle();
-  if (rawError || !rawTokenRow) {
-    return res.status(500).json({ error: 'Token stash missing' });
-  }
-
-  await supabaseAdmin
-    .from('pending_bot_links_raw_tokens')
-    .delete()
-    .eq('agent_token_id', data.agentTokenId);
-
   return res.json({
-    token: rawTokenRow.raw_token,
+    token: data.rawToken,
     agent_token_id: data.agentTokenId,
     profile: {
       id: tokenRow.profile?.id || null,

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -52,6 +52,11 @@ const parseBooleanFilter = (value) => {
   return undefined;
 };
 
+// Used for class/character agent reads. Unlike lfg's buildAgentActor
+// (models/lfg.js), this deliberately preserves the profile's REAL role
+// (e.g. 'admin') rather than stripping it: it preserves the pre-refactor
+// resolveClassAgentAccess visibility contract, where an admin's agent token
+// gets the same admin-wide read visibility an admin's session would.
 const getActorContext = (res) => ({
   userId: res.locals.user?.id || null,
   profileId: res.locals.profile?.id || null,

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -18,6 +18,8 @@ const {
 } = require('../models/bot-link');
 const { supabaseAdmin } = require('../models/_base');
 const { revokeAgentToken } = require('../models/agent-token');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 const {
   listPostsForAgent,
   getPostForAgent,
@@ -173,16 +175,13 @@ router.get('/characters/:id', async (req, res) => {
   return res.json({ character: data });
 });
 
-router.delete('/tokens/me', async (req, res) => {
-  const { data, error } = await revokeAgentToken({
-    tokenId: res.locals.agentToken.id,
-    userId: res.locals.user.id,
-    profileId: res.locals.profile.id
-  });
+router.delete('/tokens/me', asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { data, error } = await revokeAgentToken(actor, { tokenId: res.locals.agentToken.id });
   if (error) return res.status(500).json({ error: error.message });
   if (!data) return res.status(404).json({ error: 'Token not found or already revoked' });
   return res.json({ revoked: true });
-});
+}));
 
 const validatePostBody = (body, { isEdit = false } = {}) => {
   if (!body || typeof body !== 'object') {

--- a/routes/badges.js
+++ b/routes/badges.js
@@ -4,6 +4,8 @@ const { isAuthenticated, requireAdmin } = require('../util/auth');
 const { sendError } = require('../util/http-error');
 const { getBadgeCatalog, listProfileBadges, grantBadge, revokeBadge } = require('../models/badge');
 const { getProfileByIdAdmin, searchProfilesAdmin } = require('../models/profile');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 
 router.get('/manage', isAuthenticated, requireAdmin, async (req, res) => {
   const { data: catalog, error } = await getBadgeCatalog();
@@ -62,11 +64,12 @@ const grantRevokeParams = (req, res) => {
 const grantRevokeErrorStatus = (error) =>
   /milestone|not found/i.test(error?.message || '') ? 400 : 500;
 
-router.post('/grant', isAuthenticated, requireAdmin, async (req, res) => {
+router.post('/grant', isAuthenticated, requireAdmin, asyncHandler(async (req, res) => {
   const params = grantRevokeParams(req, res);
   if (!params) return;
 
-  const { error } = await grantBadge({
+  const actor = actorFromLocals(res.locals);
+  const { error } = await grantBadge(actor, {
     profileId: params.profileId,
     badgeSlug: params.badgeSlug,
     grantedById: res.locals.profile.id
@@ -78,13 +81,14 @@ router.post('/grant', isAuthenticated, requireAdmin, async (req, res) => {
     });
   }
   return res.redirect(`/badges/manage?profile_id=${encodeURIComponent(params.profileId)}`);
-});
+}));
 
-router.post('/revoke', isAuthenticated, requireAdmin, async (req, res) => {
+router.post('/revoke', isAuthenticated, requireAdmin, asyncHandler(async (req, res) => {
   const params = grantRevokeParams(req, res);
   if (!params) return;
 
-  const { error } = await revokeBadge({
+  const actor = actorFromLocals(res.locals);
+  const { error } = await revokeBadge(actor, {
     profileId: params.profileId,
     badgeSlug: params.badgeSlug
   });
@@ -95,6 +99,6 @@ router.post('/revoke', isAuthenticated, requireAdmin, async (req, res) => {
     });
   }
   return res.redirect(`/badges/manage?profile_id=${encodeURIComponent(params.profileId)}`);
-});
+}));
 
 module.exports = router;

--- a/routes/badges.test.js
+++ b/routes/badges.test.js
@@ -40,8 +40,8 @@ mock.module('../models/badge', () => ({
   // doesn't need a Handlebars view engine.
   getBadgeCatalog: async () => ({ data: null, error: new Error('catalog unavailable') }),
   listProfileBadges: async () => ({ data: [], error: null }),
-  grantBadge: async (args) => { calls.grant.push(args); return grantResult; },
-  revokeBadge: async (args) => { calls.revoke.push(args); return revokeResult; }
+  grantBadge: async (actor, args) => { calls.grant.push({ actor, ...args }); return grantResult; },
+  revokeBadge: async (actor, args) => { calls.revoke.push({ actor, ...args }); return revokeResult; }
 }));
 mock.module('../models/profile', () => ({
   getProfile: async () => ({ id: 'p-admin', user_id: 'u1', role: profileRole }),
@@ -124,7 +124,12 @@ test('POST /badges/grant calls grantBadge with the admin as granter and redirect
   });
   expect(res.status).toBe(302);
   expect(res.headers.get('location')).toBe('/badges/manage?profile_id=p2');
-  expect(calls.grant).toEqual([{ profileId: 'p2', badgeSlug: 'enclave-day-1', grantedById: 'p-admin' }]);
+  expect(calls.grant).toEqual([{
+    actor: { userId: 'u1', profileId: 'p-admin', role: 'admin' },
+    profileId: 'p2',
+    badgeSlug: 'enclave-day-1',
+    grantedById: 'p-admin'
+  }]);
 });
 
 test('POST /badges/grant surfaces milestone rejection as 400', async () => {
@@ -161,5 +166,9 @@ test('POST /badges/revoke calls revokeBadge and redirects', async () => {
     body: JSON.stringify({ profile_id: 'p2', badge_slug: 'enclave-day-1' })
   });
   expect(res.status).toBe(302);
-  expect(calls.revoke).toEqual([{ profileId: 'p2', badgeSlug: 'enclave-day-1' }]);
+  expect(calls.revoke).toEqual([{
+    actor: { userId: 'u1', profileId: 'p-admin', role: 'admin' },
+    profileId: 'p2',
+    badgeSlug: 'enclave-day-1'
+  }]);
 });

--- a/routes/bot-link-confirm.test.js
+++ b/routes/bot-link-confirm.test.js
@@ -1,0 +1,114 @@
+// routes/bot-link-confirm.test.js
+//
+// Regression test for a hang risk flagged when Task 7 switched
+// createAgentToken to THROW on an authorization failure: POST
+// /link/bot/confirm is an HTML render route, deliberately NOT wrapped in
+// asyncHandler (asyncHandler forwards to the central error handler, which
+// would answer with a JSON/generic 403 instead of this page's own error
+// notification). An authenticated-but-unconfirmed user has
+// res.locals.profile === false (see util/auth.js), so actorFromLocals
+// yields { profileId: null }, and confirmLink's create-token step throws
+// AuthorizationError. Without a local try/catch, that throw becomes an
+// unhandled rejection under Express 4 and the request never responds. This
+// test proves the route's own try/catch renders the graceful error page
+// instead, within a bounded time, for exactly that actor shape.
+const { test, expect, mock, beforeAll, afterAll } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const realAuth = require('../models/auth');
+const realSystemMessage = require('../util/system-message');
+const realLfg = require('../models/lfg');
+const realNavLoader = require('../util/nav-loader');
+const realProfile = require('../models/profile');
+const realBotLink = require('../models/bot-link');
+const realBotLinkService = require('../services/bot-link/service');
+const { AuthorizationError } = require('../util/errors');
+
+mock.module('../models/auth', () => ({
+  getUserFromToken: async (token) => (token === 'valid-jwt' ? { id: 'u1' } : false)
+}));
+mock.module('../util/system-message', () => ({ getSystemMessage: () => null }));
+mock.module('../models/lfg', () => ({ getPendingJoinRequestCount: async () => ({ count: 0 }) }));
+mock.module('../util/nav-loader', () => ({
+  populateNavItems: async () => {},
+  loadNavItems: (req, res, next) => next()
+}));
+// `false` is the exact shape isAuthenticated stores for an authenticated
+// user who hasn't completed profile confirmation yet.
+mock.module('../models/profile', () => ({
+  getProfile: async () => false
+}));
+mock.module('../models/bot-link', () => ({
+  normalizeLinkCode: (value) => {
+    if (typeof value !== 'string') return null;
+    const cleaned = value.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+    return /^[A-Z0-9]{8}$/.test(cleaned) ? cleaned : null;
+  },
+  cleanupStaleLinks: async () => {}
+}));
+// Stand in for the real BotLinkService so this test needs no live Supabase:
+// confirmLink reproduces exactly the failure mode this regression targets
+// (an actor with no profileId is not authorized to mint a token).
+mock.module('../services/bot-link/service', () => ({
+  BotLinkService: class {
+    async confirmLink(actor) {
+      if (!actor?.profileId) {
+        throw new AuthorizationError('Not authorized to manage this agent token', { reason: 'not_owner' });
+      }
+      return { data: { linked: true }, error: null };
+    }
+  }
+}));
+
+let app;
+let server;
+let baseUrl;
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
+
+beforeAll(async () => {
+  delete require.cache[require.resolve('../app')];
+  ({ createApp: app } = require('../app'));
+  const built = app();
+  ({ server, baseUrl } = await startHttpServer(built));
+});
+
+afterAll(async () => {
+  await stopHttpServer(server);
+  mock.module('../models/auth', () => realAuth);
+  mock.module('../util/system-message', () => realSystemMessage);
+  mock.module('../models/lfg', () => realLfg);
+  mock.module('../util/nav-loader', () => realNavLoader);
+  mock.module('../models/profile', () => realProfile);
+  mock.module('../models/bot-link', () => realBotLink);
+  mock.module('../services/bot-link/service', () => realBotLinkService);
+  delete require.cache[require.resolve('../app')];
+});
+
+test('POST /link/bot/confirm renders the graceful error page (not a hang) for an unconfirmed user', async () => {
+  const started = Date.now();
+  const res = await Promise.race([
+    fetch(`${baseUrl}/link/bot/confirm`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer valid-jwt',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: 'code=ABCD1234'
+    }),
+    new Promise((_, reject) => setTimeout(() => reject(new Error('request hung')), 4000))
+  ]);
+  expect(Date.now() - started).toBeLessThan(4000);
+  expect(res.status).toBe(200);
+  const body = await res.text();
+  // The view's own `{{error}}` binding is shadowed by a same-named
+  // handlebars-helpers logging helper (a pre-existing, unrelated template
+  // bug — see task report), so the notification text itself doesn't come
+  // through; the important assertion here is the *shape* of the response:
+  // a fast, complete render of the error notification (not the success
+  // notification, and not a hang/timeout).
+  expect(body).toContain('notification is-danger');
+  expect(body).not.toContain("You're linked");
+});

--- a/routes/bot-link.js
+++ b/routes/bot-link.js
@@ -2,68 +2,62 @@
 const express = require('express');
 const router = express.Router();
 const { isAuthenticated } = require('../util/auth');
-const { createAgentToken } = require('../models/agent-token');
 const { actorFromLocals } = require('../util/actor');
-const {
-  normalizeLinkCode,
-  getPendingLinkByCode,
-  attachTokenToPendingLink,
-  cleanupStaleLinks
-} = require('../models/bot-link');
-const { supabaseAdmin } = require('../models/_base');
+const { normalizeLinkCode, cleanupStaleLinks } = require('../models/bot-link');
+const { BotLinkService } = require('../services/bot-link/service');
+const botLinkRepository = require('../services/bot-link/repository');
+const { createAgentToken } = require('../models/agent-token');
+
+const botLinkService = new BotLinkService(botLinkRepository, createAgentToken);
+
+const CONFIRM_ERROR_MESSAGES = {
+  lookup_failed: 'Lookup failed.',
+  not_found: 'Code not found. Run /link in Discord again.',
+  expired: 'Code expired. Run /link in Discord again.',
+  token_create_failed: 'Could not create a token. Try again.',
+  stash_failed: 'Could not stash token. Try again.',
+  attach_failed: 'Could not attach token. Try again.'
+};
 
 router.get('/', isAuthenticated, (req, res) => {
   return res.render('bot-link', { title: 'Link Discord bot' });
 });
 
+// This is an HTML render route, not a JSON API — it gets its own local
+// try/catch rather than asyncHandler. asyncHandler forwards a thrown error
+// to the central error handler, which renders a JSON/generic error response;
+// that would break this page. A thrown AuthorizationError (e.g. an
+// authenticated-but-unconfirmed user, whose res.locals.profile is `false`
+// and therefore has no profileId) must instead render the existing graceful
+// "Could not create a token" error view.
 router.post('/confirm', express.urlencoded({ extended: false }), isAuthenticated, async (req, res) => {
-  await cleanupStaleLinks();
+  try {
+    await cleanupStaleLinks();
 
-  const normalized = normalizeLinkCode(req.body?.code);
-  if (!normalized) {
-    return res.render('bot-link', {
-      title: 'Link Discord bot',
-      error: 'Code must be 8 letters or numbers, e.g. XXXX-XXXX.'
-    });
-  }
+    const normalized = normalizeLinkCode(req.body?.code);
+    if (!normalized) {
+      return res.render('bot-link', {
+        title: 'Link Discord bot',
+        error: 'Code must be 8 letters or numbers, e.g. XXXX-XXXX.'
+      });
+    }
 
-  const { data: pending, error: pendingError } = await getPendingLinkByCode(normalized);
-  if (pendingError) {
-    return res.render('bot-link', { title: 'Link Discord bot', error: 'Lookup failed.' });
-  }
-  if (!pending) {
-    return res.render('bot-link', { title: 'Link Discord bot', error: 'Code not found. Run /link in Discord again.' });
-  }
-  if (pending.consumed_at || new Date(pending.expires_at).getTime() < Date.now()) {
-    return res.render('bot-link', { title: 'Link Discord bot', error: 'Code expired. Run /link in Discord again.' });
-  }
-  if (pending.agent_token_id) {
+    const actor = actorFromLocals(res.locals);
+    const { data, error } = await botLinkService.confirmLink(actor, { code: normalized });
+
+    if (error) {
+      const message = CONFIRM_ERROR_MESSAGES[error] || 'Could not create a token. Try again.';
+      return res.render('bot-link', { title: 'Link Discord bot', error: message });
+    }
+
     return res.render('bot-link', { title: 'Link Discord bot', success: true });
-  }
-
-  const tokenName = `Discord bot (${pending.discord_user_id})`;
-  const actor = actorFromLocals(res.locals);
-  const { data: tokenRow, error: tokenError } = await createAgentToken(actor, { name: tokenName });
-  if (tokenError || !tokenRow) {
+  } catch (err) {
+    // Covers AuthorizationError (e.g. an unconfirmed user with no profile)
+    // and any other unexpected failure — always degrade to the same
+    // graceful error view rather than letting the request hang or 500.
+    console.error(err);
     return res.render('bot-link', { title: 'Link Discord bot', error: 'Could not create a token. Try again.' });
   }
-
-  const { error: stashError } = await supabaseAdmin
-    .from('pending_bot_links_raw_tokens')
-    .insert({ agent_token_id: tokenRow.id, raw_token: tokenRow.token });
-  if (stashError) {
-    return res.render('bot-link', { title: 'Link Discord bot', error: 'Could not stash token. Try again.' });
-  }
-
-  const { error: attachError } = await attachTokenToPendingLink({
-    code: normalized,
-    agentTokenId: tokenRow.id
-  });
-  if (attachError) {
-    return res.render('bot-link', { title: 'Link Discord bot', error: 'Could not attach token. Try again.' });
-  }
-
-  return res.render('bot-link', { title: 'Link Discord bot', success: true });
 });
 
 module.exports = router;

--- a/routes/bot-link.js
+++ b/routes/bot-link.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 const { isAuthenticated } = require('../util/auth');
 const { createAgentToken } = require('../models/agent-token');
+const { actorFromLocals } = require('../util/actor');
 const {
   normalizeLinkCode,
   getPendingLinkByCode,
@@ -41,11 +42,8 @@ router.post('/confirm', express.urlencoded({ extended: false }), isAuthenticated
   }
 
   const tokenName = `Discord bot (${pending.discord_user_id})`;
-  const { data: tokenRow, error: tokenError } = await createAgentToken({
-    userId: res.locals.user.id,
-    profileId: res.locals.profile.id,
-    name: tokenName
-  });
+  const actor = actorFromLocals(res.locals);
+  const { data: tokenRow, error: tokenError } = await createAgentToken(actor, { name: tokenName });
   if (tokenError || !tokenRow) {
     return res.render('bot-link', { title: 'Link Discord bot', error: 'Could not create a token. Try again.' });
   }

--- a/routes/character-level-up.test.js
+++ b/routes/character-level-up.test.js
@@ -30,6 +30,7 @@ const realOffscreen = require('../models/offscreen-mission');
 const realCharacter = require('../models/character');
 const realMission = require('../models/mission');
 const realClass = require('../models/class');
+const { AuthorizationError } = require('../util/errors');
 
 const CHAR_ID = '11111111-1111-4111-8111-111111111111';
 const PROFILE_ID = 'p1';
@@ -138,9 +139,14 @@ mock.module('../models/character', () => ({
     error: null,
   }),
 }));
+// Mutable so a single test can force addCharacterToMission to THROW (as the
+// real MissionService.addCharacter now does on a denied/not-found mission via
+// requireEditable) without affecting the other tests in this file, which all
+// share this one mock.module registration.
+let addCharacterToMissionImpl = async () => ({ data: [{}], error: null });
 mock.module('../models/mission', () => ({
   createMission: async () => ({ data: [{ id: 'mission-1' }], error: null }),
-  addCharacterToMission: async () => ({ data: [{}], error: null }),
+  addCharacterToMission: async (...args) => addCharacterToMissionImpl(...args),
 }));
 mock.module('../models/class', () => ({
   getClass: async () => ({ data: { id: 'c1', rules_version: 'v1' }, error: null }),
@@ -191,6 +197,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   insertSeq = 0;
+  addCharacterToMissionImpl = async () => ({ data: [{}], error: null });
   adminTables.characters = [{
     id: CHAR_ID,
     creator_id: PROFILE_ID,
@@ -227,6 +234,48 @@ test('level-up backfilling real missions updates stored commissary_reward', asyn
   // Two success missions at MERX_PER_MISSION_SUCCESS (1) each, no spend → 2.
   expect(stored.commissary_reward).toBe(2);
   expect(stored.completed_missions).toBe(2);
+});
+
+test('level-up backfill returns a graceful error (not a hang) when addCharacterToMission throws', async () => {
+  // As of the mission service seam, MissionService.addCharacter throws
+  // (AuthorizationError or a raw repo error) instead of returning
+  // { error }. The level-up route isn't wrapped in asyncHandler, so an
+  // uncaught throw here previously turned into an unhandled promise
+  // rejection and the request never got a response. Race the request
+  // against a short timeout to prove it resolves instead of hanging.
+  addCharacterToMissionImpl = async () => {
+    throw new AuthorizationError('Mission not found', { reason: 'not_found' });
+  };
+
+  const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error('request hung')), 2000));
+
+  const res = await Promise.race([
+    fetch(`${baseUrl}/characters/${CHAR_ID}/level-up`, {
+      method: 'POST',
+      headers: {
+        'authorization': 'Bearer valid-jwt',
+        'content-type': 'application/json',
+        'accept': 'application/json',
+      },
+      body: JSON.stringify({
+        level: 2,
+        completed_missions: 1,
+        mission_names: ['Op Charlie'],
+        use_conduit_credit: false,
+        stats: {},
+      }),
+    }),
+    timeout,
+  ]);
+
+  expect(res.status).toBe(403);
+  const body = await res.json();
+  expect(body.error).toBeTruthy();
+
+  // The character row must be untouched — the backfill failed before the
+  // route ever reached the update at the end of the handler.
+  const stored = adminTables.characters.find(c => c.id === CHAR_ID);
+  expect(stored.completed_missions).toBe(0);
 });
 
 test('level-up resolves compounds_with links for newly-added perks', async () => {

--- a/routes/character-level-up.test.js
+++ b/routes/character-level-up.test.js
@@ -8,10 +8,13 @@
 // some other auto_calculate save re-derived it. The route must re-derive all of
 // level/completed_missions/commissary_reward from the resulting rows.
 //
-// We run the REAL isAuthenticated middleware and the REAL route handler against
-// a mocked data layer (mirroring routes/missions.test.js), with an in-memory
-// `_base` fake (mirroring models/character-update.test.js) so the route's
-// supabaseAdmin-backed character update writes to an inspectable store.
+// We run the REAL isAuthenticated middleware and the REAL route handler, the
+// REAL models/character.js, and the REAL CharacterService (services/character/
+// service.js) — the only fake at this level is services/character/repository,
+// which this file replaces with a small in-memory fake standing in for
+// supabaseAdmin. This keeps the level-up orchestration (backfill missions,
+// credit spend, re-derivation, perk-append) under real regression coverage
+// while avoiding a join-capable Postgres fake.
 const { test, expect, mock, beforeAll, afterAll, beforeEach } = require('bun:test');
 
 process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
@@ -27,85 +30,19 @@ const realSystemMessage = require('../util/system-message');
 const realLfg = require('../models/lfg');
 const realNavLoader = require('../util/nav-loader');
 const realOffscreen = require('../models/offscreen-mission');
-const realCharacter = require('../models/character');
 const realMission = require('../models/mission');
 const realClass = require('../models/class');
+const realCharacterRepository = require('../services/character/repository');
 const { AuthorizationError } = require('../util/errors');
+const { SYSTEM_ACTOR } = require('../util/actor');
 
 const CHAR_ID = '11111111-1111-4111-8111-111111111111';
 const PROFILE_ID = 'p1';
 
-// Monotonic id source for the in-memory fake's inserts (models gen_random_uuid).
-let insertSeq = 0;
-
-// In-memory admin store holding the character row the route updates. Kept as a
-// stable reference (the _base mock closes over it at require time); beforeEach
-// mutates `.characters` rather than reassigning so the closure stays valid.
-const adminTables = { characters: [] };
-
-// Minimal chainable PostgREST-shaped fake (subset of character-update.test.js's
-// makeClient) — enough for update().eq().eq().select().single() and reads.
-const makeClient = (tables) => ({
-  from(table) {
-    const filters = [];
-    let writeKind = null;
-    let writePayload = null;
-    const applyFilters = (rows) => rows.filter(r => filters.every(([col, val]) => r[col] === val));
-    const settleRead = () => ({ data: applyFilters(tables[table] ?? []), error: null });
-    const settleWrite = () => {
-      const all = tables[table] ?? [];
-      if (writeKind === 'update') {
-        const updated = [];
-        tables[table] = all.map(r => {
-          if (filters.every(([c, v]) => r[c] === v)) {
-            const next = { ...r, ...writePayload };
-            updated.push(next);
-            return next;
-          }
-          return r;
-        });
-        return { data: updated, error: null };
-      }
-      if (writeKind === 'insert') {
-        const raw = Array.isArray(writePayload) ? writePayload : [writePayload];
-        // Model gen_random_uuid(): rows without an id get a generated one.
-        const rows = raw.map(r => (r && r.id == null ? { ...r, id: `gen-${++insertSeq}` } : r));
-        tables[table] = [...all, ...rows];
-        return { data: rows, error: null };
-      }
-      return settleRead();
-    };
-    const settle = () => (writeKind ? settleWrite() : settleRead());
-    const chain = {
-      select() { return chain; },
-      eq(col, val) { filters.push([col, val]); return chain; },
-      order() { return chain; },
-      limit() { return chain; },
-      update(payload) { writeKind = 'update'; writePayload = payload; return chain; },
-      insert(payload) { writeKind = 'insert'; writePayload = payload; return chain; },
-      single() {
-        const { data } = settle();
-        const rows = Array.isArray(data) ? data : (data == null ? [] : [data]);
-        if (rows.length !== 1) {
-          return Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'no/multiple rows' } });
-        }
-        return Promise.resolve({ data: rows[0], error: null });
-      },
-      maybeSingle() {
-        const { data } = settle();
-        const row = Array.isArray(data) ? (data[0] ?? null) : data;
-        return Promise.resolve({ data: row, error: null });
-      },
-      then(onF, onR) { return Promise.resolve(settle()).then(onF, onR); }
-    };
-    return chain;
-  }
-});
-
 mock.module('../models/_base', () => ({
-  supabase: makeClient({}),
-  supabaseAdmin: makeClient(adminTables),
-  createUserClient: () => makeClient({}),
+  supabase: { from: () => { throw new Error('unexpected supabase call in level-up test'); } },
+  supabaseAdmin: { from: () => { throw new Error('unexpected supabaseAdmin call in level-up test'); } },
+  createUserClient: () => ({}),
   anonKey: 'test-anon-key',
 }));
 
@@ -117,28 +54,6 @@ mock.module('../models/profile', () => ({
   getProfile: async () => ({ id: PROFILE_ID, user_id: 'u1' }),
 }));
 
-mock.module('../models/character', () => ({
-  // Consumed by the route under test:
-  getCharacter: async () => ({
-    data: {
-      id: CHAR_ID,
-      creator_id: PROFILE_ID,
-      name: 'Tango',
-      level: 1,
-      completed_missions: 0,
-      commissary_reward: 0,
-      class_id: 'c1',
-      gear: [],
-      common_items: [],
-    },
-    error: null,
-  }),
-  // After backfilling 2 success missions, derivation reads them back:
-  getCharacterRealMissionsForDerivation: async () => ({
-    data: [{ outcome: 'success' }, { outcome: 'success' }],
-    error: null,
-  }),
-}));
 // Mutable so a single test can force addCharacterToMission to THROW (as the
 // real MissionService.addCharacter now does on a denied/not-found mission via
 // requireEditable) without affecting the other tests in this file, which all
@@ -148,8 +63,92 @@ mock.module('../models/mission', () => ({
   createMission: async () => ({ data: [{ id: 'mission-1' }], error: null }),
   addCharacterToMission: async (...args) => addCharacterToMissionImpl(...args),
 }));
+// Re-require AFTER the mock.module registration above so this file's own
+// direct calls (inside the repository fake below) resolve to the fakes too.
+const { createMission: fakeCreateMission, addCharacterToMission: fakeAddCharacterToMission } = require('../models/mission');
+
 mock.module('../models/class', () => ({
   getClass: async () => ({ data: { id: 'c1', rules_version: 'v1' }, error: null }),
+  getClasses: async () => ({ data: [], error: null }),
+  // Not exercised by the level-up flow, but models/character.js composes it
+  // into the CharacterService adapter unconditionally at module load time.
+  buildClassContentLookupMaps: async () => ({
+    gearNameToClassId: new Map(),
+    gearNameToDescription: new Map(),
+    abilityNameToClassId: new Map(),
+    abilityNameToDescription: new Map()
+  }),
+}));
+
+// In-memory state the repository fake below operates on directly (plain JS,
+// no Postgres/PostgREST chain needed at this boundary) — reset in beforeEach.
+let characterRow;
+let classAbilities;
+let characterPerks;
+let backfilledMissions;
+let perkIdSeq;
+
+mock.module('../services/character/repository', () => ({
+  getCharacter: async () => ({ data: { ...characterRow }, error: null }),
+  fetchCharacterOwnership: async () => ({ data: { ...characterRow }, error: null }),
+  updateOwnedFields: async ({ fields }) => {
+    Object.assign(characterRow, fields);
+    return { data: { ...characterRow }, error: null };
+  },
+  deleteCharacter: async () => ({ data: null, error: null }),
+  setDeceased: async () => ({ data: [{ ...characterRow, is_deceased: true }], error: null }),
+  updateClass: async () => ({ data: [{ ...characterRow }], error: null }),
+  getRealMissions: async () => ({ data: [...backfilledMissions], error: null }),
+  listOffscreenMissions: async () => ({ data: [], error: null }),
+  getClassRulesVersion: async () => ({ data: 'v1', error: null }),
+  fetchAllowedAbilityIds: async () => ({ data: classAbilities.map(a => ({ id: a.id })), error: null }),
+  fetchExistingPerks: async () => ({ data: characterPerks.map(p => ({ ...p })), error: null }),
+  insertPerks: async (rows) => {
+    for (const row of rows) {
+      characterPerks.push({ id: `perk-${++perkIdSeq}`, compounds_with: null, ...row });
+    }
+    return { error: null };
+  },
+  updatePerkLinks: async (updates) => {
+    for (const u of updates) {
+      const perk = characterPerks.find(p => p.id === u.id);
+      if (perk) perk.compounds_with = u.compounds_with;
+    }
+    return { error: null };
+  },
+  // Mirrors services/character/repository.js#createBackfillMission, using
+  // this file's (possibly test-overridden) mission mocks — preserves the
+  // throw-regression coverage below.
+  createBackfillMission: async ({ characterId, name, profileId }) => {
+    const { data: missionRows, error: missionError } = await fakeCreateMission(SYSTEM_ACTOR, {
+      name,
+      date: new Date().toISOString(),
+      outcome: 'success',
+      is_public: false,
+      creator_id: profileId
+    });
+    if (missionError) return { error: missionError };
+    const mission = Array.isArray(missionRows) ? missionRows[0] : missionRows;
+    if (!mission) return { error: { status: 400, message: 'Mission creation returned no rows' } };
+    try {
+      const { error: linkError } = await fakeAddCharacterToMission(SYSTEM_ACTOR, mission.id, characterId);
+      if (linkError) return { error: linkError };
+      backfilledMissions.push({ outcome: 'success' });
+      return { error: null };
+    } catch (error) {
+      return { error };
+    }
+  },
+  getAvailableHostedMissions: async () => ({ data: [], error: null }),
+  createOffscreenMissionRow: async () => ({ data: {}, error: null }),
+  // Unused by the level-up flow but required by CharacterService's adapter
+  // validation / other CharacterService capabilities.
+  createCharacterRow: async () => ({ data: [{}], error: null }),
+  updateCharacterRow: async () => ({ data: [{}], error: null }),
+  getChildRows: async () => ({ data: [], error: null }),
+  insertChildRows: async () => ({ data: true, error: null }),
+  updateChildRow: async () => ({ data: true, error: null }),
+  deleteChildRows: async () => ({ data: true, error: null })
 }));
 
 mock.module('../models/offscreen-mission', () => ({
@@ -175,6 +174,7 @@ let baseUrl;
 
 beforeAll(async () => {
   delete require.cache[require.resolve('./characters')];
+  delete require.cache[require.resolve('../models/character')];
   const app = express();
   app.use(express.json());
   app.use('/characters', require('./characters'));
@@ -190,15 +190,17 @@ afterAll(async () => {
   mock.module('../models/lfg', () => realLfg);
   mock.module('../util/nav-loader', () => realNavLoader);
   mock.module('../models/offscreen-mission', () => realOffscreen);
-  mock.module('../models/character', () => realCharacter);
   mock.module('../models/mission', () => realMission);
   mock.module('../models/class', () => realClass);
+  mock.module('../services/character/repository', () => realCharacterRepository);
+  delete require.cache[require.resolve('./characters')];
+  delete require.cache[require.resolve('../models/character')];
 });
 
 beforeEach(() => {
-  insertSeq = 0;
   addCharacterToMissionImpl = async () => ({ data: [{}], error: null });
-  adminTables.characters = [{
+  perkIdSeq = 0;
+  characterRow = {
     id: CHAR_ID,
     creator_id: PROFILE_ID,
     name: 'Tango',
@@ -206,9 +208,10 @@ beforeEach(() => {
     completed_missions: 0,
     commissary_reward: 0,
     class_id: 'c1',
-  }];
-  adminTables.class_abilities = [{ id: 'ab1', character_id: CHAR_ID, class_id: 'c1', name: 'Blink' }];
-  adminTables.character_perks = [];
+  };
+  classAbilities = [{ id: 'ab1', character_id: CHAR_ID, class_id: 'c1', name: 'Blink' }];
+  characterPerks = [];
+  backfilledMissions = [];
 });
 
 test('level-up backfilling real missions updates stored commissary_reward', async () => {
@@ -230,19 +233,17 @@ test('level-up backfilling real missions updates stored commissary_reward', asyn
 
   expect(res.status).toBe(200);
 
-  const stored = adminTables.characters.find(c => c.id === CHAR_ID);
   // Two success missions at MERX_PER_MISSION_SUCCESS (1) each, no spend → 2.
-  expect(stored.commissary_reward).toBe(2);
-  expect(stored.completed_missions).toBe(2);
+  expect(characterRow.commissary_reward).toBe(2);
+  expect(characterRow.completed_missions).toBe(2);
 });
 
 test('level-up backfill returns a graceful error (not a hang) when addCharacterToMission throws', async () => {
   // As of the mission service seam, MissionService.addCharacter throws
   // (AuthorizationError or a raw repo error) instead of returning
-  // { error }. The level-up route isn't wrapped in asyncHandler, so an
-  // uncaught throw here previously turned into an unhandled promise
-  // rejection and the request never got a response. Race the request
-  // against a short timeout to prove it resolves instead of hanging.
+  // { error }. The level-up route/service isn't shielded from that any other
+  // way than the repository's own try/catch, so this proves it resolves
+  // gracefully instead of hanging on an unhandled rejection.
   addCharacterToMissionImpl = async () => {
     throw new AuthorizationError('Mission not found', { reason: 'not_found' });
   };
@@ -273,14 +274,13 @@ test('level-up backfill returns a graceful error (not a hang) when addCharacterT
   expect(body.error).toBeTruthy();
 
   // The character row must be untouched — the backfill failed before the
-  // route ever reached the update at the end of the handler.
-  const stored = adminTables.characters.find(c => c.id === CHAR_ID);
-  expect(stored.completed_missions).toBe(0);
+  // route/service ever reached the update at the end of the handler.
+  expect(characterRow.completed_missions).toBe(0);
 });
 
 test('level-up resolves compounds_with links for newly-added perks', async () => {
   // An existing perk the new perks can compound with.
-  adminTables.character_perks = [
+  characterPerks = [
     { id: 'perk-existing', character_id: CHAR_ID, class_ability_id: 'ab1', text: 'Base perk', position: 0, compounds_with: null },
   ];
 
@@ -306,10 +306,9 @@ test('level-up resolves compounds_with links for newly-added perks', async () =>
 
   expect(res.status).toBe(200);
 
-  const perks = adminTables.character_perks.filter(p => p.character_id === CHAR_ID);
-  const base = perks.find(p => p.text === 'Base perk');
-  const a = perks.find(p => p.text === 'Compounds with base');
-  const b = perks.find(p => p.text === 'Chains off A');
+  const base = characterPerks.find(p => p.text === 'Base perk');
+  const a = characterPerks.find(p => p.text === 'Compounds with base');
+  const b = characterPerks.find(p => p.text === 'Chains off A');
 
   expect(a).toBeTruthy();
   expect(b).toBeTruthy();

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -12,16 +12,18 @@ const {
   getCharacterRecentMissions,
   searchPublicCharacters,
   getRandomPublicCharacters,
-  getCharacterRealMissionsForDerivation,
   upgradeCharacterClass,
+  updateCharacterStats,
+  levelUpCharacter,
   findUpgradeTargetsFor
 } = require('../models/character');
-const { getMission, createMission, addCharacterToMission } = require('../models/mission');
-const { SYSTEM_ACTOR } = require('../util/actor');
+const characterRepository = require('../services/character/repository');
+const { getMission } = require('../models/mission');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 const { getClasses, getClass, getUnlockedClassIdsForUser } = require('../models/class');
 const { getLfgPost } = require('../models/lfg');
 const { getProfileById, getProfileConduitCredits } = require('../models/profile');
-const { supabaseAdmin } = require('../models/_base');
 const { statList, personalityMap, commonItemList } = require('../util/enclave-consts');
 const { deriveCharacterTotals } = require('../util/character-derived');
 const { filterClassListsByIds } = require('../util/class-filter');
@@ -32,7 +34,6 @@ const { renderMarkdown } = require('../util/markdown');
 const { processCharacterImport } = require('../util/character-import');
 const { exportCharacter, getSupportedFormats, EXPORT_FORMATS } = require('../util/character-export');
 const { parseImageCrop } = require('../util/crop');
-const { validateAbilityPerks } = require('../util/validate');
 
 const asArray = (v) => (Array.isArray(v) ? v : (v == null || v === '' ? [] : [v]));
 
@@ -74,194 +75,17 @@ const parseInteger = (value, fallback = 0) => {
   return Number.isFinite(n) ? n : fallback;
 };
 
-const normalizeStatsPayload = (body = {}) => {
-  const out = {};
-  for (const stat of statList) {
-    const n = parseInteger(body[stat], 0);
-    out[stat] = Math.max(0, Math.min(20, n));
-  }
-  return out;
-};
-
-const getOwnedCharacterForMutation = async ({ characterId, profile }) => {
-  const { data: character, error } = await getCharacter(characterId, supabaseAdmin);
-  if (error) return { character: null, error };
-  if (!character) return { character: null, error: { status: 404, message: 'Character not found' } };
-  if (character.creator_id !== profile.id) {
-    return { character: null, error: { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND } };
-  }
-  return { character, error: null };
-};
-
+// Renders a service-returned { status, title, message }-shaped error (or a
+// plain Error/string) with the appropriate status — the equivalent of
+// passing a pre-classified shape through as sendError's `opts`. Kept at the
+// route layer (not an admin site) for the stats/level-up capabilities' business-
+// rule errors (insufficient credits, name mismatch, perk validation, ...);
+// the ownership/authorization gate itself throws and is handled by asyncHandler.
 const sendRouteError = (req, res, error) => {
   if (error && (error.status != null || error.title)) {
     return sendError(req, res, null, error);
   }
   return sendError(req, res, error);
-};
-
-const updateOwnedCharacterFields = async ({ characterId, profileId, fields }) => {
-  const { data, error } = await supabaseAdmin
-    .from('characters')
-    .update(fields)
-    .eq('id', characterId)
-    .eq('creator_id', profileId)
-    .select()
-    .single();
-  if (error) return { data: null, error };
-  if (!data) return { data: null, error: { status: 404, message: 'Character update returned no rows' } };
-  return { data, error: null };
-};
-
-// Internal, non-user-triggered mission creation (the level-up backfill flow
-// synthesizes a mission for missions the character logged before the app
-// tracked them). Uses SYSTEM_ACTOR — not the acting profile — so the new
-// addCharacter authorization gate can't reject this internal link; creator_id
-// is still set explicitly so the mission shows up under the user's own missions.
-const createBackfillMissionForCharacter = async ({ characterId, name, profile }) => {
-  const { data: missionRows, error: missionError } = await createMission(SYSTEM_ACTOR, {
-    name,
-    date: new Date().toISOString(),
-    outcome: 'success',
-    is_public: false,
-    creator_id: profile.id
-  });
-  if (missionError) return { error: missionError };
-  const mission = Array.isArray(missionRows) ? missionRows[0] : missionRows;
-  if (!mission) return { error: { status: 400, message: 'Mission creation returned no rows' } };
-  // addCharacterToMission can now THROW (MissionService.addCharacter calls
-  // requireEditable, which throws on a repo error re-reading the mission's
-  // permission row, or on a not-found). SYSTEM_ACTOR always passes the
-  // authorization check itself, so those are the only two throw paths left
-  // reachable here. This route isn't wrapped in asyncHandler, so an
-  // uncaught throw would become an unhandled rejection and hang the
-  // request instead of hitting the existing { error } response path below.
-  try {
-    const { error: linkError } = await addCharacterToMission(SYSTEM_ACTOR, mission.id, characterId);
-    return { error: linkError || null };
-  } catch (error) {
-    return { error };
-  }
-};
-
-const appendCharacterPerks = async ({ characterId, submittedPerks }) => {
-  if (!Array.isArray(submittedPerks) || submittedPerks.length === 0) {
-    return { error: null };
-  }
-
-  const { data: abilities, error: abilityError } = await supabaseAdmin
-    .from('class_abilities')
-    .select('id')
-    .eq('character_id', characterId);
-  if (abilityError) return { error: abilityError };
-  const allowedAbilityIds = new Set((abilities || []).map(a => a.id));
-
-  const { data: existing, error: existingError } = await supabaseAdmin
-    .from('character_perks')
-    .select('id, class_ability_id, text, position')
-    .eq('character_id', characterId);
-  if (existingError) return { error: existingError };
-
-  const existingCounts = new Map();
-  // id -> ability, so a new perk may only compound with an existing perk on the
-  // SAME ability (mirrors resolveCompoundLinks in the full edit-form path).
-  const abilityByExistingPerkId = new Map();
-  const existingForValidation = (existing || []).map(p => {
-    const pos = parseInteger(p.position, 0);
-    existingCounts.set(p.class_ability_id, Math.max(existingCounts.get(p.class_ability_id) ?? -1, pos));
-    abilityByExistingPerkId.set(p.id, p.class_ability_id);
-    return {
-      class_ability_id: p.class_ability_id,
-      text: p.text,
-      position: pos
-    };
-  });
-
-  // Build insert rows. `meta` runs parallel to `rows`, carrying each new perk's
-  // client `ref` and its requested compound link so we can resolve links after
-  // the rows (and their ids) exist.
-  const rows = [];
-  const meta = [];
-  for (const p of submittedPerks) {
-    if (!p || typeof p !== 'object') continue;
-    const classAbilityId = p.class_ability_id;
-    const text = typeof p.text === 'string' ? p.text.trim() : '';
-    if (!classAbilityId || !allowedAbilityIds.has(classAbilityId) || !text) continue;
-    const nextPosition = (existingCounts.get(classAbilityId) ?? -1) + 1;
-    existingCounts.set(classAbilityId, nextPosition);
-    rows.push({
-      character_id: characterId,
-      class_ability_id: classAbilityId,
-      text,
-      position: nextPosition
-    });
-    meta.push({
-      ref: typeof p.ref === 'string' ? p.ref : null,
-      compoundsWith: p.compounds_with == null ? null : String(p.compounds_with)
-    });
-  }
-
-  if (rows.length === 0) return { error: null };
-
-  const validation = validateAbilityPerks(existingForValidation.concat(rows));
-  if (!validation.ok) {
-    return { error: { status: 400, message: validation.errors.join(' ') } };
-  }
-
-  const { error } = await supabaseAdmin.from('character_perks').insert(rows);
-  if (error) return { error };
-
-  // Re-read the rows to recover server-assigned ids. We match by
-  // (class_ability_id, position) — each new perk got a unique position above —
-  // rather than relying on insert-return ordering.
-  const { data: current, error: selError } = await supabaseAdmin
-    .from('character_perks')
-    .select('id, class_ability_id, position')
-    .eq('character_id', characterId);
-  if (selError) return { error: selError };
-  const idByKey = new Map((current || []).map(r => [`${r.class_ability_id}:${parseInteger(r.position, 0)}`, r.id]));
-  const keyOf = (row) => `${row.class_ability_id}:${row.position}`;
-
-  // ref -> { id, class_ability_id } for perks inserted in this batch.
-  const insertedByRef = new Map();
-  for (let i = 0; i < rows.length; i++) {
-    if (!meta[i].ref) continue;
-    insertedByRef.set(meta[i].ref, { id: idByKey.get(keyOf(rows[i])), class_ability_id: rows[i].class_ability_id });
-  }
-
-  // Resolve each new perk's compound link. A link is either `new:<ref>` (another
-  // perk inserted in this batch) or an existing perk UUID. The target must be on
-  // the same ability and not the perk itself; anything else resolves to null.
-  const linkUpdates = [];
-  for (let i = 0; i < rows.length; i++) {
-    const link = meta[i].compoundsWith;
-    if (!link) continue;
-    const rowId = idByKey.get(keyOf(rows[i]));
-    if (!rowId) continue;
-
-    let target = null;
-    if (link.startsWith('new:')) {
-      const ref = link.slice('new:'.length);
-      const cand = insertedByRef.get(ref);
-      if (cand) target = { id: cand.id, class_ability_id: cand.class_ability_id };
-    } else if (abilityByExistingPerkId.has(link)) {
-      target = { id: link, class_ability_id: abilityByExistingPerkId.get(link) };
-    }
-
-    if (target && target.id && target.id !== rowId && target.class_ability_id === rows[i].class_ability_id) {
-      linkUpdates.push({ id: rowId, compounds_with: target.id });
-    }
-  }
-
-  for (const u of linkUpdates) {
-    const { error: updError } = await supabaseAdmin
-      .from('character_perks')
-      .update({ compounds_with: u.compounds_with })
-      .eq('id', u.id);
-    if (updError) return { error: updError };
-  }
-
-  return { error: null };
 };
 
 // Helper to filter class lists/lookup maps by user's unlocked classes
@@ -629,8 +453,8 @@ router.get('/:id/edit', isAuthenticated, async (req, res) => {
     }
 
     const [missionsRes, offscreenRes] = await Promise.all([
-      getCharacterRealMissionsForDerivation(id, supabaseAdmin),
-      listOffscreenMissions({ characterId: id, supabase: supabaseAdmin })
+      characterRepository.getRealMissions(id),
+      characterRepository.listOffscreenMissions(id)
     ]);
     const derived = deriveCharacterTotals({
       character,
@@ -695,8 +519,8 @@ router.get('/:id/auto-calc-fields', isAuthenticated, async (req, res) => {
   let derived = { completed_missions: 0, commissary_reward: 0, level: 1 };
   if (on) {
     const [missionsRes, offscreenRes] = await Promise.all([
-      getCharacterRealMissionsForDerivation(id, supabaseAdmin),
-      listOffscreenMissions({ characterId: id, supabase: supabaseAdmin })
+      characterRepository.getRealMissions(id),
+      characterRepository.listOffscreenMissions(id)
     ]);
     if (missionsRes.error || offscreenRes.error) {
       return sendError(req, res, null, { status: 503, message: 'Failed to load mission data' });
@@ -1309,155 +1133,34 @@ router.get('/:id/:name?', authOptional, async (req, res) => {
   }
 });
 
-router.patch('/:id/stats', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.patch('/:id/stats', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
-  const { character, error: charError } = await getOwnedCharacterForMutation({ characterId: id, profile });
-  if (charError) return sendRouteError(req, res, charError);
 
-  const stats = normalizeStatsPayload(req.body || {});
-  const { data, error } = await updateOwnedCharacterFields({
-    characterId: id,
-    profileId: profile.id,
-    fields: stats
-  });
-  if (error) return sendError(req, res, error);
-  return res.status(200).json({
-    character: {
-      id: data.id,
-      name: data.name || character.name,
-      stats: Object.fromEntries(statList.map(stat => [stat, data[stat] ?? stats[stat]]))
-    }
-  });
-});
+  // updateStats throws AuthorizationError (caught by asyncHandler) when the
+  // actor may not mutate this character; everything else it returns as
+  // { data, error } for sendRouteError to render (matching the pre-service
+  // behavior of getOwnedCharacterForMutation/updateOwnedCharacterFields).
+  const { data, error } = await updateCharacterStats(actor, id, req.body || {});
+  if (error) return sendRouteError(req, res, error);
+  return res.status(200).json({ character: data });
+}));
 
-router.post('/:id/level-up', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/level-up', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
-  const body = req.body || {};
-  const { character, error: charError } = await getOwnedCharacterForMutation({ characterId: id, profile });
-  if (charError) return sendRouteError(req, res, charError);
 
-  const currentLevel = Math.max(1, parseInteger(character.level, 1));
-  const requestedLevel = Math.max(currentLevel + 1, Math.min(20, parseInteger(body.level, currentLevel + 1)));
-  const currentCompleted = Math.max(0, parseInteger(character.completed_missions, 0));
-  const requestedCompleted = Math.max(currentCompleted, parseInteger(body.completed_missions, currentCompleted));
-  const missionNames = Array.isArray(body.mission_names)
-    ? body.mission_names.map(v => String(v || '').trim()).filter(Boolean)
-    : [];
-  const useConduitCredit = body.use_conduit_credit === true || body.use_conduit_credit === 'true' || body.use_conduit_credit === 'on';
-  const creditCount = useConduitCredit ? Math.max(0, requestedCompleted - currentCompleted - missionNames.length) : 0;
+  // levelUp throws AuthorizationError (caught by asyncHandler) for the
+  // ownership gate; every other failure (missing mission names, insufficient
+  // Conduit Credits, backfill-mission errors, perk validation) is returned
+  // as { data, error } exactly as the pre-service route did, so
+  // sendRouteError keeps rendering their specific status/message.
+  const { data, error } = await levelUpCharacter(actor, id, req.body || {});
+  if (error) return sendRouteError(req, res, error);
+  return res.status(200).json({ character: data });
+}));
 
-  if (!useConduitCredit && requestedCompleted > currentCompleted + missionNames.length) {
-    return sendError(req, res, null, {
-      status: 400,
-      message: 'Provide mission names for each missing mission, or spend Conduit Credits.'
-    });
-  }
-
-  let creditSources = [];
-  if (creditCount > 0) {
-    const { data: availableHostedMissions, error: availableError } = await getAvailableHostedMissionsForPicker({
-      profileId: profile.id,
-      supabase: supabaseAdmin
-    });
-    if (availableError) return sendError(req, res, availableError);
-    creditSources = (availableHostedMissions || []).slice(0, creditCount);
-    if (creditSources.length < creditCount) {
-      return sendError(req, res, null, {
-        status: 400,
-        message: 'Not enough Conduit Credits available.'
-      });
-    }
-  }
-
-  for (const name of missionNames) {
-    const { error } = await createBackfillMissionForCharacter({ characterId: id, name, profile });
-    if (error) return sendRouteError(req, res, error);
-  }
-
-  for (let i = 0; i < creditSources.length; i++) {
-    const src = creditSources[i];
-    const sourceDate = typeof src.date === 'string'
-      ? src.date.slice(0, 10)
-      : new Date(src.date).toISOString().slice(0, 10);
-    const { error } = await createOffscreenMission({
-      characterId: id,
-      profileId: profile.id,
-      payload: {
-        name: `Conduit Credit: Level ${requestedLevel}`,
-        summary: 'Spent through the level-up modal.',
-        merx_gained: 0,
-        source_mission_id: src.id,
-        source_mission_name: src.name || `Hosted mission ${i + 1}`,
-        source_mission_date: sourceDate
-      },
-      supabase: supabaseAdmin
-    });
-    if (error) return sendRouteError(req, res, error);
-  }
-
-  // Re-derive level / completed_missions / commissary_reward from the rows we
-  // just created (real success missions and offscreen credits) so the stored
-  // counters match what every derive-path computes. The character detail page
-  // renders the stored commissary_reward directly, so writing raw requested
-  // values here left it stale — each backfilled success mission is worth
-  // MERX_PER_MISSION_SUCCESS that never landed in the column.
-  const [missionsRes, offscreenRes] = await Promise.all([
-    getCharacterRealMissionsForDerivation(id, supabaseAdmin),
-    listOffscreenMissions({ characterId: id, supabase: supabaseAdmin })
-  ]);
-  if (missionsRes.error || offscreenRes.error) {
-    return sendError(req, res, missionsRes.error || offscreenRes.error);
-  }
-
-  let rulesVersion = 'v1';
-  if (character.class_id) {
-    try {
-      const { data: cls } = await getClass(character.class_id, supabaseAdmin);
-      if (cls && cls.rules_version === 'v2') rulesVersion = 'v2';
-    } catch (_) { /* default to v1 */ }
-  }
-
-  const derived = deriveCharacterTotals({
-    character,
-    realMissions: missionsRes.data || [],
-    offscreenMissions: offscreenRes.data || [],
-    rulesVersion
-  });
-
-  const stats = normalizeStatsPayload(body.stats || body);
-  const fields = {
-    ...stats,
-    level: derived.level,
-    completed_missions: derived.completed_missions,
-    commissary_reward: derived.commissary_reward
-  };
-  const { data, error } = await updateOwnedCharacterFields({
-    characterId: id,
-    profileId: profile.id,
-    fields
-  });
-  if (error) return sendError(req, res, error);
-
-  const { error: perksError } = await appendCharacterPerks({
-    characterId: id,
-    submittedPerks: Array.isArray(body.ability_perks) ? body.ability_perks : []
-  });
-  if (perksError) return sendRouteError(req, res, perksError);
-
-  return res.status(200).json({
-    character: {
-      id: data.id,
-      name: data.name || character.name,
-      level: data.level,
-      completed_missions: data.completed_missions,
-      commissary_reward: data.commissary_reward
-    }
-  });
-});
-
-router.put('/:id/:name?', isAuthenticated, async (req, res) => {
+router.put('/:id/:name?', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
   const { id } = req.params;
   const image_crop = parseImageCrop(req.body.image_crop);
@@ -1476,57 +1179,52 @@ router.put('/:id/:name?', isAuthenticated, async (req, res) => {
   delete req.body.quirk_description;
   delete req.body.accessory_name;
   delete req.body.accessory_description;
+  // updateCharacter throws AuthorizationError (caught by asyncHandler) when
+  // the actor doesn't own the character; other failures are still returned.
   const { data, error } = await updateCharacter(id, req.body, profile);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', `/characters/${id}/${encodeURIComponent(data.name)}`).send();
   }
-});
+}));
 
-router.delete('/:id/:name?', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.delete('/:id/:name?', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
-  const { error } = await deleteCharacter(id, profile);
+  const { error } = await deleteCharacter(actor, id);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', '/characters').send();
   }
-});
+}));
 
-router.post('/:id/upgrade', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/upgrade', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
   const { target_class_id } = req.body;
-  const { data, error } = await upgradeCharacterClass(id, target_class_id, profile, res.locals.supabase);
+  const { data, error } = await upgradeCharacterClass(actor, id, target_class_id, res.locals.supabase);
   if (error) return sendError(req, res, error);
   return res.header('HX-Location', `/characters/${id}/edit`).send();
-});
+}));
 
-router.post('/:id/deceased', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/deceased', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
   const { confirmName } = req.body;
 
-  // Get the character to verify ownership and name
-  const { data: character, error: getError } = await getCharacter(id, res.locals.supabase);
-  if (getError) {
-    return sendError(req, res, getError);
-  }
-
-  // Verify the confirmation name matches
-  if (!confirmName || confirmName.trim() !== character.name) {
-    return sendError(req, res, null, { status: 400, message: 'Character name does not match. Please type the exact name to confirm.' });
-  }
-
-  // Mark as deceased
-  const { data, error } = await markCharacterDeceased(id, profile);
+  // markCharacterDeceased throws AuthorizationError (caught by asyncHandler)
+  // when the actor doesn't own the character; the confirm-name mismatch and
+  // already-deceased checks are still returned as { data, error } (the
+  // service loads the character once, admin-privileged, and reuses it for
+  // both the ownership gate and the name check).
+  const { data, error } = await markCharacterDeceased(actor, id, confirmName);
   if (error) {
-    return sendError(req, res, error);
+    return sendRouteError(req, res, error);
   }
 
   return res.header('HX-Location', `/characters/${id}/${encodeURIComponent(data.name)}`).send();
-});
+}));
 
 module.exports = router;

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -129,8 +129,19 @@ const createBackfillMissionForCharacter = async ({ characterId, name, profile })
   if (missionError) return { error: missionError };
   const mission = Array.isArray(missionRows) ? missionRows[0] : missionRows;
   if (!mission) return { error: { status: 400, message: 'Mission creation returned no rows' } };
-  const { error: linkError } = await addCharacterToMission(SYSTEM_ACTOR, mission.id, characterId);
-  return { error: linkError || null };
+  // addCharacterToMission can now THROW (MissionService.addCharacter calls
+  // requireEditable, which throws on a repo error re-reading the mission's
+  // permission row, or on a not-found). SYSTEM_ACTOR always passes the
+  // authorization check itself, so those are the only two throw paths left
+  // reachable here. This route isn't wrapped in asyncHandler, so an
+  // uncaught throw would become an unhandled rejection and hang the
+  // request instead of hitting the existing { error } response path below.
+  try {
+    const { error: linkError } = await addCharacterToMission(SYSTEM_ACTOR, mission.id, characterId);
+    return { error: linkError || null };
+  } catch (error) {
+    return { error };
+  }
 };
 
 const appendCharacterPerks = async ({ characterId, submittedPerks }) => {

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -17,6 +17,7 @@ const {
   findUpgradeTargetsFor
 } = require('../models/character');
 const { getMission, createMission, addCharacterToMission } = require('../models/mission');
+const { SYSTEM_ACTOR } = require('../util/actor');
 const { getClasses, getClass, getUnlockedClassIdsForUser } = require('../models/class');
 const { getLfgPost } = require('../models/lfg');
 const { getProfileById, getProfileConduitCredits } = require('../models/profile');
@@ -112,17 +113,23 @@ const updateOwnedCharacterFields = async ({ characterId, profileId, fields }) =>
   return { data, error: null };
 };
 
+// Internal, non-user-triggered mission creation (the level-up backfill flow
+// synthesizes a mission for missions the character logged before the app
+// tracked them). Uses SYSTEM_ACTOR — not the acting profile — so the new
+// addCharacter authorization gate can't reject this internal link; creator_id
+// is still set explicitly so the mission shows up under the user's own missions.
 const createBackfillMissionForCharacter = async ({ characterId, name, profile }) => {
-  const { data: missionRows, error: missionError } = await createMission({
+  const { data: missionRows, error: missionError } = await createMission(SYSTEM_ACTOR, {
     name,
     date: new Date().toISOString(),
     outcome: 'success',
-    is_public: false
-  }, profile);
+    is_public: false,
+    creator_id: profile.id
+  });
   if (missionError) return { error: missionError };
   const mission = Array.isArray(missionRows) ? missionRows[0] : missionRows;
   if (!mission) return { error: { status: 400, message: 'Mission creation returned no rows' } };
-  const { error: linkError } = await addCharacterToMission(mission.id, characterId);
+  const { error: linkError } = await addCharacterToMission(SYSTEM_ACTOR, mission.id, characterId);
   return { error: linkError || null };
 };
 

--- a/routes/classes-stat-spread.test.js
+++ b/routes/classes-stat-spread.test.js
@@ -68,7 +68,7 @@ mock.module('../models/profile', () => ({
 
 mock.module('../models/class', () => ({
   // The route under test — capture the payload and return a created class.
-  createClass: async (payload) => {
+  createClass: async (actor, payload) => {
     capturedCreate = payload;
     return { data: { id: 'new-class-id', name: payload.name }, error: null };
   },

--- a/routes/classes.js
+++ b/routes/classes.js
@@ -25,6 +25,8 @@ const { storeClassPdf, getSignedPdfUrl, deletePdfObject, CLASS_PDF_BUCKET } = re
 const { getProfileById } = require('../models/profile');
 const { isAuthenticated, requireAdmin, authOptional } = require('../util/auth');
 const { sendError, FRIENDLY_NOT_FOUND } = require('../util/http-error');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 const { processClassImport } = require('../util/class-import');
 const { exportClass, getSupportedFormats, EXPORT_FORMATS } = require('../util/class-export');
 const { parseImageCrop } = require('../util/crop');
@@ -169,10 +171,9 @@ router.get('/import', isAuthenticated, (req, res) => {
 });
 
 router.post('/import', isAuthenticated, async (req, res) => {
-    const { profile } = res.locals;
     const { inputText } = req.body;
     try {
-        const importedClass = await processClassImport(inputText, profile);
+        const importedClass = await processClassImport(inputText, actorFromLocals(res.locals));
         const classData = Array.isArray(importedClass) ? importedClass[0] : importedClass;
         return res.header('HX-Location', `/classes/${classData.id}/${encodeURIComponent(classData.name)}`).send();
     } catch (error) {
@@ -514,12 +515,13 @@ router.post('/:id/unlock/self', isAuthenticated, async (req, res) => {
 });
 
 // Admin: generate unlock code for a class
-router.post('/:id/codes', isAuthenticated, requireAdmin, async (req, res) => {
+router.post('/:id/codes', isAuthenticated, requireAdmin, asyncHandler(async (req, res) => {
     const { id } = req.params;
     const { expires_at, max_uses, amount } = req.body;
     const createdByProfileId = res.locals.profile.id;
     const count = parseInt(amount, 10) || 1;
-    const { data, error } = await createUnlockCodes({ classId: id, createdByProfileId, expiresAt: expires_at || null, maxUses: max_uses || 1, amount: count });
+    const actor = actorFromLocals(res.locals);
+    const { data, error } = await createUnlockCodes(actor, { classId: id, createdByProfileId, expiresAt: expires_at || null, maxUses: max_uses || 1, amount: count });
     if (error) return sendError(req, res, error);
 
     if (count > 1) {
@@ -539,7 +541,7 @@ router.post('/:id/codes', isAuthenticated, requireAdmin, async (req, res) => {
         max_uses: code.max_uses,
         expires_at: code.expires_at
     });
-});
+}));
 
 // Admin: list unlock codes for a class
 router.get('/:id/codes', isAuthenticated, requireAdmin, async (req, res) => {
@@ -567,13 +569,14 @@ router.post('/redeem', isAuthenticated, async (req, res) => {
     }
 });
 
-router.post('/', isAuthenticated, upload.single('class_pdf'), async (req, res) => {
+router.post('/', isAuthenticated, upload.single('class_pdf'), asyncHandler(async (req, res) => {
     const { profile } = res.locals;
     const profileId = profile?.id;
     if (!profileId) {
         return sendError(req, res, null, { status: 500, message: 'Missing profile id' });
     }
-    
+    const actor = actorFromLocals(res.locals);
+
     // Process abilities and gear arrays
     const abilityNames = ensureArray(req.body['ability_name[]'] || req.body.ability_name);
     const abilityDescriptions = ensureArray(req.body['ability_description[]'] || req.body.ability_description);
@@ -622,9 +625,6 @@ router.post('/', isAuthenticated, upload.single('class_pdf'), async (req, res) =
         req.body.status = ['alpha', 'beta'].includes(req.body.status) ? req.body.status : 'alpha';
     }
 
-    // Always set created_by to the current profile
-    req.body.created_by = profileId;
-
     const image_crop = parseImageCrop(req.body.image_crop);
     if (image_crop !== undefined) {
         req.body.image_crop = image_crop;
@@ -632,7 +632,7 @@ router.post('/', isAuthenticated, upload.single('class_pdf'), async (req, res) =
 
     req.body.stat_spread = parseStatSpread(req.body);
 
-    const { data: classData, error } = await createClass(req.body);
+    const { data: classData, error } = await createClass(actor, req.body);
     if (error) {
         return sendError(req, res, error);
     }
@@ -642,30 +642,25 @@ router.post('/', isAuthenticated, upload.single('class_pdf'), async (req, res) =
         if (storageError) {
             return sendError(req, res, storageError, { status: 500, message: 'Failed to store class PDF' });
         }
-        const { error: metaError } = await saveClassPdfMetadata(classData.id, storageInfo.path);
+        const { error: metaError } = await saveClassPdfMetadata(actor, classData.id, storageInfo.path);
         if (metaError) {
             return sendError(req, res, metaError, { status: 500, message: 'Failed to update class PDF metadata' });
         }
     }
 
     return res.header('HX-Location', `/classes/${classData.id}/${encodeURIComponent(classData.name)}`).send();
-});
+}));
 
-router.put('/:id', isAuthenticated, upload.single('class_pdf'), async (req, res) => {
+router.put('/:id', isAuthenticated, upload.single('class_pdf'), asyncHandler(async (req, res) => {
     const { id } = req.params;
-    const { profile } = res.locals;
+    const actor = actorFromLocals(res.locals);
 
     const { data: existingClass, error: fetchError } = await getClass(id, res.locals.supabase);
     if (fetchError || !existingClass) {
         return sendError(req, res, fetchError, { status: 404, title: 'Not found', message: 'Class not found' });
     }
 
-    // Authz: only the class creator or an admin may update
-    const isAdminCaller = profile?.role === 'admin';
-    const isOwner = !!profile?.id && profile.id === existingClass.created_by;
-    if (!isAdminCaller && !isOwner) {
-        return sendError(req, res, null, { status: 403, title: 'No access', message: 'Not authorized' });
-    }
+    // Authz (owner-or-admin) is enforced by the service via classService.updateClass.
 
     const image_crop = parseImageCrop(req.body.image_crop);
     if (image_crop !== undefined) {
@@ -725,7 +720,7 @@ router.put('/:id', isAuthenticated, upload.single('class_pdf'), async (req, res)
 
     req.body.stat_spread = parseStatSpread(req.body);
 
-    const { data: classData, error } = await updateClass(id, req.body);
+    const { data: classData, error } = await updateClass(actor, id, req.body);
     if (error) {
         return sendError(req, res, error);
     }
@@ -735,39 +730,33 @@ router.put('/:id', isAuthenticated, upload.single('class_pdf'), async (req, res)
         if (storageError) {
             return sendError(req, res, storageError, { status: 500, message: 'Failed to store class PDF' });
         }
-        const { error: metaError } = await saveClassPdfMetadata(id, storageInfo.path);
+        const { error: metaError } = await saveClassPdfMetadata(actor, id, storageInfo.path);
         if (metaError) {
             return sendError(req, res, metaError, { status: 500, message: 'Failed to update class PDF metadata' });
         }
     } else if (removePdf && existingClass.pdf_storage_path) {
         await deletePdfObject({ bucket: CLASS_PDF_BUCKET, path: existingClass.pdf_storage_path });
-        await saveClassPdfMetadata(id, null);
+        await saveClassPdfMetadata(actor, id, null);
     }
 
     return res.header('HX-Location', `/classes/${id}/${encodeURIComponent(classData.name)}`).send();
-});
+}));
 
-// Delete a class (owner or admin)
-router.delete('/:id', isAuthenticated, async (req, res) => {
+// Delete a class (owner or admin; enforced by the service via classService.deleteClass)
+router.delete('/:id', isAuthenticated, asyncHandler(async (req, res) => {
     const { id } = req.params;
-    const { profile } = res.locals;
+    const actor = actorFromLocals(res.locals);
 
     const { data: existingClass, error: fetchError } = await getClass(id, res.locals.supabase);
     if (fetchError || !existingClass) {
         return sendError(req, res, fetchError, { status: 404, message: 'Class not found' });
     }
 
-    const isAdminCaller = profile?.role === 'admin';
-    const isOwner = !!profile?.id && profile.id === existingClass.created_by;
-    if (!isAdminCaller && !isOwner) {
-        return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
-    }
-
-    const { error } = await deleteClass(id);
+    const { error } = await deleteClass(actor, id);
     if (error) {
         return sendError(req, res, error);
     }
     return res.status(204).send();
-});
+}));
 
 module.exports = router;

--- a/routes/lfg.js
+++ b/routes/lfg.js
@@ -22,6 +22,8 @@ const { getOwnCharacters } = require('../models/character');
 const { isAuthenticated, authOptional } = require('../util/auth');
 const { sendError, FRIENDLY_NOT_FOUND } = require('../util/http-error');
 const { statList } = require('../util/enclave-consts');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 
 router.get('/', isAuthenticated, async (req, res) => {
   const { profile } = res.locals;
@@ -76,15 +78,16 @@ router.get('/new', isAuthenticated, async (req, res) => {
   res.render('partials/lfg-form', { layout: false, isNew: true, profile, characters });
 });
 
-router.post('/', isAuthenticated, async (req, res) => {
+router.post('/', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
-  const { data, error } = await createLfgPost(req.body, profile);
+  const actor = { ...actorFromLocals(res.locals), timezone: profile.timezone };
+  const { data, error } = await createLfgPost(actor, req.body);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', '/lfg').send();
   }
-});
+}));
 
 router.get('/:id', authOptional, async (req, res) => {
   const { profile } = res.locals;
@@ -137,25 +140,26 @@ router.get('/:id/edit', isAuthenticated, async (req, res) => {
   }
 });
 
-router.put('/:id', isAuthenticated, async (req, res) => {
+router.put('/:id', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
-  const { data, error } = await updateLfgPost(req.params.id, req.body, profile);
+  const actor = { ...actorFromLocals(res.locals), timezone: profile.timezone };
+  const { data, error } = await updateLfgPost(actor, req.params.id, req.body);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', `/lfg`).send();
   }
-});
+}));
 
-router.delete('/:id', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
-  const { data, error } = await deleteLfgPost(req.params.id, profile);
+router.delete('/:id', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { data, error } = await deleteLfgPost(actor, req.params.id);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', '/lfg').send();
   }
-});
+}));
 
 router.get('/:id/join', isAuthenticated, async (req, res) => {
   const { profile } = res.locals;
@@ -199,7 +203,7 @@ router.get('/:id/requests', isAuthenticated, async (req, res) => {
   }
 });
 
-router.put('/:id/requests/:requestId', isAuthenticated, async (req, res) => {
+router.put('/:id/requests/:requestId', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
   const { data: post, error: postError } = await getLfgPost(req.params.id, res.locals.supabase);
 
@@ -210,21 +214,23 @@ router.put('/:id/requests/:requestId', isAuthenticated, async (req, res) => {
     return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
   }
 
+  const actor = actorFromLocals(res.locals);
   const { status } = req.body;
-  const { data, error } = await updateJoinRequest(req.params.requestId, status, req.params.id);
+  const { data, error } = await updateJoinRequest(actor, req.params.requestId, status, req.params.id);
   if (error) {
     return sendError(req, res, error);
   } else {
     res.send('Request updated successfully');
   }
-});
+}));
 
-router.delete('/:id/join', isAuthenticated, async (req, res) => {
+router.delete('/:id/join', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
+  const actor = actorFromLocals(res.locals);
 
   const { data: request } = await getLfgJoinRequestForUserAndPost(profile.id, req.params.id, res.locals.supabase);
   if (request) {
-    const { error } = await deleteJoinRequest(request.id);
+    const { error } = await deleteJoinRequest(actor, request.id);
     if (error) {
       return sendError(req, res, error, { message: 'Failed to unjoin' });
     }
@@ -240,7 +246,7 @@ router.delete('/:id/join', isAuthenticated, async (req, res) => {
     return res.header('HX-Location', `/lfg`).send();
   }
   return sendError(req, res, null, { status: 400, message: 'No join request found' });
-});
+}));
 
 router.get('/events/all', isAuthenticated, async (req, res) => {
   const { profile } = res.locals;

--- a/routes/library.js
+++ b/routes/library.js
@@ -24,6 +24,8 @@ const { getProfileByNameAdmin, getProfileByIdAdmin } = require('../models/profil
 const { isAuthenticated, requireAdmin, authOptional } = require('../util/auth');
 const { sendError } = require('../util/http-error');
 const { expandRulesUnlocksByTitle } = require('../util/rules-family');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 
 const upload = multer({
     storage: multer.memoryStorage(),
@@ -264,12 +266,13 @@ router.delete('/:id/unlocks/:userId', isAuthenticated, requireAdmin, async (req,
 });
 
 // Admin: generate unlock codes for a rules PDF
-router.post('/:id/codes', isAuthenticated, requireAdmin, async (req, res) => {
+router.post('/:id/codes', isAuthenticated, requireAdmin, asyncHandler(async (req, res) => {
     const { id } = req.params;
     const { expires_at, max_uses, amount } = req.body;
     const createdByProfileId = res.locals.profile.id;
     const count = parseInt(amount, 10) || 1;
-    const { data, error } = await createRulesPdfUnlockCodes({
+    const actor = actorFromLocals(res.locals);
+    const { data, error } = await createRulesPdfUnlockCodes(actor, {
         rulesPdfId: id,
         createdByProfileId,
         expiresAt: parseExpiresAt(expires_at),
@@ -295,7 +298,7 @@ router.post('/:id/codes', isAuthenticated, requireAdmin, async (req, res) => {
         max_uses: codeRow.max_uses,
         expires_at: codeRow.expires_at
     });
-});
+}));
 
 // Admin: list unlock codes for a rules PDF
 router.get('/:id/codes', isAuthenticated, requireAdmin, async (req, res) => {

--- a/routes/missions.js
+++ b/routes/missions.js
@@ -33,6 +33,8 @@ const { statList, adventClassList, aspirantPreviewClassList, playerCreatedClassL
 const { isAuthenticated, authOptional } = require('../util/auth');
 const { sendError, FRIENDLY_NOT_FOUND } = require('../util/http-error');
 const { processMissionImport } = require('../util/mission-import');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 
 router.get('/search', authOptional, async (req, res) => {
   const { profile } = res.locals;
@@ -164,10 +166,10 @@ router.post('/import', isAuthenticated, async (req, res) => {
   }
 });
 
-router.post('/', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { characters, ...missionData } = req.body;
-  
+
   // Normalize host_id: empty string means no linked profile
   if (!missionData.host_id) {
     missionData.host_id = null;
@@ -184,16 +186,16 @@ router.post('/', isAuthenticated, async (req, res) => {
   } else {
     missionDate = new Date().toISOString();
   }
-  
+
   // Use form outcome or default to 'pending'
   const outcome = missionData.outcome || 'pending';
-  
+
   // Create the mission
-  const { data: missionRes, error: missionError } = await createMission({
+  const { data: missionRes, error: missionError } = await createMission(actor, {
     ...missionData,
     date: missionDate,
     outcome: outcome
-  }, profile);
+  });
 
   if (missionError) {
     return sendError(req, res, missionError);
@@ -207,7 +209,7 @@ router.post('/', isAuthenticated, async (req, res) => {
   // Add characters to the mission
   if (characters && characters.length > 0) {
     for (const characterId of characters) {
-      const { error: characterError } = await addCharacterToMission(mission.id, characterId);
+      const { error: characterError } = await addCharacterToMission(actor, mission.id, characterId);
       if (characterError) {
         return sendError(req, res, characterError);
       }
@@ -215,7 +217,7 @@ router.post('/', isAuthenticated, async (req, res) => {
   }
 
   return res.header('HX-Location', `/missions/${mission.id}/edit`).send();
-});
+}));
 
 // ============================================
 // Similar Missions / Deduplication Endpoints
@@ -296,8 +298,8 @@ router.get('/:id/edit', isAuthenticated, async (req, res) => {
   });
 });
 
-router.put('/:id', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.put('/:id', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   let { characters, unregistered_character_names, ...missionData } = req.body;
 
   delete missionData.q;
@@ -326,7 +328,7 @@ router.put('/:id', isAuthenticated, async (req, res) => {
   missionData.unregistered_character_names = unregisteredNames.filter(n => n && n.trim().length > 0);
   
   // Update the mission
-  const { data, error } = await updateMission(req.params.id, missionData, profile);
+  const { data, error } = await updateMission(actor, req.params.id, missionData);
   if (error) {
     return sendError(req, res, error);
   }
@@ -339,7 +341,7 @@ router.put('/:id', isAuthenticated, async (req, res) => {
   // Remove characters that are no longer in the mission
   for (const id of currentIds) {
     if (!newIds.includes(id)) {
-      const { error: removeError } = await removeCharacterFromMission(req.params.id, id);
+      const { error: removeError } = await removeCharacterFromMission(actor, req.params.id, id);
       if (removeError) {
         return sendError(req, res, removeError);
       }
@@ -349,7 +351,7 @@ router.put('/:id', isAuthenticated, async (req, res) => {
   // Add new characters
   for (const id of newIds) {
     if (!currentIds.includes(id)) {
-      const { error: addError } = await addCharacterToMission(req.params.id, id);
+      const { error: addError } = await addCharacterToMission(actor, req.params.id, id);
       if (addError) {
         return sendError(req, res, addError);
       }
@@ -357,26 +359,27 @@ router.put('/:id', isAuthenticated, async (req, res) => {
   }
 
   return res.header('HX-Location', `/missions/${req.params.id}`).send();
-});
+}));
 
-router.delete('/:id', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
-  const { error } = await deleteMission(req.params.id, profile);
+router.delete('/:id', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { error } = await deleteMission(actor, req.params.id);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', '/missions').send();
   }
-});
+}));
 
-router.post('/:id/characters/:characterId', isAuthenticated, async (req, res) => {
+router.post('/:id/characters/:characterId', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
+  const actor = actorFromLocals(res.locals);
   const { id, characterId } = req.params;
   const canEdit = await canEditMission(id, profile);
   if (!canEdit) {
     return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
   }
-  const { error } = await addCharacterToMission(id, characterId);
+  const { error } = await addCharacterToMission(actor, id, characterId);
   if (error) {
     return sendError(req, res, error);
   }
@@ -389,7 +392,7 @@ router.post('/:id/characters/:characterId', isAuthenticated, async (req, res) =>
     mission: { id },
     character: { id: character.id, name: character.name },
   });
-});
+}));
 
 // Search characters (JSON, for link UI)
 router.get('/:id/search-characters', isAuthenticated, async (req, res) => {
@@ -406,8 +409,9 @@ router.get('/:id/search-characters', isAuthenticated, async (req, res) => {
 
 // Link an unregistered character name to a real character
 // Adds the character to the mission and removes the unregistered name
-router.post('/:id/link-character', isAuthenticated, async (req, res) => {
+router.post('/:id/link-character', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
   const { character_id, unregistered_name } = req.body;
 
@@ -421,7 +425,7 @@ router.post('/:id/link-character', isAuthenticated, async (req, res) => {
   }
 
   // Add character to mission
-  const { error: addError } = await addCharacterToMission(id, character_id);
+  const { error: addError } = await addCharacterToMission(actor, id, character_id);
   if (addError) {
     return sendError(req, res, addError);
   }
@@ -431,7 +435,7 @@ router.post('/:id/link-character', isAuthenticated, async (req, res) => {
   if (mission) {
     const names = (mission.unregistered_character_names || [])
       .filter(n => n !== unregistered_name);
-    await setUnregisteredCharacterNames(id, names, profile);
+    await setUnregisteredCharacterNames(actor, id, names);
   }
 
   const { data: character, error: characterError } = await getCharacter(character_id, res.locals.supabase);
@@ -443,21 +447,22 @@ router.post('/:id/link-character', isAuthenticated, async (req, res) => {
     mission: { id },
     character: { id: character.id, name: character.name },
   });
-});
+}));
 
-router.delete('/:id/characters/:characterId', isAuthenticated, async (req, res) => {
+router.delete('/:id/characters/:characterId', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
+  const actor = actorFromLocals(res.locals);
   const { id, characterId } = req.params;
   const canEdit = await canEditMission(id, profile);
   if (!canEdit) {
     return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
   }
-  const { error } = await removeCharacterFromMission(id, characterId);
+  const { error } = await removeCharacterFromMission(actor, id, characterId);
   if (error) {
     return sendError(req, res, error);
   }
   return res.send('');
-});
+}));
 
 router.get('/character/:id', authOptional, async (req, res) => {
   const { profile } = res.locals;
@@ -532,8 +537,9 @@ router.get('/:id/editors', isAuthenticated, async (req, res) => {
 });
 
 // Add an editor to a mission
-router.post('/:id/editors', isAuthenticated, async (req, res) => {
+router.post('/:id/editors', isAuthenticated, asyncHandler(async (req, res) => {
   const { profile } = res.locals;
+  const actor = actorFromLocals(res.locals);
   const { id } = req.params;
   const { profile_id } = req.body;
 
@@ -546,12 +552,6 @@ router.post('/:id/editors', isAuthenticated, async (req, res) => {
     return sendError(req, res, null, { status: 400, message: 'Invalid profile ID format' });
   }
 
-  // Check if user can edit this mission
-  const canEdit = await canEditMission(id, profile);
-  if (!canEdit) {
-    return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
-  }
-
   // Prevent adding creator or host as editor (redundant)
   const { data: mission, error: missionError } = await getMission(id, res.locals.supabase);
   if (missionError) {
@@ -561,7 +561,8 @@ router.post('/:id/editors', isAuthenticated, async (req, res) => {
     return sendError(req, res, null, { status: 400, message: 'Creator and host are already editors by default' });
   }
 
-  const { error } = await addMissionEditor(id, profile_id, profile.id);
+  // Managing editors is creator-only — enforced by the service (addMissionEditor).
+  const { error } = await addMissionEditor(actor, id, profile_id);
   if (error) {
     return sendError(req, res, error);
   }
@@ -574,20 +575,15 @@ router.post('/:id/editors', isAuthenticated, async (req, res) => {
     missionId: id,
     canRemoveEditors: await isCreator(id, profile)
   });
-});
+}));
 
 // Remove an editor from a mission
-router.delete('/:id/editors/:profileId', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.delete('/:id/editors/:profileId', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id, profileId } = req.params;
 
-  // Only creator can remove editors
-  const creator = await isCreator(id, profile);
-  if (!creator) {
-    return sendError(req, res, null, { status: 403, title: 'No access', message: 'Only the mission creator can remove editors' });
-  }
-
-  const { error } = await removeMissionEditor(id, profileId);
+  // Managing editors is creator-only — enforced by the service (removeMissionEditor).
+  const { error } = await removeMissionEditor(actor, id, profileId);
   if (error) {
     return sendError(req, res, error);
   }
@@ -600,7 +596,7 @@ router.delete('/:id/editors/:profileId', isAuthenticated, async (req, res) => {
     missionId: id,
     canRemoveEditors: true
   });
-});
+}));
 
 // ============================================
 // Mission Merge Endpoints
@@ -638,16 +634,16 @@ router.get('/:id/merge/:targetId/preview', isAuthenticated, async (req, res) => 
 });
 
 // Execute a merge
-router.post('/:id/merge/:targetId', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/merge/:targetId', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id, targetId } = req.params;
 
-  const { data: mergedMission, error } = await mergeMissions(id, targetId, profile);
+  const { data: mergedMission, error } = await mergeMissions(actor, id, targetId);
   if (error) {
     return sendError(req, res, error);
   }
 
   return res.header('HX-Location', `/missions/${mergedMission.id}`).send();
-});
+}));
 
 module.exports = router;

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -11,6 +11,8 @@ const { createAgentToken, listAgentTokens, revokeAgentToken } = require('../mode
 const { getProfileBadges } = require('../models/badge');
 const { isAuthenticated, authOptional } = require('../util/auth');
 const { sendError } = require('../util/http-error');
+const { actorFromLocals } = require('../util/actor');
+const { asyncHandler } = require('../util/async-handler');
 
 router.get('/', isAuthenticated, async (req, res) => {
   const { user, profile } = res.locals;
@@ -95,8 +97,9 @@ router.get('/view/:name', authOptional, async (req, res) => {
   });
 });
 
-router.put('/', isAuthenticated, async (req, res) => {
+router.put('/', isAuthenticated, asyncHandler(async (req, res) => {
   const user = res.locals.user;
+  const actor = actorFromLocals(res.locals);
   const { email, password, name, bio, image_url, is_public, timezone, conduit_briefing } = req.body;
   const image_crop = parseImageCrop(req.body.image_crop);
   const profile = {
@@ -108,32 +111,34 @@ router.put('/', isAuthenticated, async (req, res) => {
     timezone,
     conduit_briefing
   }
-  const { data, error } = await updateUser(user.id, email, password, profile);
+  const { data, error } = await updateUser(actor, user.id, email, password, profile);
   if (error) {
     return sendError(req, res, error);
   } else {
     return res.header('HX-Location', '/profile').send();
   }
-});
+}));
 
-router.post('/discord/sync', isAuthenticated, async (req, res) => {
+router.post('/discord/sync', isAuthenticated, asyncHandler(async (req, res) => {
   const user = res.locals.user;
+  const actor = actorFromLocals(res.locals);
   const { discord_id, discord_email } = req.body;
-  const { error } = await setDiscordId(user.id, discord_id, discord_email);
+  const { error } = await setDiscordId(actor, user.id, discord_id, discord_email);
   if (error) {
     return sendError(req, res, error);
   }
   return res.status(204).send();
-});
+}));
 
-router.post('/discord/clear', isAuthenticated, async (req, res) => {
+router.post('/discord/clear', isAuthenticated, asyncHandler(async (req, res) => {
   const user = res.locals.user;
-  const { error } = await setDiscordId(user.id, null, null);
+  const actor = actorFromLocals(res.locals);
+  const { error } = await setDiscordId(actor, user.id, null, null);
   if (error) {
     return sendError(req, res, error);
   }
   return res.status(204).send();
-});
+}));
 
 router.get('/agent-tokens', isAuthenticated, async (req, res) => {
   const { user, profile } = res.locals;

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -140,57 +140,45 @@ router.post('/discord/clear', isAuthenticated, asyncHandler(async (req, res) => 
   return res.status(204).send();
 }));
 
-router.get('/agent-tokens', isAuthenticated, async (req, res) => {
-  const { user, profile } = res.locals;
+router.get('/agent-tokens', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const includeRevoked = req.query.include_revoked === 'true';
-  const { data, error } = await listAgentTokens({
-    userId: user.id,
-    profileId: profile.id,
-    includeRevoked
-  });
+  const { data, error } = await listAgentTokens(actor, { includeRevoked });
 
   if (error) {
     return res.status(500).json({ error: error.message });
   }
 
   return res.json({ tokens: data });
-});
+}));
 
-router.post('/agent-tokens', isAuthenticated, async (req, res) => {
-  const { user, profile } = res.locals;
+router.post('/agent-tokens', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const name = (req.body.name || '').trim();
 
   if (!name) {
     return res.status(400).json({ error: 'Token name is required' });
   }
 
-  const { data, error } = await createAgentToken({
-    userId: user.id,
-    profileId: profile.id,
-    name
-  });
+  const { data, error } = await createAgentToken(actor, { name });
 
   if (error) {
     return res.status(500).json({ error: error.message });
   }
 
   return res.status(201).json(data);
-});
+}));
 
-router.delete('/agent-tokens/:id', isAuthenticated, async (req, res) => {
-  const { user, profile } = res.locals;
-  const { data, error } = await revokeAgentToken({
-    tokenId: req.params.id,
-    userId: user.id,
-    profileId: profile.id
-  });
+router.delete('/agent-tokens/:id', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { data, error } = await revokeAgentToken(actor, { tokenId: req.params.id });
 
   if (error) {
     return res.status(404).json({ error: 'Token not found' });
   }
 
   return res.json(data);
-});
+}));
 
 // Search profiles (for adding editors, etc.)
 router.get('/search', isAuthenticated, async (req, res) => {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -11,6 +11,7 @@ const integrationFiles = new Set([
 ]);
 const httpFiles = new Set([
   'routes/badges.test.js',
+  'routes/bot-link-confirm.test.js',
   'routes/character-level-up.test.js',
   'routes/character-wizard.test.js',
   'routes/characters.test.js',

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -24,7 +24,7 @@ const testFiles = (dir) => readdirSync(join(root, dir), { withFileTypes: true })
     ? testFiles(`${dir}/${entry.name}`)
     : entry.name.endsWith('.test.js') ? [`${dir}/${entry.name}`] : []);
 
-const allFiles = ['models', 'routes', 'util', 'views'].flatMap(testFiles).sort();
+const allFiles = ['models', 'routes', 'services', 'util', 'views'].flatMap(testFiles).sort();
 const files = mode === 'integration'
   ? allFiles.filter(file => integrationFiles.has(file))
   : mode === 'http'

--- a/services/agent-token/policy.js
+++ b/services/agent-token/policy.js
@@ -1,0 +1,10 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// A caller may manage agent tokens owned by their own profile, or is
+// admin/system acting on behalf of a user.
+const canManageOwnTokens = (actor, ownerProfileId) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor && !!actor.profileId && actor.profileId === ownerProfileId;
+};
+
+module.exports = { canManageOwnTokens };

--- a/services/agent-token/policy.test.js
+++ b/services/agent-token/policy.test.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('bun:test');
+const { canManageOwnTokens } = require('./policy');
+
+test('a user may manage tokens owned by their own profile', () => {
+  expect(canManageOwnTokens({ profileId: 'p1', role: 'user' }, 'p1')).toBe(true);
+});
+
+test('a user may not manage tokens owned by another profile', () => {
+  expect(canManageOwnTokens({ profileId: 'p2', role: 'user' }, 'p1')).toBe(false);
+});
+
+test('admin and system may manage any profile\'s tokens', () => {
+  expect(canManageOwnTokens({ profileId: 'pX', role: 'admin' }, 'p1')).toBe(true);
+  expect(canManageOwnTokens({ role: 'system' }, 'p1')).toBe(true);
+});
+
+test('a missing/anonymous actor may not manage tokens', () => {
+  expect(canManageOwnTokens(null, 'p1')).toBe(false);
+  expect(canManageOwnTokens({ role: 'user' }, 'p1')).toBe(false);
+});

--- a/services/agent-token/repository.js
+++ b/services/agent-token/repository.js
@@ -1,0 +1,82 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin for the agent-token domain. Holds every
+// privileged (service-role) query verbatim; models/agent-token.js keeps the
+// surrounding logic (token generation/hashing).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+const TOKEN_ROW_SELECT = 'id, name, token_hint, created_at, last_used_at, revoked_at';
+
+module.exports = {
+  insertToken: (row) => withResult(
+    supabaseAdmin.from('agent_api_tokens').insert(row).select(TOKEN_ROW_SELECT).single()
+  ),
+
+  listTokens: ({ userId, profileId, includeRevoked = false }) => {
+    let query = supabaseAdmin
+      .from('agent_api_tokens')
+      .select(TOKEN_ROW_SELECT)
+      .eq('user_id', userId)
+      .eq('profile_id', profileId)
+      .order('created_at', { ascending: false });
+
+    if (!includeRevoked) {
+      query = query.is('revoked_at', null);
+    }
+
+    return withResult(query);
+  },
+
+  // Keeps the same self-scoping as the original model: a token can only be
+  // revoked by the user_id/profile_id that owns it, and only while active.
+  revokeToken: ({ tokenId, userId, profileId }) => withResult(
+    supabaseAdmin
+      .from('agent_api_tokens')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', tokenId)
+      .eq('user_id', userId)
+      .eq('profile_id', profileId)
+      .is('revoked_at', null)
+      .select(TOKEN_ROW_SELECT)
+      .single()
+  ),
+
+  // Authentication primitive lookup — always called with a hash (never a
+  // raw token). Returns the profile join needed to build the agent actor.
+  findTokenByHash: (tokenHash) => withResult(
+    supabaseAdmin
+      .from('agent_api_tokens')
+      .select('id, user_id, profile_id, name, token_hint, revoked_at, profile:profile_id(id, user_id, name, role, timezone)')
+      .eq('token_hash', tokenHash)
+      .is('revoked_at', null)
+      .single()
+  ),
+
+  // System write (no policy) — bumps the token's last-used timestamp on a
+  // successful authentication.
+  touchLastUsed: async (tokenId) => {
+    const { error } = await supabaseAdmin
+      .from('agent_api_tokens')
+      .update({ last_used_at: new Date().toISOString() })
+      .eq('id', tokenId);
+    if (error) console.error(error);
+    return { error: error || null };
+  },
+
+  // Task-8's bot-link claim route resolves a token's owning profile through
+  // this lookup; nothing in this task calls it yet.
+  fetchTokenWithProfile: (tokenId) => withResult(
+    supabaseAdmin
+      .from('agent_api_tokens')
+      .select('id, profile:profile_id(id, name)')
+      .eq('id', tokenId)
+      .single()
+  )
+};

--- a/services/agent-token/repository.test.js
+++ b/services/agent-token/repository.test.js
@@ -1,0 +1,25 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const repository = require('./repository');
+
+// Guards against a missed extraction: every privileged agent-token query
+// (including the auth-primitive lookup/write) must be reachable through the
+// repository, the sole consumer of supabaseAdmin for this domain.
+const expectedMethods = [
+  'insertToken',
+  'listTokens',
+  'revokeToken',
+  'findTokenByHash',
+  'touchLastUsed',
+  'fetchTokenWithProfile'
+];
+
+test('exports every repository method', () => {
+  for (const method of expectedMethods) {
+    expect(typeof repository[method]).toBe('function');
+  }
+});

--- a/services/agent-token/service.js
+++ b/services/agent-token/service.js
@@ -1,0 +1,137 @@
+const crypto = require('crypto');
+const { AuthorizationError } = require('../../util/errors');
+const { canManageOwnTokens } = require('./policy');
+
+const AGENT_TOKEN_PREFIX = 'ar_pat_';
+const AGENT_TOKEN_BYTES = 24;
+
+const hashAgentToken = (token) => crypto.createHash('sha256').update(token).digest('hex');
+
+const generateAgentToken = () => {
+  const secret = crypto.randomBytes(AGENT_TOKEN_BYTES).toString('base64url');
+  const token = `${AGENT_TOKEN_PREFIX}${secret}`;
+  return {
+    token,
+    tokenHint: secret.slice(-4)
+  };
+};
+
+const REQUIRED_REPOSITORY_METHODS = [
+  'insertToken',
+  'listTokens',
+  'revokeToken',
+  'findTokenByHash',
+  'touchLastUsed'
+];
+
+const requireOwner = (actor, ownerProfileId) => {
+  if (!canManageOwnTokens(actor, ownerProfileId)) {
+    throw new AuthorizationError('Not authorized to manage this agent token', { reason: 'not_owner' });
+  }
+};
+
+/** Application boundary for agent-token commands: policy -> validate -> mutate.
+ * create/list/revoke act on the caller's own profile (owner defaults to the
+ * actor's own userId/profileId; an explicit override is only honored for
+ * admin/system actors — see canManageOwnTokens). verifyAgentToken is the
+ * authentication primitive that PRODUCES an actor, so it takes none and
+ * bypasses policy entirely. */
+class AgentTokenService {
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`AgentTokenService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
+  }
+
+  async createToken(actor, { name, userId, profileId } = {}) {
+    const ownerProfileId = profileId ?? actor?.profileId ?? null;
+    const ownerUserId = userId ?? actor?.userId ?? null;
+    requireOwner(actor, ownerProfileId);
+
+    const trimmedName = (name || '').trim();
+    if (!ownerUserId || !ownerProfileId) {
+      return { data: null, error: new Error('Missing user context') };
+    }
+    if (!trimmedName) {
+      return { data: null, error: new Error('Token name is required') };
+    }
+
+    const { token, tokenHint } = generateAgentToken();
+    const tokenHash = hashAgentToken(token);
+
+    const { data, error } = await this.repo.insertToken({
+      user_id: ownerUserId,
+      profile_id: ownerProfileId,
+      name: trimmedName,
+      token_hash: tokenHash,
+      token_hint: tokenHint
+    });
+
+    if (error) {
+      return { data: null, error };
+    }
+
+    return {
+      data: {
+        ...data,
+        token
+      },
+      error: null
+    };
+  }
+
+  async listTokens(actor, { userId, profileId, includeRevoked = false } = {}) {
+    const ownerProfileId = profileId ?? actor?.profileId ?? null;
+    const ownerUserId = userId ?? actor?.userId ?? null;
+    requireOwner(actor, ownerProfileId);
+
+    if (!ownerUserId || !ownerProfileId) {
+      return { data: null, error: new Error('Missing user context') };
+    }
+
+    return this.repo.listTokens({ userId: ownerUserId, profileId: ownerProfileId, includeRevoked });
+  }
+
+  async revokeToken(actor, { tokenId, userId, profileId } = {}) {
+    const ownerProfileId = profileId ?? actor?.profileId ?? null;
+    const ownerUserId = userId ?? actor?.userId ?? null;
+    requireOwner(actor, ownerProfileId);
+
+    if (!tokenId || !ownerUserId || !ownerProfileId) {
+      return { data: null, error: new Error('Missing revoke context') };
+    }
+
+    return this.repo.revokeToken({ tokenId, userId: ownerUserId, profileId: ownerProfileId });
+  }
+
+  // Authentication primitive: verifies a raw bearer token and returns the
+  // actor-shaped payload util/auth.js needs to populate res.locals. Takes no
+  // actor (it produces one) and performs no authorization check — there is
+  // nothing to authorize yet.
+  async verifyAgentToken(token) {
+    if (!token || !token.startsWith(AGENT_TOKEN_PREFIX)) {
+      return { data: null, error: new Error('Invalid token format') };
+    }
+
+    const tokenHash = hashAgentToken(token);
+    const { data, error } = await this.repo.findTokenByHash(tokenHash);
+    if (error) {
+      return { data: null, error };
+    }
+
+    await this.repo.touchLastUsed(data.id);
+
+    return {
+      data: {
+        tokenId: data.id,
+        tokenName: data.name,
+        tokenHint: data.token_hint,
+        userId: data.user_id,
+        profile: data.profile
+      },
+      error: null
+    };
+  }
+}
+
+module.exports = { AgentTokenService, AGENT_TOKEN_PREFIX };

--- a/services/agent-token/service.test.js
+++ b/services/agent-token/service.test.js
@@ -1,0 +1,147 @@
+const { test, expect } = require('bun:test');
+const { AgentTokenService, AGENT_TOKEN_PREFIX } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
+
+const TOKEN_ROW = { id: 'token-1', name: 'Bot', token_hint: 'abcd', created_at: 't', last_used_at: null, revoked_at: null };
+
+const makeRepo = ({ hashLookupRow } = {}) => {
+  const calls = [];
+  return {
+    calls,
+    insertToken: async (row) => { calls.push(['insertToken', row]); return { data: { ...TOKEN_ROW }, error: null }; },
+    listTokens: async (opts) => { calls.push(['listTokens', opts]); return { data: [TOKEN_ROW], error: null }; },
+    revokeToken: async (opts) => { calls.push(['revokeToken', opts]); return { data: TOKEN_ROW, error: null }; },
+    findTokenByHash: async (hash) => {
+      calls.push(['findTokenByHash', hash]);
+      return { data: hashLookupRow !== undefined ? hashLookupRow : {
+        id: 'token-1', user_id: 'u1', profile_id: 'p1', name: 'Bot', token_hint: 'abcd', revoked_at: null,
+        profile: { id: 'p1', user_id: 'u1', name: 'Bot Profile', role: 'user', timezone: 'UTC' }
+      }, error: null };
+    },
+    touchLastUsed: async (tokenId) => { calls.push(['touchLastUsed', tokenId]); return { error: null }; }
+  };
+};
+
+const SELF_ACTOR = { userId: 'u1', profileId: 'p1', role: 'user' };
+const OTHER_ACTOR = { userId: 'u2', profileId: 'p2', role: 'user' };
+const ADMIN_ACTOR = { userId: 'admin-1', profileId: 'admin-profile', role: 'admin' };
+const SYSTEM_ACTOR = { role: 'system' };
+
+test('constructor requires every repository method', () => {
+  expect(() => new AgentTokenService({})).toThrow(TypeError);
+});
+
+test('createToken derives the owner from the actor and inserts a hashed token row', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  const { data, error } = await service.createToken(SELF_ACTOR, { name: '  My Bot  ' });
+  expect(error).toBe(null);
+  expect(repo.calls).toHaveLength(1);
+  const [method, row] = repo.calls[0];
+  expect(method).toBe('insertToken');
+  expect(row.user_id).toBe('u1');
+  expect(row.profile_id).toBe('p1');
+  expect(row.name).toBe('My Bot');
+  expect(typeof row.token_hash).toBe('string');
+  expect(data.token.startsWith(AGENT_TOKEN_PREFIX)).toBe(true);
+});
+
+test('createToken rejects an empty name without reaching the repository', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  const { data, error } = await service.createToken(SELF_ACTOR, { name: '   ' });
+  expect(data).toBe(null);
+  expect(error.message).toBe('Token name is required');
+  expect(repo.calls).toEqual([]);
+});
+
+test('createToken throws AuthorizationError when a caller claims a profile that is not their own', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  await expect(service.createToken(OTHER_ACTOR, { name: 'Bot', profileId: 'p1', userId: 'u1' }))
+    .rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('admin may create a token on behalf of another profile', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  await service.createToken(ADMIN_ACTOR, { name: 'Bot', profileId: 'p1', userId: 'u1' });
+  expect(repo.calls[0][1].profile_id).toBe('p1');
+});
+
+test('listTokens lists the caller\'s own tokens', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  const { data, error } = await service.listTokens(SELF_ACTOR, { includeRevoked: true });
+  expect(error).toBe(null);
+  expect(data).toEqual([TOKEN_ROW]);
+  expect(repo.calls).toEqual([['listTokens', { userId: 'u1', profileId: 'p1', includeRevoked: true }]]);
+});
+
+test('listTokens throws AuthorizationError for a mismatched profile, never reaching the repository', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  await expect(service.listTokens(OTHER_ACTOR, { profileId: 'p1', userId: 'u1' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('revokeToken revokes the caller\'s own token', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  const { data, error } = await service.revokeToken(SELF_ACTOR, { tokenId: 'token-1' });
+  expect(error).toBe(null);
+  expect(data).toEqual(TOKEN_ROW);
+  expect(repo.calls).toEqual([['revokeToken', { tokenId: 'token-1', userId: 'u1', profileId: 'p1' }]]);
+});
+
+test('revoking another profile\'s token throws AuthorizationError, never reaching the repository', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  await expect(service.revokeToken(OTHER_ACTOR, { tokenId: 'token-1', profileId: 'p1', userId: 'u1' }))
+    .rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('the system actor may revoke a token on behalf of any profile', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  await service.revokeToken(SYSTEM_ACTOR, { tokenId: 'token-1', profileId: 'p1', userId: 'u1' });
+  expect(repo.calls).toEqual([['revokeToken', { tokenId: 'token-1', userId: 'u1', profileId: 'p1' }]]);
+});
+
+test('verifyAgentToken rejects a malformed token before touching the repository', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  const { data, error } = await service.verifyAgentToken('not-a-real-token');
+  expect(data).toBe(null);
+  expect(error.message).toBe('Invalid token format');
+  expect(repo.calls).toEqual([]);
+});
+
+test('verifyAgentToken looks up the hash, touches last_used_at, and returns the actor-shaped payload', async () => {
+  const repo = makeRepo();
+  const service = new AgentTokenService(repo);
+  const token = `${AGENT_TOKEN_PREFIX}abcdef`;
+  const { data, error } = await service.verifyAgentToken(token);
+  expect(error).toBe(null);
+  expect(data).toEqual({
+    tokenId: 'token-1',
+    tokenName: 'Bot',
+    tokenHint: 'abcd',
+    userId: 'u1',
+    profile: { id: 'p1', user_id: 'u1', name: 'Bot Profile', role: 'user', timezone: 'UTC' }
+  });
+  expect(repo.calls.map(c => c[0])).toEqual(['findTokenByHash', 'touchLastUsed']);
+  expect(repo.calls[1][1]).toBe('token-1');
+});
+
+test('verifyAgentToken propagates a repository lookup error without touching last_used_at', async () => {
+  const repo = makeRepo();
+  repo.findTokenByHash = async (hash) => { repo.calls.push(['findTokenByHash', hash]); return { data: null, error: new Error('not found') }; };
+  const service = new AgentTokenService(repo);
+  const { data, error } = await service.verifyAgentToken(`${AGENT_TOKEN_PREFIX}xyz`);
+  expect(data).toBe(null);
+  expect(error.message).toBe('not found');
+  expect(repo.calls).toEqual([['findTokenByHash', expect.any(String)]]);
+});

--- a/services/badge/policy.js
+++ b/services/badge/policy.js
@@ -1,0 +1,11 @@
+const { isAdmin } = require('../../util/actor');
+
+// Only admins grant or revoke non-milestone badges (today's requireAdmin
+// route). Deliberately admin-only, not admin-or-system like class/rules
+// unlock-code minting: milestone badges are earned automatically via
+// recalculateMilestoneBadges (system-by-construction, no policy call at
+// all), and there is no other system caller for grant/revoke.
+const canGrantBadge = (actor) => isAdmin(actor);
+const canRevokeBadge = (actor) => isAdmin(actor);
+
+module.exports = { canGrantBadge, canRevokeBadge };

--- a/services/badge/policy.test.js
+++ b/services/badge/policy.test.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('bun:test');
+const { canGrantBadge, canRevokeBadge } = require('./policy');
+
+const ADMIN_ACTOR = { profileId: 'admin-1', role: 'admin' };
+const USER_ACTOR = { profileId: 'p1', role: 'user' };
+const SYSTEM_ACTOR = { role: 'system' };
+
+test('an admin may grant a badge', () => {
+  expect(canGrantBadge(ADMIN_ACTOR)).toBe(true);
+});
+
+test('a non-admin user may not grant a badge', () => {
+  expect(canGrantBadge(USER_ACTOR)).toBe(false);
+});
+
+// Grant/revoke are human-admin actions with no system caller today (unlike
+// milestone recalc, which is system-by-construction) — deliberately not
+// admin-or-system.
+test('the system actor may not grant a badge', () => {
+  expect(canGrantBadge(SYSTEM_ACTOR)).toBe(false);
+});
+
+test('an admin may revoke a badge', () => {
+  expect(canRevokeBadge(ADMIN_ACTOR)).toBe(true);
+});
+
+test('a non-admin user may not revoke a badge', () => {
+  expect(canRevokeBadge(USER_ACTOR)).toBe(false);
+});
+
+test('the system actor may not revoke a badge', () => {
+  expect(canRevokeBadge(SYSTEM_ACTOR)).toBe(false);
+});

--- a/services/badge/repository.js
+++ b/services/badge/repository.js
@@ -1,0 +1,105 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+const BADGES_BUCKET = process.env.SUPABASE_BADGES_BUCKET || 'badges';
+
+// The only consumer of supabaseAdmin for the badge domain. Holds every
+// privileged (service-role) query verbatim; models/badge.js keeps the
+// surrounding logic (counter math, milestone gating, display-shelf shaping).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+module.exports = {
+  BADGES_BUCKET,
+
+  // Reads
+  // Counters deliberately use supabaseAdmin: private missions count toward
+  // badges, and the shared anon client (no JWT) would be RLS-filtered.
+  countMissionsPlayed: (profileId) => withResult(
+    supabaseAdmin
+      .from('mission_characters')
+      .select('mission_id, characters!inner(creator_id)')
+      .eq('characters.creator_id', profileId)
+  ),
+  countMissionsHosted: (profileId) => withResult(
+    supabaseAdmin.from('missions').select('id').eq('host_id', profileId)
+  ),
+  // Shared by milestone recalc (id/track/threshold) and the profile-badges
+  // progress shelf (track/threshold/name) — one active-milestone-catalog
+  // projection serves both call sites.
+  fetchActiveMilestoneBadges: () => withResult(
+    supabaseAdmin
+      .from('badges')
+      .select('id, track, threshold, name')
+      .eq('category', 'milestone')
+      .eq('is_active', true)
+      .order('threshold', { ascending: true })
+  ),
+  // All profiles affected by a mission: host + creators of attached
+  // characters. Used by delete/merge hooks, which must capture this BEFORE
+  // the mutation.
+  fetchMissionHostId: (missionId) => withResult(
+    supabaseAdmin.from('missions').select('host_id').eq('id', missionId).maybeSingle()
+  ),
+  fetchMissionCharacterCreators: (missionId) => withResult(
+    supabaseAdmin
+      .from('mission_characters')
+      .select('character:characters(creator_id)')
+      .eq('mission_id', missionId)
+  ),
+  publicBadgeImageUrl: (imagePath) =>
+    supabaseAdmin.storage.from(BADGES_BUCKET).getPublicUrl(imagePath).data.publicUrl,
+  listProfileBadgeRows: (profileId) => withResult(
+    supabaseAdmin
+      .from('profile_badges')
+      .select('awarded_at, granted_by, badge:badges(id, slug, name, description, category, track, rank, threshold, image_path, is_active)')
+      .eq('profile_id', profileId)
+      .order('awarded_at', { ascending: true })
+  ),
+  fetchBadgeCatalog: () => withResult(
+    supabaseAdmin
+      .from('badges')
+      .select('*')
+      .eq('is_active', true)
+      .order('category', { ascending: true })
+      .order('track', { ascending: true })
+      .order('rank', { ascending: true })
+      .order('name', { ascending: true })
+  ),
+  // Authz-support read for grant/revoke: the authoritative gate (milestone
+  // category / inactive / unknown slug) is applied by the caller against
+  // this row, not here.
+  fetchGrantableBadgeBySlug: (slug) => withResult(
+    supabaseAdmin.from('badges').select('id, slug, category, is_active').eq('slug', slug).maybeSingle()
+  ),
+
+  // Writes
+  // Insert-only: badges are permanent once earned. ignoreDuplicates keeps
+  // the original awarded_at (and any granted_by) on re-runs — backfill and
+  // live hooks share this single code path so retroactive and ongoing
+  // awards cannot drift.
+  upsertProfileBadges: (rows) => withResult(
+    supabaseAdmin
+      .from('profile_badges')
+      .upsert(rows, { onConflict: 'profile_id,badge_id', ignoreDuplicates: true })
+  ),
+  upsertGrantedBadge: (row) => withResult(
+    supabaseAdmin
+      .from('profile_badges')
+      .upsert(row, { onConflict: 'profile_id,badge_id', ignoreDuplicates: true })
+  ),
+  deleteProfileBadge: async ({ profileId, badgeId }) => {
+    const { error } = await supabaseAdmin
+      .from('profile_badges')
+      .delete()
+      .eq('profile_id', profileId)
+      .eq('badge_id', badgeId);
+    if (error) console.error(error);
+    return { error: error || null };
+  }
+};

--- a/services/badge/service.js
+++ b/services/badge/service.js
@@ -1,0 +1,68 @@
+const { AuthorizationError } = require('../../util/errors');
+const { canGrantBadge, canRevokeBadge } = require('./policy');
+
+const REQUIRED_REPOSITORY_METHODS = [
+  'fetchGrantableBadgeBySlug',
+  'upsertGrantedBadge',
+  'deleteProfileBadge'
+];
+
+// Milestone badges are automatic-only: enforced here (the authoritative
+// gate), not just in the routes. This is a domain rule about which badges
+// are grantable at all, independent of who is asking — not a policy
+// predicate, so it lives in the service rather than policy.js.
+const findGrantableBadge = async (repo, badgeSlug) => {
+  const { data: badgeRow, error } = await repo.fetchGrantableBadgeBySlug(badgeSlug);
+  if (error) return { data: null, error };
+  if (!badgeRow || !badgeRow.is_active) {
+    return { data: null, error: new Error('Badge not found') };
+  }
+  if (badgeRow.category === 'milestone') {
+    return { data: null, error: new Error('Milestone badges are awarded automatically and cannot be granted or revoked') };
+  }
+  return { data: badgeRow, error: null };
+};
+
+/** Application boundary for badge grant/revoke: policy -> domain guard ->
+ * throw-or-mutate. Milestone recalculation is system-by-construction (no
+ * user authorization exists for it) and never routes through this service —
+ * models/badge.js calls the repository directly for that, mirroring
+ * services/rules. */
+class BadgeService {
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`BadgeService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
+  }
+
+  async grantBadge(actor, { profileId, badgeSlug, grantedById }) {
+    if (!canGrantBadge(actor)) {
+      throw new AuthorizationError('Not authorized to grant badges', { reason: 'not_admin' });
+    }
+    const { data: badgeRow, error } = await findGrantableBadge(this.repo, badgeSlug);
+    if (error) return { data: null, error };
+
+    const { error: upsertError } = await this.repo.upsertGrantedBadge({
+      profile_id: profileId,
+      badge_id: badgeRow.id,
+      granted_by: grantedById || null
+    });
+    if (upsertError) return { data: null, error: upsertError };
+    return { data: { slug: badgeRow.slug }, error: null };
+  }
+
+  // Revoking a badge the profile doesn't hold deletes 0 rows — no-op success.
+  async revokeBadge(actor, { profileId, badgeSlug }) {
+    if (!canRevokeBadge(actor)) {
+      throw new AuthorizationError('Not authorized to revoke badges', { reason: 'not_admin' });
+    }
+    const { data: badgeRow, error } = await findGrantableBadge(this.repo, badgeSlug);
+    if (error) return { data: null, error };
+
+    const { error: deleteError } = await this.repo.deleteProfileBadge({ profileId, badgeId: badgeRow.id });
+    if (deleteError) return { data: null, error: deleteError };
+    return { data: { slug: badgeRow.slug }, error: null };
+  }
+}
+
+module.exports = { BadgeService };

--- a/services/badge/service.test.js
+++ b/services/badge/service.test.js
@@ -1,0 +1,93 @@
+const { test, expect } = require('bun:test');
+const { BadgeService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
+
+const MILESTONE_BADGE = { id: 'b-milestone', slug: 'newcomer-1', category: 'milestone', is_active: true };
+const EVENT_BADGE = { id: 'b-event', slug: 'enclave-day-1', category: 'event', is_active: true };
+const INACTIVE_BADGE = { id: 'b-inactive', slug: 'retired', category: 'event', is_active: false };
+
+const makeRepo = ({ badgesBySlug = {} } = {}) => {
+  const calls = [];
+  return {
+    calls,
+    fetchGrantableBadgeBySlug: async (slug) => {
+      calls.push(['fetchGrantableBadgeBySlug', slug]);
+      return { data: badgesBySlug[slug] || null, error: null };
+    },
+    upsertGrantedBadge: async (row) => { calls.push(['upsertGrantedBadge', row]); return { data: row, error: null }; },
+    deleteProfileBadge: async (args) => { calls.push(['deleteProfileBadge', args]); return { error: null }; }
+  };
+};
+
+const ADMIN_ACTOR = { profileId: 'admin-1', role: 'admin' };
+const USER_ACTOR = { profileId: 'p1', role: 'user' };
+
+test('constructor requires every repository method', () => {
+  expect(() => new BadgeService({})).toThrow(TypeError);
+});
+
+test('an admin may grant a non-milestone badge; the write reaches the repository', async () => {
+  const repo = makeRepo({ badgesBySlug: { 'enclave-day-1': EVENT_BADGE } });
+  const service = new BadgeService(repo);
+  const result = await service.grantBadge(ADMIN_ACTOR, { profileId: 'p2', badgeSlug: 'enclave-day-1', grantedById: 'admin-1' });
+  expect(result).toEqual({ data: { slug: 'enclave-day-1' }, error: null });
+  expect(repo.calls).toEqual([
+    ['fetchGrantableBadgeBySlug', 'enclave-day-1'],
+    ['upsertGrantedBadge', { profile_id: 'p2', badge_id: 'b-event', granted_by: 'admin-1' }]
+  ]);
+});
+
+test('a non-admin granting a badge throws AuthorizationError, never reaching the repository', async () => {
+  const repo = makeRepo({ badgesBySlug: { 'enclave-day-1': EVENT_BADGE } });
+  const service = new BadgeService(repo);
+  await expect(service.grantBadge(USER_ACTOR, { profileId: 'p2', badgeSlug: 'enclave-day-1' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('granting a milestone badge is rejected as a domain error, not an authorization error', async () => {
+  const repo = makeRepo({ badgesBySlug: { 'newcomer-1': MILESTONE_BADGE } });
+  const service = new BadgeService(repo);
+  const result = await service.grantBadge(ADMIN_ACTOR, { profileId: 'p2', badgeSlug: 'newcomer-1' });
+  expect(result.data).toBeNull();
+  expect(result.error.message).toMatch(/milestone/i);
+  expect(repo.calls).toEqual([['fetchGrantableBadgeBySlug', 'newcomer-1']]);
+});
+
+test('granting an unknown badge slug returns a not-found domain error', async () => {
+  const repo = makeRepo();
+  const service = new BadgeService(repo);
+  const result = await service.grantBadge(ADMIN_ACTOR, { profileId: 'p2', badgeSlug: 'does-not-exist' });
+  expect(result.error.message).toBe('Badge not found');
+});
+
+test('granting an inactive badge returns a not-found domain error', async () => {
+  const repo = makeRepo({ badgesBySlug: { retired: INACTIVE_BADGE } });
+  const service = new BadgeService(repo);
+  const result = await service.grantBadge(ADMIN_ACTOR, { profileId: 'p2', badgeSlug: 'retired' });
+  expect(result.error.message).toBe('Badge not found');
+});
+
+test('an admin may revoke a badge; the delete reaches the repository', async () => {
+  const repo = makeRepo({ badgesBySlug: { 'enclave-day-1': EVENT_BADGE } });
+  const service = new BadgeService(repo);
+  const result = await service.revokeBadge(ADMIN_ACTOR, { profileId: 'p2', badgeSlug: 'enclave-day-1' });
+  expect(result).toEqual({ data: { slug: 'enclave-day-1' }, error: null });
+  expect(repo.calls).toEqual([
+    ['fetchGrantableBadgeBySlug', 'enclave-day-1'],
+    ['deleteProfileBadge', { profileId: 'p2', badgeId: 'b-event' }]
+  ]);
+});
+
+test('a non-admin revoking a badge throws AuthorizationError, never reaching the repository', async () => {
+  const repo = makeRepo({ badgesBySlug: { 'enclave-day-1': EVENT_BADGE } });
+  const service = new BadgeService(repo);
+  await expect(service.revokeBadge(USER_ACTOR, { profileId: 'p2', badgeSlug: 'enclave-day-1' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('revoking a milestone badge is rejected as a domain error', async () => {
+  const repo = makeRepo({ badgesBySlug: { 'newcomer-1': MILESTONE_BADGE } });
+  const service = new BadgeService(repo);
+  const result = await service.revokeBadge(ADMIN_ACTOR, { profileId: 'p2', badgeSlug: 'newcomer-1' });
+  expect(result.error.message).toMatch(/milestone/i);
+});

--- a/services/bot-link/policy.js
+++ b/services/bot-link/policy.js
@@ -1,0 +1,24 @@
+const { isSystem } = require('../../util/actor');
+
+// Authorization for this domain is by protocol/possession, not identity: the
+// Discord bot and the browser confirm page act as unauthenticated or
+// pseudonymous callers for the claim step. A caller proves the right to
+// consume a pending link by presenting the exact code + discord_user_id pair
+// the link was minted for — there is no user identity to check against.
+// This predicate documents that decision explicitly; it never throws (the
+// PUBLIC claim route maps a `false` result to its own protocol status code).
+const canClaimByPossession = (link, { code, discordUserId }) =>
+  !!link &&
+  link.code === code &&
+  link.discord_user_id === discordUserId &&
+  !link.consumed_at &&
+  !!link.agent_token_id;
+
+// Attaching a freshly-minted agent token to a pending link is performed by
+// the authenticated web user who just created that token in the same
+// request (or the system actor). The `agent_token_id == null` guard ensures
+// a link can only ever be attached once.
+const canAttachToken = (actor, link) =>
+  isSystem(actor) || (!!actor?.profileId && !!link && link.agent_token_id == null);
+
+module.exports = { canClaimByPossession, canAttachToken };

--- a/services/bot-link/policy.test.js
+++ b/services/bot-link/policy.test.js
@@ -1,0 +1,54 @@
+const { test, expect } = require('bun:test');
+const { canClaimByPossession, canAttachToken } = require('./policy');
+
+const attachedLink = () => ({
+  code: 'ABCD1234',
+  discord_user_id: 'discord-1',
+  consumed_at: null,
+  agent_token_id: 'token-1'
+});
+
+test('canClaimByPossession allows an exact code+discord match on an attached, unconsumed link', () => {
+  expect(canClaimByPossession(attachedLink(), { code: 'ABCD1234', discordUserId: 'discord-1' })).toBe(true);
+});
+
+test('canClaimByPossession rejects a mismatched discord_user_id', () => {
+  expect(canClaimByPossession(attachedLink(), { code: 'ABCD1234', discordUserId: 'someone-else' })).toBe(false);
+});
+
+test('canClaimByPossession rejects a mismatched code', () => {
+  expect(canClaimByPossession(attachedLink(), { code: 'WRONGCOD', discordUserId: 'discord-1' })).toBe(false);
+});
+
+test('canClaimByPossession rejects an already-consumed link', () => {
+  const link = { ...attachedLink(), consumed_at: '2020-01-01T00:00:00.000Z' };
+  expect(canClaimByPossession(link, { code: 'ABCD1234', discordUserId: 'discord-1' })).toBe(false);
+});
+
+test('canClaimByPossession rejects a link with no token attached yet (still pending)', () => {
+  const link = { ...attachedLink(), agent_token_id: null };
+  expect(canClaimByPossession(link, { code: 'ABCD1234', discordUserId: 'discord-1' })).toBe(false);
+});
+
+test('canClaimByPossession rejects a missing link', () => {
+  expect(canClaimByPossession(null, { code: 'ABCD1234', discordUserId: 'discord-1' })).toBe(false);
+  expect(canClaimByPossession(undefined, { code: 'ABCD1234', discordUserId: 'discord-1' })).toBe(false);
+});
+
+test('canAttachToken allows an authenticated actor to attach to an unattached link', () => {
+  expect(canAttachToken({ profileId: 'profile-1', role: 'user' }, { agent_token_id: null })).toBe(true);
+});
+
+test('canAttachToken rejects an anonymous/profile-less actor', () => {
+  expect(canAttachToken({ profileId: null, role: 'user' }, { agent_token_id: null })).toBe(false);
+  expect(canAttachToken(null, { agent_token_id: null })).toBe(false);
+});
+
+test('canAttachToken rejects a link that already has a token attached', () => {
+  expect(canAttachToken({ profileId: 'profile-1', role: 'user' }, { agent_token_id: 'token-1' })).toBe(false);
+});
+
+test('canAttachToken allows the system actor regardless of link state', () => {
+  expect(canAttachToken({ role: 'system' }, { agent_token_id: 'token-1' })).toBe(true);
+  expect(canAttachToken({ role: 'system' }, null)).toBe(true);
+});

--- a/services/bot-link/repository.js
+++ b/services/bot-link/repository.js
@@ -1,0 +1,115 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin for the bot-link domain. Holds every
+// privileged (service-role) query verbatim; models/bot-link.js keeps the
+// surrounding pure logic (code generation/formatting/validation).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+const PENDING_LINK_SELECT = 'code, discord_user_id, agent_token_id, created_at, expires_at, consumed_at';
+
+module.exports = {
+  // System write (no policy) — periodic cleanup of abandoned rows.
+  deleteStaleLinks: async (olderThanIso) => {
+    const { error } = await supabaseAdmin
+      .from('pending_bot_links')
+      .delete()
+      .lt('created_at', olderThanIso);
+    if (error) console.error(error);
+    return { error: error || null };
+  },
+
+  // Rate-limit gate for starting a new link, keyed by discord_user_id.
+  countRecentPending: async (discordUserId, sinceIso) => {
+    const { count, error } = await supabaseAdmin
+      .from('pending_bot_links')
+      .select('code', { count: 'exact', head: true })
+      .eq('discord_user_id', discordUserId)
+      .gte('created_at', sinceIso)
+      .is('consumed_at', null);
+    if (error) return { count: 0, error };
+    return { count: count || 0, error: null };
+  },
+
+  // PUBLIC — the Discord bot starts a link for itself; row is keyed only by
+  // a randomly generated code (retried by the caller on unique violations).
+  insertPendingLink: (row) => withResult(
+    supabaseAdmin
+      .from('pending_bot_links')
+      .insert(row)
+      .select('code, discord_user_id, expires_at')
+      .single()
+  ),
+
+  fetchPendingByCode: async (code) => {
+    const { data, error } = await supabaseAdmin
+      .from('pending_bot_links')
+      .select(PENDING_LINK_SELECT)
+      .eq('code', code)
+      .maybeSingle();
+    return { data: data || null, error };
+  },
+
+  // Authenticated web user attaches the token they just minted. Guards
+  // (unconsumed / unexpired / not already attached) are enforced in the
+  // query itself so the attach is atomic against a racing second request.
+  attachToken: ({ code, agentTokenId }) => withResult(
+    supabaseAdmin
+      .from('pending_bot_links')
+      .update({ agent_token_id: agentTokenId })
+      .eq('code', code)
+      .is('consumed_at', null)
+      .gt('expires_at', new Date().toISOString())
+      .is('agent_token_id', null)
+      .select('code')
+      .single()
+  ),
+
+  // PUBLIC/possession — the Discord-side claim marks the link consumed. The
+  // discord_user_id filter is a defense-in-depth guard: the caller (service)
+  // has already verified possession via policy before calling this, but
+  // scoping the mutation itself closes the race window between check and use.
+  consumePending: ({ code, discordUserId }) => withResult(
+    supabaseAdmin
+      .from('pending_bot_links')
+      .update({ consumed_at: new Date().toISOString() })
+      .eq('code', code)
+      .eq('discord_user_id', discordUserId)
+      .is('consumed_at', null)
+      .select('code, agent_token_id')
+      .single()
+  ),
+
+  // Raw-token stash: the one-time disclosure channel between the web confirm
+  // step (which has the raw token) and the Discord-side claim step (which
+  // doesn't). Never touched by anything but the service that mediates both.
+  stashRawToken: ({ agentTokenId, rawToken }) => withResult(
+    supabaseAdmin
+      .from('pending_bot_links_raw_tokens')
+      .insert({ agent_token_id: agentTokenId, raw_token: rawToken })
+  ),
+
+  fetchRawToken: async (agentTokenId) => {
+    const { data, error } = await supabaseAdmin
+      .from('pending_bot_links_raw_tokens')
+      .select('raw_token')
+      .eq('agent_token_id', agentTokenId)
+      .maybeSingle();
+    return { data: data || null, error };
+  },
+
+  deleteRawToken: async (agentTokenId) => {
+    const { error } = await supabaseAdmin
+      .from('pending_bot_links_raw_tokens')
+      .delete()
+      .eq('agent_token_id', agentTokenId);
+    if (error) console.error(error);
+    return { error: error || null };
+  }
+};

--- a/services/bot-link/repository.test.js
+++ b/services/bot-link/repository.test.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const repository = require('./repository');
+
+// Guards against a missed extraction: every privileged bot-link query
+// (rate-limit gate, pending-link CRUD, and the raw-token stash) must be
+// reachable through the repository, the sole consumer of supabaseAdmin for
+// this domain.
+const expectedMethods = [
+  'deleteStaleLinks',
+  'countRecentPending',
+  'insertPendingLink',
+  'fetchPendingByCode',
+  'attachToken',
+  'consumePending',
+  'stashRawToken',
+  'fetchRawToken',
+  'deleteRawToken'
+];
+
+test('exports every repository method', () => {
+  for (const method of expectedMethods) {
+    expect(typeof repository[method]).toBe('function');
+  }
+});

--- a/services/bot-link/service.js
+++ b/services/bot-link/service.js
@@ -1,0 +1,195 @@
+const crypto = require('crypto');
+const { AuthorizationError } = require('../../util/errors');
+const { canClaimByPossession, canAttachToken } = require('./policy');
+
+const LINK_CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const LINK_CODE_LENGTH = 8;
+const LINK_CODE_TTL_MS = 10 * 60 * 1000;
+const LINK_CODE_MAX_PENDING_PER_DISCORD_ID = 3;
+const LINK_CODE_RATE_WINDOW_MS = 10 * 60 * 1000;
+const LINK_ROW_CLEANUP_AGE_MS = 60 * 60 * 1000;
+const CODE_ALLOCATION_ATTEMPTS = 5;
+
+const nowIso = () => new Date().toISOString();
+const plusMsIso = (ms) => new Date(Date.now() + ms).toISOString();
+const minusMsIso = (ms) => new Date(Date.now() - ms).toISOString();
+
+const generateLinkCode = () => {
+  const bytes = crypto.randomBytes(LINK_CODE_LENGTH);
+  let out = '';
+  for (let i = 0; i < LINK_CODE_LENGTH; i++) {
+    out += LINK_CODE_ALPHABET[bytes[i] % LINK_CODE_ALPHABET.length];
+  }
+  return out;
+};
+
+const formatLinkCode = (code) => {
+  if (typeof code !== 'string' || !/^[A-Z0-9]{8}$/.test(code)) {
+    throw new Error('Invalid link code');
+  }
+  return `${code.slice(0, 4)}-${code.slice(4)}`;
+};
+
+const normalizeLinkCode = (value) => {
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+  if (!/^[A-Z0-9]{8}$/.test(cleaned)) return null;
+  return cleaned;
+};
+
+const isValidDiscordUserId = (value) =>
+  typeof value === 'string' && /^[0-9]{1,32}$/.test(value);
+
+const REQUIRED_REPOSITORY_METHODS = [
+  'deleteStaleLinks',
+  'countRecentPending',
+  'insertPendingLink',
+  'fetchPendingByCode',
+  'attachToken',
+  'consumePending',
+  'stashRawToken',
+  'fetchRawToken',
+  'deleteRawToken'
+];
+
+/** Application boundary for the bot-link domain: policy -> validate -> mutate.
+ *
+ * The Discord-facing capabilities (startLink, claimLink) are PUBLIC by
+ * design — the Discord bot is an unauthenticated caller, and authorization
+ * for the claim step is by possession of the code+discord_user_id pair
+ * (see policy.canClaimByPossession), not actor identity. They therefore
+ * return protocol-shaped errors (`'not_found' | 'expired' | 'mismatch' |
+ * 'pending'` or an Error for internal failures) rather than throwing, so
+ * the PUBLIC routes can keep their existing explicit status codes.
+ *
+ * confirmLink is the one authenticated capability — it requires an actor
+ * and throws AuthorizationError (via policy.canAttachToken) when the actor
+ * may not attach a token to the link.
+ */
+class BotLinkService {
+  constructor(repository, createAgentToken) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`BotLinkService requires repository methods: ${missing.join(', ')}`);
+    if (typeof createAgentToken !== 'function') {
+      throw new TypeError('BotLinkService requires a createAgentToken(actor, { name }) function');
+    }
+    this.repo = repository;
+    this.createAgentToken = createAgentToken;
+  }
+
+  async cleanupStaleLinks() {
+    return this.repo.deleteStaleLinks(minusMsIso(LINK_ROW_CLEANUP_AGE_MS));
+  }
+
+  // PUBLIC — the Discord bot requests a fresh code for itself, rate-limited
+  // per discord_user_id.
+  async startLink({ discordUserId }) {
+    if (!isValidDiscordUserId(discordUserId)) {
+      return { data: null, error: new Error('Invalid discord_user_id') };
+    }
+
+    await this.cleanupStaleLinks();
+
+    const since = minusMsIso(LINK_CODE_RATE_WINDOW_MS);
+    const { count, error: countError } = await this.repo.countRecentPending(discordUserId, since);
+    if (countError) return { data: null, error: countError };
+    if (count >= LINK_CODE_MAX_PENDING_PER_DISCORD_ID) {
+      return { data: null, error: new Error('Too many pending codes') };
+    }
+
+    for (let attempt = 0; attempt < CODE_ALLOCATION_ATTEMPTS; attempt++) {
+      const code = generateLinkCode();
+      const expiresAt = plusMsIso(LINK_CODE_TTL_MS);
+      const { data, error } = await this.repo.insertPendingLink({
+        code,
+        discord_user_id: discordUserId,
+        expires_at: expiresAt
+      });
+      if (!error) return { data, error: null };
+      if (error.code !== '23505') return { data: null, error };
+    }
+    return { data: null, error: new Error('Could not allocate unique link code') };
+  }
+
+  // PUBLIC/possession — the Discord bot claims a code once the web confirm
+  // step has attached a token. Consumes the link, then discloses-and-purges
+  // the one-time raw token stash.
+  async claimLink({ code, discordUserId }) {
+    const { data: link, error } = await this.repo.fetchPendingByCode(code);
+    if (error && error.code !== 'PGRST116') return { data: null, error };
+    if (!link) return { data: null, error: 'not_found' };
+    if (link.consumed_at) return { data: null, error: 'expired' };
+    if (new Date(link.expires_at).getTime() < Date.now()) {
+      return { data: null, error: 'expired' };
+    }
+    if (link.discord_user_id !== discordUserId) return { data: null, error: 'mismatch' };
+    if (!link.agent_token_id) return { data: null, error: 'pending' };
+
+    // Belt-and-suspenders: the checks above already establish possession;
+    // this documents/re-asserts the same decision via the pure policy
+    // predicate before the consuming mutation.
+    if (!canClaimByPossession(link, { code, discordUserId })) {
+      return { data: null, error: 'mismatch' };
+    }
+
+    const { data: consumed, error: consumeError } = await this.repo.consumePending({ code, discordUserId });
+    if (consumeError || !consumed) return { data: null, error: 'expired' };
+
+    const agentTokenId = consumed.agent_token_id;
+    const { data: rawTokenRow, error: rawError } = await this.repo.fetchRawToken(agentTokenId);
+    if (rawError || !rawTokenRow) {
+      return { data: null, error: new Error('Token stash missing') };
+    }
+
+    await this.repo.deleteRawToken(agentTokenId);
+
+    return { data: { agentTokenId, rawToken: rawTokenRow.raw_token }, error: null };
+  }
+
+  // Authenticated — the web user who ran /link in Discord confirms the code
+  // in the browser. Mints a new agent token, stashes its raw value for the
+  // one-time Discord-side disclosure, then attaches it to the link.
+  async confirmLink(actor, { code }) {
+    const { data: pending, error: pendingError } = await this.repo.fetchPendingByCode(code);
+    if (pendingError) return { data: null, error: 'lookup_failed' };
+    if (!pending) return { data: null, error: 'not_found' };
+    if (pending.consumed_at || new Date(pending.expires_at).getTime() < Date.now()) {
+      return { data: null, error: 'expired' };
+    }
+    if (pending.agent_token_id) {
+      return { data: { alreadyLinked: true }, error: null };
+    }
+
+    if (!canAttachToken(actor, pending)) {
+      throw new AuthorizationError('Not authorized to attach a token to this link', { reason: 'not_owner' });
+    }
+
+    const tokenName = `Discord bot (${pending.discord_user_id})`;
+    const { data: tokenRow, error: tokenError } = await this.createAgentToken(actor, { name: tokenName });
+    if (tokenError || !tokenRow) return { data: null, error: 'token_create_failed' };
+
+    const { error: stashError } = await this.repo.stashRawToken({
+      agentTokenId: tokenRow.id,
+      rawToken: tokenRow.token
+    });
+    if (stashError) return { data: null, error: 'stash_failed' };
+
+    const { error: attachError } = await this.repo.attachToken({ code, agentTokenId: tokenRow.id });
+    if (attachError) return { data: null, error: 'attach_failed' };
+
+    return { data: { linked: true }, error: null };
+  }
+}
+
+module.exports = {
+  BotLinkService,
+  LINK_CODE_TTL_MS,
+  LINK_CODE_MAX_PENDING_PER_DISCORD_ID,
+  LINK_CODE_RATE_WINDOW_MS,
+  LINK_ROW_CLEANUP_AGE_MS,
+  generateLinkCode,
+  formatLinkCode,
+  normalizeLinkCode,
+  isValidDiscordUserId,
+  nowIso
+};

--- a/services/bot-link/service.test.js
+++ b/services/bot-link/service.test.js
@@ -1,0 +1,273 @@
+const { test, expect } = require('bun:test');
+const { BotLinkService } = require('./service');
+
+const REQUIRED_REPO_METHODS = [
+  'deleteStaleLinks',
+  'countRecentPending',
+  'insertPendingLink',
+  'fetchPendingByCode',
+  'attachToken',
+  'consumePending',
+  'stashRawToken',
+  'fetchRawToken',
+  'deleteRawToken'
+];
+
+const makeRepo = (overrides = {}) => {
+  const calls = [];
+  const base = {
+    deleteStaleLinks: async (olderThanIso) => { calls.push(['deleteStaleLinks', olderThanIso]); return { error: null }; },
+    countRecentPending: async (discordUserId, sinceIso) => { calls.push(['countRecentPending', discordUserId, sinceIso]); return { count: 0, error: null }; },
+    insertPendingLink: async (row) => { calls.push(['insertPendingLink', row]); return { data: { code: row.code, discord_user_id: row.discord_user_id, expires_at: row.expires_at }, error: null }; },
+    fetchPendingByCode: async (code) => { calls.push(['fetchPendingByCode', code]); return { data: null, error: null }; },
+    attachToken: async ({ code, agentTokenId }) => { calls.push(['attachToken', code, agentTokenId]); return { data: { code }, error: null }; },
+    consumePending: async ({ code, discordUserId }) => { calls.push(['consumePending', code, discordUserId]); return { data: { code, agent_token_id: 'token-1' }, error: null }; },
+    stashRawToken: async ({ agentTokenId, rawToken }) => { calls.push(['stashRawToken', agentTokenId, rawToken]); return { data: {}, error: null }; },
+    fetchRawToken: async (agentTokenId) => { calls.push(['fetchRawToken', agentTokenId]); return { data: { raw_token: 'ar_pat_secret' }, error: null }; },
+    deleteRawToken: async (agentTokenId) => { calls.push(['deleteRawToken', agentTokenId]); return { error: null }; }
+  };
+  return { calls, ...base, ...overrides };
+};
+
+const makeCreateAgentToken = (overrides) => overrides || (async (actor, { name }) => ({
+  data: { id: 'token-1', token: 'ar_pat_secret', name },
+  error: null
+}));
+
+test('constructor requires every repository method', () => {
+  expect(() => new BotLinkService({}, makeCreateAgentToken())).toThrow();
+  for (const method of REQUIRED_REPO_METHODS) {
+    const repo = makeRepo();
+    delete repo[method];
+    expect(() => new BotLinkService(repo, makeCreateAgentToken())).toThrow();
+  }
+});
+
+test('constructor requires a createAgentToken function', () => {
+  expect(() => new BotLinkService(makeRepo(), null)).toThrow();
+});
+
+// --- startLink -------------------------------------------------------------
+
+test('startLink rejects an invalid discord_user_id without touching the repo', async () => {
+  const repo = makeRepo();
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.startLink({ discordUserId: 'not-a-snowflake' });
+  expect(data).toBe(null);
+  expect(error).toBeInstanceOf(Error);
+  expect(repo.calls).toEqual([]);
+});
+
+test('startLink rate-limits after the max pending count for a discord_user_id', async () => {
+  const repo = makeRepo({ countRecentPending: async () => ({ count: 3, error: null }) });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.startLink({ discordUserId: '123456789012345678' });
+  expect(data).toBe(null);
+  expect(error.message).toBe('Too many pending codes');
+});
+
+test('startLink cleans up stale links then inserts a fresh pending link', async () => {
+  const repo = makeRepo();
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.startLink({ discordUserId: '123456789012345678' });
+  expect(error).toBe(null);
+  expect(data.discord_user_id).toBe('123456789012345678');
+  expect(repo.calls[0][0]).toBe('deleteStaleLinks');
+  expect(repo.calls[1][0]).toBe('countRecentPending');
+  expect(repo.calls[2][0]).toBe('insertPendingLink');
+});
+
+test('startLink retries code generation on a unique-constraint collision', async () => {
+  let attempts = 0;
+  const repo = makeRepo({
+    insertPendingLink: async (row) => {
+      attempts += 1;
+      if (attempts < 2) return { data: null, error: { code: '23505' } };
+      return { data: { code: row.code, discord_user_id: row.discord_user_id, expires_at: row.expires_at }, error: null };
+    }
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.startLink({ discordUserId: '123456789012345678' });
+  expect(error).toBe(null);
+  expect(data).toBeTruthy();
+  expect(attempts).toBe(2);
+});
+
+// --- claimLink ---------------------------------------------------------
+
+test('claimLink returns not_found when no link matches the code', async () => {
+  const repo = makeRepo({ fetchPendingByCode: async () => ({ data: null, error: null }) });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'd1' });
+  expect(data).toBe(null);
+  expect(error).toBe('not_found');
+});
+
+test('claimLink returns expired for a consumed link', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: 'token-1', consumed_at: '2020-01-01T00:00:00.000Z', expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'd1' });
+  expect(error).toBe('expired');
+});
+
+test('claimLink returns expired for a link past its expires_at', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: 'token-1', consumed_at: null, expires_at: '2000-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'd1' });
+  expect(error).toBe('expired');
+});
+
+test('claimLink returns mismatch when the discord_user_id does not match (possession check)', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: 'token-1', consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'someone-else' });
+  expect(error).toBe('mismatch');
+  expect(repo.calls.some(c => c[0] === 'consumePending')).toBe(false);
+});
+
+test('claimLink returns pending when no token has been attached yet', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: null, consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'd1' });
+  expect(error).toBe('pending');
+});
+
+test('claimLink consumes the link and discloses+purges the raw token on a valid possession match', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: 'token-1', consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'd1' });
+  expect(error).toBe(null);
+  expect(data).toEqual({ agentTokenId: 'token-1', rawToken: 'ar_pat_secret' });
+  expect(repo.calls.some(c => c[0] === 'consumePending')).toBe(true);
+  expect(repo.calls.some(c => c[0] === 'fetchRawToken')).toBe(true);
+  expect(repo.calls.some(c => c[0] === 'deleteRawToken')).toBe(true);
+});
+
+test('claimLink surfaces an internal error if the raw token stash is missing', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: 'token-1', consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    }),
+    fetchRawToken: async () => ({ data: null, error: null })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const { data, error } = await service.claimLink({ code: 'ABCD1234', discordUserId: 'd1' });
+  expect(data).toBe(null);
+  expect(error).toBeInstanceOf(Error);
+  expect(error.message).toBe('Token stash missing');
+});
+
+// --- confirmLink ---------------------------------------------------------
+
+test('confirmLink returns not_found when the code does not resolve to a link', async () => {
+  const repo = makeRepo({ fetchPendingByCode: async () => ({ data: null, error: null }) });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const actor = { userId: 'u1', profileId: 'p1', role: 'user' };
+  const { data, error } = await service.confirmLink(actor, { code: 'ABCD1234' });
+  expect(data).toBe(null);
+  expect(error).toBe('not_found');
+});
+
+test('confirmLink returns expired for an expired link', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: null, consumed_at: null, expires_at: '2000-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const actor = { userId: 'u1', profileId: 'p1', role: 'user' };
+  const { error } = await service.confirmLink(actor, { code: 'ABCD1234' });
+  expect(error).toBe('expired');
+});
+
+test('confirmLink short-circuits to already-linked success if a token is already attached', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: 'token-existing', consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const actor = { userId: 'u1', profileId: 'p1', role: 'user' };
+  const { data, error } = await service.confirmLink(actor, { code: 'ABCD1234' });
+  expect(error).toBe(null);
+  expect(data.alreadyLinked).toBe(true);
+  expect(repo.calls.some(c => c[0] === 'attachToken')).toBe(false);
+});
+
+test('confirmLink throws AuthorizationError for an actor with no profile (unconfirmed user)', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: null, consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const service = new BotLinkService(repo, makeCreateAgentToken());
+  const actor = { userId: 'u1', profileId: null, role: null };
+  await expect(service.confirmLink(actor, { code: 'ABCD1234' })).rejects.toThrow();
+  expect(repo.calls.some(c => c[0] === 'stashRawToken')).toBe(false);
+});
+
+test('confirmLink creates a token, stashes the raw token, and attaches it for an authenticated actor', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: null, consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  let createTokenArgs = null;
+  const createAgentToken = async (actor, opts) => {
+    createTokenArgs = [actor, opts];
+    return { data: { id: 'token-new', token: 'ar_pat_freshsecret', name: opts.name }, error: null };
+  };
+  const service = new BotLinkService(repo, createAgentToken);
+  const actor = { userId: 'u1', profileId: 'p1', role: 'user' };
+  const { data, error } = await service.confirmLink(actor, { code: 'ABCD1234' });
+  expect(error).toBe(null);
+  expect(data.linked).toBe(true);
+  expect(createTokenArgs[1].name).toBe('Discord bot (d1)');
+  expect(repo.calls.some(c => c[0] === 'stashRawToken' && c[1] === 'token-new' && c[2] === 'ar_pat_freshsecret')).toBe(true);
+  expect(repo.calls.some(c => c[0] === 'attachToken' && c[1] === 'ABCD1234' && c[2] === 'token-new')).toBe(true);
+});
+
+test('confirmLink returns a protocol error if token creation fails', async () => {
+  const repo = makeRepo({
+    fetchPendingByCode: async () => ({
+      data: { code: 'ABCD1234', discord_user_id: 'd1', agent_token_id: null, consumed_at: null, expires_at: '2999-01-01T00:00:00.000Z' },
+      error: null
+    })
+  });
+  const createAgentToken = async () => ({ data: null, error: new Error('boom') });
+  const service = new BotLinkService(repo, createAgentToken);
+  const actor = { userId: 'u1', profileId: 'p1', role: 'user' };
+  const { data, error } = await service.confirmLink(actor, { code: 'ABCD1234' });
+  expect(data).toBe(null);
+  expect(error).toBe('token_create_failed');
+});

--- a/services/character/input.js
+++ b/services/character/input.js
@@ -1,5 +1,6 @@
 const { sanitizeHttpUrl } = require('../../util/url');
 const { validateAbilityPerks } = require('../../util/validate');
+const { statList } = require('../../util/enclave-consts');
 
 const V2_ONLY_FIELDS = ['quirks', 'accessories', 'ability_perks'];
 const V1_ONLY_FIELDS = ['perks', 'additional_gear'];
@@ -118,11 +119,29 @@ const normalizeCharacterInput = (input, context = {}) => {
   return { data, childData, error: null };
 };
 
+// Shared by the stats/level-up capabilities (PATCH /:id/stats, POST
+// /:id/level-up) for parsing raw HTTP request-body values.
+const parseInteger = (value, fallback = 0) => {
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const normalizeStatsPayload = (body = {}) => {
+  const out = {};
+  for (const stat of statList) {
+    const n = parseInteger(body[stat], 0);
+    out[stat] = Math.max(0, Math.min(20, n));
+  }
+  return out;
+};
+
 module.exports = {
   cloneInput,
   normalizeCharacterInput,
   normalizeNamedJsonbList,
   normalizeGearItems: normalizeClassItems,
   normalizeAbilityItems: normalizeClassItems,
-  normalizeAbilityPerks
+  normalizeAbilityPerks,
+  parseInteger,
+  normalizeStatsPayload
 };

--- a/services/character/policy.js
+++ b/services/character/policy.js
@@ -1,0 +1,12 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// A character may be mutated by its creator, or by an admin/system actor.
+// Operates over a pre-loaded character row (no I/O) so the repository owns
+// every privileged read; mirrors services/mission/policy.js's canEditMission
+// and services/class/policy.js's canManageClass.
+const canMutateCharacter = (actor, character) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor?.profileId && !!character && actor.profileId === character.creator_id;
+};
+
+module.exports = { canMutateCharacter };

--- a/services/character/policy.test.js
+++ b/services/character/policy.test.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('bun:test');
+const { canMutateCharacter } = require('./policy');
+
+const character = { id: 'char-1', creator_id: 'profile-1' };
+
+test('canMutateCharacter allows the creator', () => {
+  expect(canMutateCharacter({ profileId: 'profile-1', role: null }, character)).toBe(true);
+});
+
+test('canMutateCharacter allows an admin actor regardless of ownership', () => {
+  expect(canMutateCharacter({ profileId: 'someone-else', role: 'admin' }, character)).toBe(true);
+});
+
+test('canMutateCharacter allows the system actor regardless of ownership', () => {
+  expect(canMutateCharacter({ profileId: null, role: 'system' }, character)).toBe(true);
+});
+
+test('canMutateCharacter denies a stranger profile', () => {
+  expect(canMutateCharacter({ profileId: 'someone-else', role: null }, character)).toBe(false);
+});
+
+test('canMutateCharacter denies an actor with no profileId', () => {
+  expect(canMutateCharacter({ profileId: null, role: null }, character)).toBe(false);
+});
+
+test('canMutateCharacter denies when the character is missing', () => {
+  expect(canMutateCharacter({ profileId: 'profile-1', role: null }, null)).toBe(false);
+});

--- a/services/character/repository.js
+++ b/services/character/repository.js
@@ -1,0 +1,404 @@
+const { supabase, supabaseAdmin } = require('../../models/_base');
+const {
+  listOffscreenMissions: listOffscreenMissionsForCharacter,
+  createOffscreenMission,
+  getAvailableHostedMissionsForPicker
+} = require('../../models/offscreen-mission');
+const { createMission, addCharacterToMission } = require('../../models/mission');
+const { SYSTEM_ACTOR } = require('../../util/actor');
+const { escapeLikePattern } = require('../../util/validate');
+const { statList } = require('../../util/enclave-consts');
+
+// The only consumer of supabaseAdmin for the character domain. Holds every
+// privileged (service-role) query verbatim; models/character.js keeps
+// `getCharacter` (used by both admin AND RLS callers) and the surrounding
+// derivation/serialization logic. Repository methods never throw — they
+// resolve to { data, error } (or { error } for write-only calls).
+
+// --- trait/gear/ability/perk read helpers -----------------------------
+// These always read through supabaseAdmin regardless of the `client` param
+// (mirrors the pre-refactor behavior in models/character.js): only the
+// secondary, non-fatal "classes" catalog lookup honors the caller's client.
+
+const getCharacterTraits = async (id) => {
+  const { data, error } = await supabaseAdmin.from('traits').select('*').eq('character_id', id);
+  return { data, error };
+};
+
+const getCharacterGear = async (id, client = supabase) => {
+  const { data: gear, error: gearError } = await supabaseAdmin
+    .from('class_gear')
+    .select('*')
+    .eq('character_id', id);
+  if (gearError) {
+    return { data: null, error: gearError };
+  }
+
+  if (!Array.isArray(gear) || gear.length === 0) {
+    return { data: [], error: null };
+  }
+
+  const classIds = [...new Set(gear.map(g => g.class_id).filter(Boolean))];
+  if (classIds.length === 0) {
+    return { data: gear, error: null };
+  }
+  const { data: classes, error: classesError } = await client
+    .from('classes')
+    .select('id, name, gear')
+    .in('id', classIds);
+  if (classesError) {
+    return { data: gear, error: null };
+  }
+
+  const mergedGear = gear.map(item => {
+    const cls = classes?.find(c => c.id === item.class_id);
+    const classGear = Array.isArray(cls?.gear)
+      ? cls.gear.find(g => g && g.name === item.name)
+      : null;
+
+    if (classGear) {
+      return { ...classGear, ...item };
+    }
+    return item;
+  });
+
+  return { data: mergedGear, error: null };
+};
+
+const getCharacterAbilities = async (id, client = supabase) => {
+  const { data: abilities, error: abilitiesError } = await supabaseAdmin
+    .from('class_abilities')
+    .select('*')
+    .eq('character_id', id);
+
+  if (abilitiesError) {
+    return { data: null, error: abilitiesError };
+  }
+
+  if (!abilities || abilities.length === 0) {
+    return { data: [], error: null };
+  }
+
+  const classIds = [...new Set(abilities.map(ability => ability.class_id).filter(Boolean))];
+  if (classIds.length === 0) {
+    return { data: abilities, error: null };
+  }
+
+  const { data: classes, error: classesError } = await client
+    .from('classes')
+    .select('id, name, abilities')
+    .in('id', classIds);
+
+  if (classesError) {
+    return { data: abilities, error: null };
+  }
+
+  const mergedAbilities = abilities.map(ability => {
+    const cls = classes.find(c => c.id === ability.class_id);
+    const classAbility = Array.isArray(cls?.abilities)
+      ? cls.abilities.find(a => a && a.name === ability.name)
+      : null;
+
+    if (classAbility) {
+      return { ...classAbility, ...ability };
+    }
+
+    return ability;
+  });
+
+  return { data: mergedAbilities, error: null };
+};
+
+const getCharacterAbilityPerks = async (id) => {
+  const { data, error } = await supabaseAdmin
+    .from('character_perks')
+    .select('*')
+    .eq('character_id', id)
+    .order('position', { ascending: true });
+  if (error) return { data: null, error };
+  return { data: Array.isArray(data) ? data : [], error: null };
+};
+
+// Self-contained, admin-only equivalent of models/character.js#getCharacter.
+// Can't call that model function directly (circular require: models/character
+// requires this repository), so it duplicates the same read-and-attach
+// sequence, always via supabaseAdmin. Used as the CharacterService adapter's
+// `getCharacter` — the privileged ownership+data probe shared by every
+// mutation capability (delete/markDeceased/updateStats/levelUp/updateCharacter).
+const getCharacterAdmin = async (id) => {
+  const { data, error } = await supabaseAdmin.from('characters').select('*').eq('id', id).single();
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+
+  const { data: traits, error: traitsError } = await getCharacterTraits(id);
+  if (traitsError) return { data: null, error: traitsError };
+  data.traits = traits.map(trait => trait.name);
+
+  const { data: gear, error: gearError } = await getCharacterGear(id, supabaseAdmin);
+  if (gearError) return { data: null, error: gearError };
+  data.gear = gear;
+
+  const { data: abilities, error: abilitiesError } = await getCharacterAbilities(id, supabaseAdmin);
+  if (abilitiesError) return { data: null, error: abilitiesError };
+  data.abilities = abilities;
+
+  const { data: abilityPerks, error: perksError } = await getCharacterAbilityPerks(id);
+  if (perksError) return { data: null, error: perksError };
+  data.ability_perks = abilityPerks;
+
+  if (Array.isArray(data.ability_perks) && data.ability_perks.length > 0) {
+    const byId = new Map(data.ability_perks.map(p => [p.id, p]));
+    for (const p of data.ability_perks) {
+      if (!p.compounds_with) continue;
+      const target = byId.get(p.compounds_with);
+      if (target && target.class_ability_id === p.class_ability_id) {
+        p.compounds_with = `position-${target.position}`;
+      } else {
+        p.compounds_with = null;
+      }
+    }
+  }
+
+  return { data, error: null };
+};
+
+// Duplicate (admin-hardcoded) of models/character.js#getCharacterRealMissionsForDerivation —
+// same circular-require reasoning as getCharacterAdmin above.
+const getRealMissions = async (characterId) => {
+  const { data, error } = await supabaseAdmin
+    .from('mission_characters')
+    .select(`mission_id, missions ( id, outcome )`)
+    .eq('character_id', characterId);
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data: (data || []).map(mc => mc.missions).filter(Boolean), error: null };
+};
+
+const getClassRulesVersion = async (classId) => {
+  if (!classId) return { data: 'v1', error: null };
+  try {
+    const { data, error } = await supabaseAdmin.from('classes').select('rules_version').eq('id', classId).maybeSingle();
+    if (error || !data) return { data: 'v1', error: null };
+    return { data: data.rules_version === 'v2' ? 'v2' : 'v1', error: null };
+  } catch (_) {
+    return { data: 'v1', error: null };
+  }
+};
+
+const searchCharactersForAgent = async (query, actor = {}) => {
+  const q = typeof query === 'string' ? query.trim() : '';
+  let builder = supabaseAdmin
+    .from('characters')
+    .select('id, name, class, level, is_public, is_deceased, creator_id, profile:creator_id(name)')
+    .order('name', { ascending: true })
+    .limit(10);
+
+  if (actor.role !== 'admin') {
+    if (actor.profileId) {
+      builder = builder.or(`is_public.eq.true,creator_id.eq.${actor.profileId}`);
+    } else {
+      builder = builder.eq('is_public', true);
+    }
+  }
+
+  if (q.length > 0) {
+    const escaped = escapeLikePattern(q);
+    builder = builder.ilike('name', `%${escaped}%`);
+  } else if (actor.profileId) {
+    builder = builder.eq('creator_id', actor.profileId).order('updated_at', { ascending: false });
+  } else {
+    return { data: [], error: null };
+  }
+
+  return builder;
+};
+
+const getCharacterForAgentRow = async (id) => {
+  const { data, error } = await supabaseAdmin
+    .from('characters')
+    .select(`
+      id, name, class, class_id, level, is_public, is_deceased, creator_id,
+      ${statList.join(',')},
+      profile:creator_id(name),
+      personality:traits(name),
+      abilities:class_abilities(name,description),
+      gear:class_gear(name,description)
+    `)
+    .eq('id', id)
+    .maybeSingle();
+  if (error && error.code !== 'PGRST116') return { data: null, error };
+  return { data: data || null, error: null };
+};
+
+module.exports = {
+  // Verbatim from the former inline adapter in models/character.js. (Two
+  // adapter entries — getRulesVersion, resolveClassReference, and
+  // getClassContentLookupMaps — don't touch supabaseAdmin and stay composed
+  // directly in models/character.js to avoid a circular require back into
+  // this file.)
+  getCharacter: id => getCharacterAdmin(id),
+  createCharacterRow: input => supabaseAdmin.from('characters').insert(input).select(),
+  updateCharacterRow: (id, input, actor) => supabaseAdmin
+    .from('characters')
+    .update(input)
+    .eq('id', id)
+    .eq('creator_id', actor.id)
+    .select(),
+  ...(typeof supabaseAdmin.rpc === 'function' ? {
+    saveCharacterAtomic: async ({ characterId, creatorId, character, traits, gear, abilities, perks }) => {
+      const { data, error } = await supabaseAdmin.rpc('save_character_atomic', {
+        p_character_id: characterId,
+        p_creator_id: creatorId,
+        p_character: character,
+        p_traits: traits,
+        p_gear: gear,
+        p_abilities: abilities,
+        p_perks: perks
+      });
+      return { data, error };
+    }
+  } : {}),
+  getChildRows: (table, characterId) => supabaseAdmin
+    .from(table)
+    .select('*')
+    .eq('character_id', characterId),
+  insertChildRows: (table, characterId, rows) => supabaseAdmin
+    .from(table)
+    .insert(rows.map(row => ({ character_id: characterId, ...row }))),
+  updateChildRow: (table, rowId, changes) => supabaseAdmin
+    .from(table)
+    .update(changes)
+    .eq('id', rowId),
+  deleteChildRows: (table, characterId, rowIds) => supabaseAdmin
+    .from(table)
+    .delete()
+    .in('id', rowIds)
+    .eq('character_id', characterId),
+  getRealMissions,
+  listOffscreenMissions: id => listOffscreenMissionsForCharacter({ characterId: id, supabase: supabaseAdmin }),
+
+  // Trait/gear/ability/perk read helpers (used by models/character.js#getCharacter
+  // and #getCharacterForAgent, both of which stay in the model as RLS-capable
+  // multi-purpose readers).
+  getCharacterTraits,
+  getCharacterGear,
+  getCharacterAbilities,
+  getCharacterAbilityPerks,
+
+  // Agent-search reads.
+  searchCharactersForAgent,
+  getCharacterForAgentRow,
+
+  // Ownership probe (lean projection) — used by upgradeClass, matching the
+  // pre-refactor inline admin select in models/character.js#upgradeCharacterClass.
+  fetchCharacterOwnership: (id) => supabaseAdmin
+    .from('characters')
+    .select('id, creator_id, class_id')
+    .eq('id', id)
+    .maybeSingle(),
+
+  // Mutation primitives for the policy-gated service capabilities. Each keeps
+  // the `.eq('creator_id', creatorId)` SQL filter as defense in depth — the
+  // caller passes the *loaded row's* creator_id (not necessarily the acting
+  // actor's profileId) so admin/system mutations of another user's character
+  // still match a row.
+  deleteCharacter: ({ id, creatorId }) => supabaseAdmin
+    .from('characters')
+    .delete()
+    .eq('id', id)
+    .eq('creator_id', creatorId),
+  setDeceased: async ({ id, creatorId }) => {
+    const { data, error } = await supabaseAdmin
+      .from('characters')
+      .update({ is_deceased: true })
+      .eq('id', id)
+      .eq('creator_id', creatorId)
+      .select();
+    if (error) console.error(error);
+    return { data, error };
+  },
+  updateClass: async ({ id, creatorId, classId, className }) => {
+    const { data, error } = await supabaseAdmin
+      .from('characters')
+      .update({ class_id: classId, class: className })
+      .eq('id', id)
+      .eq('creator_id', creatorId)
+      .select();
+    if (error) console.error(error);
+    return { data, error };
+  },
+  updateOwnedFields: async ({ id, creatorId, fields }) => {
+    const { data, error } = await supabaseAdmin
+      .from('characters')
+      .update(fields)
+      .eq('id', id)
+      .eq('creator_id', creatorId)
+      .select()
+      .single();
+    return { data, error };
+  },
+  getClassRulesVersion,
+
+  // Perk-append primitives (level-up flow).
+  fetchAllowedAbilityIds: async (characterId) => {
+    const { data, error } = await supabaseAdmin.from('class_abilities').select('id').eq('character_id', characterId);
+    return { data, error };
+  },
+  fetchExistingPerks: async (characterId) => {
+    const { data, error } = await supabaseAdmin
+      .from('character_perks')
+      .select('id, class_ability_id, text, position')
+      .eq('character_id', characterId);
+    return { data, error };
+  },
+  insertPerks: async (rows) => {
+    const { error } = await supabaseAdmin.from('character_perks').insert(rows);
+    return { error };
+  },
+  updatePerkLinks: async (updates) => {
+    for (const u of updates) {
+      const { error } = await supabaseAdmin.from('character_perks').update({ compounds_with: u.compounds_with }).eq('id', u.id);
+      if (error) return { error };
+    }
+    return { error: null };
+  },
+
+  // Level-up backfill/credit-spend writes — internal, non-user-triggered
+  // mission creation via SYSTEM_ACTOR (see util/actor.js), so the mission
+  // service's addCharacter authorization gate can't reject this internal
+  // link. creator_id is still set explicitly so the mission shows up under
+  // the user's own missions.
+  createBackfillMission: async ({ characterId, name, profileId }) => {
+    const { data: missionRows, error: missionError } = await createMission(SYSTEM_ACTOR, {
+      name,
+      date: new Date().toISOString(),
+      outcome: 'success',
+      is_public: false,
+      creator_id: profileId
+    });
+    if (missionError) return { error: missionError };
+    const mission = Array.isArray(missionRows) ? missionRows[0] : missionRows;
+    if (!mission) return { error: { status: 400, message: 'Mission creation returned no rows' } };
+    // addCharacterToMission can THROW (MissionService.addCharacter calls
+    // requireEditable, which throws on a repo error re-reading the mission's
+    // permission row, or on a not-found). SYSTEM_ACTOR always passes the
+    // authorization check itself, so those are the only two throw paths left
+    // reachable here. Catch and return as a normal { error } so a denied/
+    // not-found mission surfaces as a graceful response instead of an
+    // unhandled rejection.
+    try {
+      const { error: linkError } = await addCharacterToMission(SYSTEM_ACTOR, mission.id, characterId);
+      return { error: linkError || null };
+    } catch (error) {
+      return { error };
+    }
+  },
+  getAvailableHostedMissions: (profileId) => getAvailableHostedMissionsForPicker({ profileId, supabase: supabaseAdmin }),
+  createOffscreenMissionRow: ({ characterId, profileId, payload }) => createOffscreenMission({
+    characterId, profileId, payload, supabase: supabaseAdmin
+  })
+};

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -3,11 +3,16 @@ const {
   normalizeCharacterInput,
   normalizeGearItems,
   normalizeAbilityItems,
-  normalizeAbilityPerks
+  normalizeAbilityPerks,
+  parseInteger,
+  normalizeStatsPayload
 } = require('./input');
 const { deriveCharacterTotals } = require('../../util/character-derived');
 const { remapPerkAbilityIds, remapPerkAbilityIdsByName } = require('../../util/ability-perks');
 const { diffChildRows, resolveCompoundLinks } = require('../../util/reconcile');
+const { validateAbilityPerks } = require('../../util/validate');
+const { AuthorizationError } = require('../../util/errors');
+const { canMutateCharacter } = require('./policy');
 
 const V2_ONLY_FIELDS = ['quirks', 'accessories', 'ability_perks'];
 
@@ -23,8 +28,48 @@ const REQUIRED_ADAPTER_METHODS = [
   'deleteChildRows',
   'getClassContentLookupMaps',
   'getRealMissions',
-  'listOffscreenMissions'
+  'listOffscreenMissions',
+  // Mutation capabilities (delete/markDeceased/upgradeClass/updateStats/levelUp).
+  'fetchCharacterOwnership',
+  'deleteCharacter',
+  'setDeceased',
+  'updateClass',
+  'updateOwnedFields',
+  'getClassRulesVersion',
+  'fetchAllowedAbilityIds',
+  'fetchExistingPerks',
+  'insertPerks',
+  'updatePerkLinks',
+  'createBackfillMission',
+  'getAvailableHostedMissions',
+  'createOffscreenMissionRow',
+  'findUpgradeTargets'
 ];
+
+// Loads the full character row (admin-privileged; includes traits/gear/
+// abilities/ability_perks) and throws unless the actor may mutate it.
+// Mirrors services/mission/service.js#requireEditable.
+const requireOwnedCharacter = async (adapter, actor, id) => {
+  const { data: character, error } = await adapter.getCharacter(id);
+  if (error) throw error;
+  if (!character) throw new AuthorizationError('Character not found', { reason: 'not_found' });
+  if (!canMutateCharacter(actor, character)) {
+    throw new AuthorizationError('Not authorized to modify this character', { reason: 'not_owner' });
+  }
+  return character;
+};
+
+// Leaner ownership probe (id/creator_id/class_id only) — used by upgradeClass,
+// matching the pre-refactor inline admin select.
+const requireOwnedCharacterLean = async (adapter, actor, id) => {
+  const { data: character, error } = await adapter.fetchCharacterOwnership(id);
+  if (error) throw error;
+  if (!character) throw new AuthorizationError('Character not found', { reason: 'not_found' });
+  if (!canMutateCharacter(actor, character)) {
+    throw new AuthorizationError('Not authorized to modify this character', { reason: 'not_owner' });
+  }
+  return character;
+};
 
 const resolveSubmittedGear = (gear, gearNameToClassId) => {
   const submitted = Array.isArray(gear) ? gear : (gear ? [gear] : []);
@@ -103,7 +148,9 @@ class CharacterService {
   async updateCharacter(id, input, actor) {
     const existing = await this.adapter.getCharacter(id);
     if (existing.error) return { data: null, error: existing.error };
-    if (existing.data.creator_id != actor.id) return { data: null, error: 'Unauthorized' };
+    if (existing.data.creator_id != actor.id) {
+      throw new AuthorizationError('Not authorized to modify this character', { reason: 'not_owner' });
+    }
 
     let rulesVersion = await this.adapter.getRulesVersion(input.class_id);
     let prepared = cloneInput(input);
@@ -308,6 +355,285 @@ class CharacterService {
       if (result.error) return result;
     }
     return current;
+  }
+
+  // --- Policy-gated mutation capabilities (formerly inline route helpers
+  // in routes/characters.js). Each loads ownership via the repository,
+  // THROWS an AuthorizationError unless canMutateCharacter, then mutates.
+  // Everything past the ownership gate keeps returning { data, error }
+  // (string or { status, message } shaped) exactly as the routes did, so
+  // callers keep using their existing error-rendering (sendError/
+  // sendRouteError) for business-rule failures — only the authorization
+  // gate itself is new-to-throw.
+
+  async deleteCharacter(actor, id) {
+    const character = await requireOwnedCharacter(this.adapter, actor, id);
+    return this.adapter.deleteCharacter({ id, creatorId: character.creator_id });
+  }
+
+  async markDeceased(actor, id, confirmName) {
+    const character = await requireOwnedCharacter(this.adapter, actor, id);
+    if (!confirmName || String(confirmName).trim() !== character.name) {
+      return {
+        data: null,
+        error: { status: 400, message: 'Character name does not match. Please type the exact name to confirm.' }
+      };
+    }
+    if (character.is_deceased) return { data: null, error: 'Character is already deceased' };
+
+    const { data, error } = await this.adapter.setDeceased({ id, creatorId: character.creator_id });
+    if (error) return { data: null, error };
+    if (!data || data.length === 0) return { data: null, error: 'Character update returned no rows' };
+    return { data: data[0], error: null };
+  }
+
+  async upgradeClass(actor, id, targetClassId, client) {
+    const character = await requireOwnedCharacterLean(this.adapter, actor, id);
+    if (!targetClassId) return { data: null, error: 'Missing target class id' };
+
+    const candidates = await this.adapter.findUpgradeTargets(character.class_id, client);
+    const target = (candidates || []).find(c => c.id === targetClassId);
+    if (!target) return { data: null, error: 'Target class is not a valid upgrade for this character' };
+
+    const { data, error } = await this.adapter.updateClass({
+      id, creatorId: character.creator_id, classId: target.id, className: target.name
+    });
+    if (error) return { data: null, error };
+    if (!data || data.length === 0) return { data: null, error: 'Character upgrade returned no rows' };
+    return { data: data[0], error: null };
+  }
+
+  async updateStats(actor, id, rawFields) {
+    const character = await requireOwnedCharacter(this.adapter, actor, id);
+    const stats = normalizeStatsPayload(rawFields || {});
+    const { data, error } = await this.adapter.updateOwnedFields({
+      id, creatorId: character.creator_id, fields: stats
+    });
+    if (error) return { data: null, error };
+    if (!data) return { data: null, error: { status: 404, message: 'Character update returned no rows' } };
+    return {
+      data: {
+        id: data.id,
+        name: data.name || character.name,
+        stats: Object.fromEntries(Object.keys(stats).map(stat => [stat, data[stat] ?? stats[stat]]))
+      },
+      error: null
+    };
+  }
+
+  async levelUp(actor, id, body = {}) {
+    const character = await requireOwnedCharacter(this.adapter, actor, id);
+
+    const currentLevel = Math.max(1, parseInteger(character.level, 1));
+    const requestedLevel = Math.max(currentLevel + 1, Math.min(20, parseInteger(body.level, currentLevel + 1)));
+    const currentCompleted = Math.max(0, parseInteger(character.completed_missions, 0));
+    const requestedCompleted = Math.max(currentCompleted, parseInteger(body.completed_missions, currentCompleted));
+    const missionNames = Array.isArray(body.mission_names)
+      ? body.mission_names.map(v => String(v || '').trim()).filter(Boolean)
+      : [];
+    const useConduitCredit = body.use_conduit_credit === true || body.use_conduit_credit === 'true' || body.use_conduit_credit === 'on';
+    const creditCount = useConduitCredit ? Math.max(0, requestedCompleted - currentCompleted - missionNames.length) : 0;
+
+    if (!useConduitCredit && requestedCompleted > currentCompleted + missionNames.length) {
+      return {
+        data: null,
+        error: { status: 400, message: 'Provide mission names for each missing mission, or spend Conduit Credits.' }
+      };
+    }
+
+    let creditSources = [];
+    if (creditCount > 0) {
+      const { data: availableHostedMissions, error: availableError } = await this.adapter.getAvailableHostedMissions(actor.profileId);
+      if (availableError) return { data: null, error: availableError };
+      creditSources = (availableHostedMissions || []).slice(0, creditCount);
+      if (creditSources.length < creditCount) {
+        return { data: null, error: { status: 400, message: 'Not enough Conduit Credits available.' } };
+      }
+    }
+
+    for (const name of missionNames) {
+      const { error } = await this.adapter.createBackfillMission({ characterId: id, name, profileId: actor.profileId });
+      if (error) return { data: null, error };
+    }
+
+    for (let i = 0; i < creditSources.length; i++) {
+      const src = creditSources[i];
+      const sourceDate = typeof src.date === 'string'
+        ? src.date.slice(0, 10)
+        : new Date(src.date).toISOString().slice(0, 10);
+      const { error } = await this.adapter.createOffscreenMissionRow({
+        characterId: id,
+        profileId: actor.profileId,
+        payload: {
+          name: `Conduit Credit: Level ${requestedLevel}`,
+          summary: 'Spent through the level-up modal.',
+          merx_gained: 0,
+          source_mission_id: src.id,
+          source_mission_name: src.name || `Hosted mission ${i + 1}`,
+          source_mission_date: sourceDate
+        }
+      });
+      if (error) return { data: null, error };
+    }
+
+    // Re-derive level / completed_missions / commissary_reward from the rows
+    // we just created (real success missions and offscreen credits) so the
+    // stored counters match what every derive-path computes — see
+    // deriveCharacterTotals. Writing raw requested values here would leave
+    // commissary_reward stale (each backfilled success mission is worth
+    // MERX_PER_MISSION_SUCCESS that never landed in the column).
+    const [missionsRes, offscreenRes] = await Promise.all([
+      this.adapter.getRealMissions(id),
+      this.adapter.listOffscreenMissions(id)
+    ]);
+    if (missionsRes.error || offscreenRes.error) {
+      return { data: null, error: missionsRes.error || offscreenRes.error };
+    }
+
+    const rulesVersionResult = character.class_id
+      ? await this.adapter.getClassRulesVersion(character.class_id)
+      : { data: 'v1' };
+    const rulesVersion = rulesVersionResult.data || 'v1';
+
+    const derived = deriveCharacterTotals({
+      character,
+      realMissions: missionsRes.data || [],
+      offscreenMissions: offscreenRes.data || [],
+      rulesVersion
+    });
+
+    const stats = normalizeStatsPayload(body.stats || body);
+    const fields = {
+      ...stats,
+      level: derived.level,
+      completed_missions: derived.completed_missions,
+      commissary_reward: derived.commissary_reward
+    };
+    const { data, error } = await this.adapter.updateOwnedFields({ id, creatorId: character.creator_id, fields });
+    if (error) return { data: null, error };
+
+    const { error: perksError } = await this.appendPerks(id, Array.isArray(body.ability_perks) ? body.ability_perks : []);
+    if (perksError) return { data: null, error: perksError };
+
+    return {
+      data: {
+        id: data.id,
+        name: data.name || character.name,
+        level: data.level,
+        completed_missions: data.completed_missions,
+        commissary_reward: data.commissary_reward
+      },
+      error: null
+    };
+  }
+
+  // Appends newly-submitted ability perks (level-up modal) to a character's
+  // existing perk set, resolving `compounds_with` links either to an existing
+  // perk (by id) or to another perk inserted in the same batch (`new:<ref>`).
+  // Moved verbatim from routes/characters.js#appendCharacterPerks.
+  async appendPerks(characterId, submittedPerks) {
+    if (!Array.isArray(submittedPerks) || submittedPerks.length === 0) {
+      return { error: null };
+    }
+
+    const { data: abilities, error: abilityError } = await this.adapter.fetchAllowedAbilityIds(characterId);
+    if (abilityError) return { error: abilityError };
+    const allowedAbilityIds = new Set((abilities || []).map(a => a.id));
+
+    const { data: existing, error: existingError } = await this.adapter.fetchExistingPerks(characterId);
+    if (existingError) return { error: existingError };
+
+    const existingCounts = new Map();
+    // id -> ability, so a new perk may only compound with an existing perk on
+    // the SAME ability (mirrors resolveCompoundLinks in the full edit-form path).
+    const abilityByExistingPerkId = new Map();
+    const existingForValidation = (existing || []).map(p => {
+      const pos = parseInteger(p.position, 0);
+      existingCounts.set(p.class_ability_id, Math.max(existingCounts.get(p.class_ability_id) ?? -1, pos));
+      abilityByExistingPerkId.set(p.id, p.class_ability_id);
+      return { class_ability_id: p.class_ability_id, text: p.text, position: pos };
+    });
+
+    // Build insert rows. `meta` runs parallel to `rows`, carrying each new
+    // perk's client `ref` and its requested compound link so we can resolve
+    // links after the rows (and their ids) exist.
+    const rows = [];
+    const meta = [];
+    for (const p of submittedPerks) {
+      if (!p || typeof p !== 'object') continue;
+      const classAbilityId = p.class_ability_id;
+      const text = typeof p.text === 'string' ? p.text.trim() : '';
+      if (!classAbilityId || !allowedAbilityIds.has(classAbilityId) || !text) continue;
+      const nextPosition = (existingCounts.get(classAbilityId) ?? -1) + 1;
+      existingCounts.set(classAbilityId, nextPosition);
+      rows.push({
+        character_id: characterId,
+        class_ability_id: classAbilityId,
+        text,
+        position: nextPosition
+      });
+      meta.push({
+        ref: typeof p.ref === 'string' ? p.ref : null,
+        compoundsWith: p.compounds_with == null ? null : String(p.compounds_with)
+      });
+    }
+
+    if (rows.length === 0) return { error: null };
+
+    const validation = validateAbilityPerks(existingForValidation.concat(rows));
+    if (!validation.ok) {
+      return { error: { status: 400, message: validation.errors.join(' ') } };
+    }
+
+    const { error: insertError } = await this.adapter.insertPerks(rows);
+    if (insertError) return { error: insertError };
+
+    // Re-read the rows to recover server-assigned ids. We match by
+    // (class_ability_id, position) — each new perk got a unique position
+    // above — rather than relying on insert-return ordering.
+    const { data: current, error: selError } = await this.adapter.fetchExistingPerks(characterId);
+    if (selError) return { error: selError };
+    const idByKey = new Map((current || []).map(r => [`${r.class_ability_id}:${parseInteger(r.position, 0)}`, r.id]));
+    const keyOf = (row) => `${row.class_ability_id}:${row.position}`;
+
+    // ref -> { id, class_ability_id } for perks inserted in this batch.
+    const insertedByRef = new Map();
+    for (let i = 0; i < rows.length; i++) {
+      if (!meta[i].ref) continue;
+      insertedByRef.set(meta[i].ref, { id: idByKey.get(keyOf(rows[i])), class_ability_id: rows[i].class_ability_id });
+    }
+
+    // Resolve each new perk's compound link. A link is either `new:<ref>`
+    // (another perk inserted in this batch) or an existing perk UUID. The
+    // target must be on the same ability and not the perk itself; anything
+    // else resolves to null.
+    const linkUpdates = [];
+    for (let i = 0; i < rows.length; i++) {
+      const link = meta[i].compoundsWith;
+      if (!link) continue;
+      const rowId = idByKey.get(keyOf(rows[i]));
+      if (!rowId) continue;
+
+      let target = null;
+      if (link.startsWith('new:')) {
+        const ref = link.slice('new:'.length);
+        const cand = insertedByRef.get(ref);
+        if (cand) target = { id: cand.id, class_ability_id: cand.class_ability_id };
+      } else if (abilityByExistingPerkId.has(link)) {
+        target = { id: link, class_ability_id: abilityByExistingPerkId.get(link) };
+      }
+
+      if (target && target.id && target.id !== rowId && target.class_ability_id === rows[i].class_ability_id) {
+        linkUpdates.push({ id: rowId, compounds_with: target.id });
+      }
+    }
+
+    if (linkUpdates.length > 0) {
+      const { error: linkError } = await this.adapter.updatePerkLinks(linkUpdates);
+      if (linkError) return { error: linkError };
+    }
+
+    return { error: null };
   }
 }
 

--- a/services/character/service.test.js
+++ b/services/character/service.test.js
@@ -1,7 +1,26 @@
 const { test, expect } = require('bun:test');
 const { CharacterService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
 
 const ok = data => ({ data, error: null });
+
+const CREATOR = { profileId: 'profile-1', role: null };
+const STRANGER = { profileId: 'someone-else', role: null };
+const ADMIN = { profileId: 'admin-profile', role: 'admin' };
+
+const OWNED_CHARACTER = {
+  id: 'character-1',
+  creator_id: 'profile-1',
+  class_id: 'class-1',
+  name: 'Owned Hero',
+  level: 1,
+  completed_missions: 0,
+  commissary_reward: 0,
+  is_deceased: false,
+  gear: [],
+  common_items: [],
+  abilities: []
+};
 
 const makeAdapter = (calls, overrides = {}) => ({
   getRulesVersion: async () => 'v1',
@@ -39,6 +58,33 @@ const makeAdapter = (calls, overrides = {}) => ({
   }),
   getRealMissions: async () => ok([]),
   listOffscreenMissions: async () => ok([]),
+  // Mutation-capability defaults.
+  fetchCharacterOwnership: async () => ok({ id: 'character-1', creator_id: 'profile-1', class_id: 'class-1' }),
+  deleteCharacter: async ({ id, creatorId }) => {
+    calls.push(['deleteCharacter', id, creatorId]);
+    return ok(null);
+  },
+  setDeceased: async ({ id, creatorId }) => {
+    calls.push(['setDeceased', id, creatorId]);
+    return ok([{ id, creator_id: creatorId, is_deceased: true }]);
+  },
+  updateClass: async ({ id, creatorId, classId, className }) => {
+    calls.push(['updateClass', id, creatorId, classId, className]);
+    return ok([{ id, class_id: classId, class: className }]);
+  },
+  updateOwnedFields: async ({ id, creatorId, fields }) => {
+    calls.push(['updateOwnedFields', id, creatorId, fields]);
+    return ok({ id, name: 'Owned Hero', ...fields });
+  },
+  getClassRulesVersion: async () => ok('v1'),
+  fetchAllowedAbilityIds: async () => ok([]),
+  fetchExistingPerks: async () => ok([]),
+  insertPerks: async () => ({ error: null }),
+  updatePerkLinks: async () => ({ error: null }),
+  createBackfillMission: async () => ({ error: null }),
+  getAvailableHostedMissions: async () => ok([]),
+  createOffscreenMissionRow: async () => ok({}),
+  findUpgradeTargets: async () => ([{ id: 'target-class', name: 'Upgraded Class' }]),
   ...overrides
 });
 
@@ -74,18 +120,179 @@ test('CharacterService stops a create when a child write fails', async () => {
   }]]);
 });
 
-test('CharacterService enforces ownership before update persistence', async () => {
+test('CharacterService throws AuthorizationError before update persistence when the actor is not the owner', async () => {
   const calls = [];
   const service = new CharacterService(makeAdapter(calls, {
     getCharacter: async () => ok({ id: 'character-1', creator_id: 'another-profile', abilities: [] })
   }));
 
-  expect(await service.updateCharacter('character-1', { name: 'Changed' }, { id: 'profile-1' })).toEqual({
-    data: null, error: 'Unauthorized'
-  });
+  await expect(
+    service.updateCharacter('character-1', { name: 'Changed' }, { id: 'profile-1' })
+  ).rejects.toThrow(AuthorizationError);
   expect(calls).toEqual([]);
 });
 
 test('CharacterService rejects an incomplete persistence adapter', () => {
   expect(() => new CharacterService({ createCharacter() {} })).toThrow(/requires/);
+});
+
+// --- Policy-gated mutation capabilities ------------------------------
+
+test('CharacterService.deleteCharacter throws for a non-creator actor', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  await expect(service.deleteCharacter(STRANGER, 'character-1')).rejects.toThrow(AuthorizationError);
+  expect(calls).toEqual([]);
+});
+
+test('CharacterService.deleteCharacter succeeds for the creator', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  const result = await service.deleteCharacter(CREATOR, 'character-1');
+  expect(result.error).toBeNull();
+  expect(calls).toEqual([['deleteCharacter', 'character-1', 'profile-1']]);
+});
+
+test('CharacterService.deleteCharacter succeeds for an admin acting on another profile\'s character', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  const result = await service.deleteCharacter(ADMIN, 'character-1');
+  expect(result.error).toBeNull();
+  // The SQL safety filter uses the *loaded row's* creator_id, not the actor's
+  // profileId, so an admin/system mutation of someone else's row still matches.
+  expect(calls).toEqual([['deleteCharacter', 'character-1', 'profile-1']]);
+});
+
+test('CharacterService.markDeceased throws for a non-creator actor', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  await expect(service.markDeceased(STRANGER, 'character-1', 'Owned Hero')).rejects.toThrow(AuthorizationError);
+  expect(calls).toEqual([]);
+});
+
+test('CharacterService.markDeceased succeeds for the creator with a matching confirm name', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  const result = await service.markDeceased(CREATOR, 'character-1', 'Owned Hero');
+  expect(result.error).toBeNull();
+  expect(result.data.is_deceased).toBe(true);
+  expect(calls).toEqual([['setDeceased', 'character-1', 'profile-1']]);
+});
+
+test('CharacterService.markDeceased returns a validation error (not a throw) for a mismatched confirm name', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  const result = await service.markDeceased(CREATOR, 'character-1', 'Wrong Name');
+  expect(result.data).toBeNull();
+  expect(result.error.status).toBe(400);
+  expect(calls).toEqual([]);
+});
+
+test('CharacterService.upgradeClass throws for a non-creator actor', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls));
+  await expect(service.upgradeClass(STRANGER, 'character-1', 'target-class', {})).rejects.toThrow(AuthorizationError);
+  expect(calls).toEqual([]);
+});
+
+test('CharacterService.upgradeClass succeeds for the creator with a valid target', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls));
+  const result = await service.upgradeClass(CREATOR, 'character-1', 'target-class', {});
+  expect(result.error).toBeNull();
+  expect(result.data.class_id).toBe('target-class');
+  expect(calls).toEqual([['updateClass', 'character-1', 'profile-1', 'target-class', 'Upgraded Class']]);
+});
+
+test('CharacterService.updateStats throws for a non-creator actor', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  await expect(service.updateStats(STRANGER, 'character-1', { vitality: 5 })).rejects.toThrow(AuthorizationError);
+  expect(calls).toEqual([]);
+});
+
+test('CharacterService.updateStats succeeds for the creator', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  const result = await service.updateStats(CREATOR, 'character-1', { vitality: '5' });
+  expect(result.error).toBeNull();
+  expect(result.data.stats.vitality).toBe(5);
+  // normalizeStatsPayload fills every stat in statList (defaulting to 0),
+  // not just the ones present in the raw payload.
+  expect(calls[0][0]).toBe('updateOwnedFields');
+  expect(calls[0][3].vitality).toBe(5);
+  expect(Object.keys(calls[0][3]).length).toBe(12);
+});
+
+test('CharacterService.levelUp throws for a non-creator actor', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER })
+  }));
+  await expect(service.levelUp(STRANGER, 'character-1', { level: 2 })).rejects.toThrow(AuthorizationError);
+  expect(calls).toEqual([]);
+});
+
+test('CharacterService.levelUp succeeds for the creator, backfilling named missions', async () => {
+  const calls = [];
+  const backfillCalls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER }),
+    createBackfillMission: async (args) => {
+      backfillCalls.push(args);
+      return { error: null };
+    },
+    getRealMissions: async () => ok([{ outcome: 'success' }, { outcome: 'success' }])
+  }));
+
+  const result = await service.levelUp(CREATOR, 'character-1', {
+    level: 2,
+    completed_missions: 2,
+    mission_names: ['Op Alpha', 'Op Bravo'],
+    use_conduit_credit: false,
+    stats: {}
+  });
+
+  expect(result.error).toBeNull();
+  expect(result.data.completed_missions).toBe(2);
+  expect(result.data.commissary_reward).toBe(2);
+  expect(backfillCalls).toEqual([
+    { characterId: 'character-1', name: 'Op Alpha', profileId: 'profile-1' },
+    { characterId: 'character-1', name: 'Op Bravo', profileId: 'profile-1' }
+  ]);
+});
+
+test('CharacterService.levelUp surfaces a backfill mission error without throwing (graceful, not a hang)', async () => {
+  const calls = [];
+  const service = new CharacterService(makeAdapter(calls, {
+    getCharacter: async () => ok({ ...OWNED_CHARACTER }),
+    createBackfillMission: async () => ({ error: new AuthorizationError('Mission not found', { reason: 'not_found' }) })
+  }));
+
+  const result = await service.levelUp(CREATOR, 'character-1', {
+    level: 2,
+    completed_missions: 1,
+    mission_names: ['Op Charlie'],
+    use_conduit_credit: false,
+    stats: {}
+  });
+
+  expect(result.data).toBeNull();
+  expect(result.error).toBeInstanceOf(AuthorizationError);
 });

--- a/services/class/policy.js
+++ b/services/class/policy.js
@@ -1,0 +1,12 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// A class may be edited or deleted by its creator or an admin.
+const canManageClass = (actor, classRow) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor && !!actor.profileId && !!classRow && actor.profileId === classRow.created_by;
+};
+
+// Only admins mint unlock codes for a class (today's requireAdmin route).
+const canMintUnlockCodes = (actor) => isAdmin(actor) || isSystem(actor);
+
+module.exports = { canManageClass, canMintUnlockCodes };

--- a/services/class/policy.test.js
+++ b/services/class/policy.test.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('bun:test');
+const { canManageClass, canMintUnlockCodes } = require('./policy');
+
+const cls = { id: 'c1', created_by: 'p1' };
+
+test('creator may manage their class', () => {
+  expect(canManageClass({ profileId: 'p1', role: 'user' }, cls)).toBe(true);
+});
+test('a non-creator non-admin may not manage the class', () => {
+  expect(canManageClass({ profileId: 'p2', role: 'user' }, cls)).toBe(false);
+});
+test('admin and system may manage any class', () => {
+  expect(canManageClass({ profileId: 'pX', role: 'admin' }, cls)).toBe(true);
+  expect(canManageClass({ role: 'system' }, cls)).toBe(true);
+});
+test('only admin/system may mint unlock codes', () => {
+  expect(canMintUnlockCodes({ role: 'admin' })).toBe(true);
+  expect(canMintUnlockCodes({ role: 'system' })).toBe(true);
+  expect(canMintUnlockCodes({ profileId: 'p1', role: 'user' })).toBe(false);
+});

--- a/services/class/repository.js
+++ b/services/class/repository.js
@@ -1,0 +1,117 @@
+const { supabaseAdmin } = require('../../models/_base');
+const { applyClassFilters } = require('../../util/class-filters');
+
+// The only consumer of supabaseAdmin for the class domain. Holds every
+// privileged (service-role) query verbatim; models/class.js keeps the
+// surrounding logic (computeVersionFamily, date math, agent serialization).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+module.exports = {
+  // Writes
+  insertClass: (data) => withResult(
+    supabaseAdmin.from('classes').insert([data]).select().single()
+  ),
+  updateClass: (id, data) => withResult(
+    supabaseAdmin.from('classes').update(data).eq('id', id).select().single()
+  ),
+  deleteClass: async (id) => {
+    const { error } = await supabaseAdmin.from('classes').delete().eq('id', id);
+    if (error) console.error(error);
+    return { error: error || null };
+  },
+  saveClassPdfMetadata: (id, data) => withResult(
+    supabaseAdmin.from('classes').update(data).eq('id', id).select().single()
+  ),
+  insertUnlockCodes: (rows) => withResult(
+    supabaseAdmin.from('class_unlock_codes').insert(rows).select()
+  ),
+  insertUnlock: (payload) => withResult(
+    supabaseAdmin.from('class_unlocks').insert([payload]).select().single()
+  ),
+
+  // Reads
+  // Lean projection of all classes for version-family resolution. Admin
+  // client so private forks don't break chain links. Returns null on any
+  // failure so callers can degrade to exact-id behavior.
+  fetchClassFamilyRows: async () => {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('classes')
+        .select('id, base_class_id, rules_edition');
+      if (error || !Array.isArray(data)) {
+        if (error) console.error(error);
+        return null;
+      }
+      return data;
+    } catch (e) {
+      console.error(e);
+      return null;
+    }
+  },
+  activeUnlockRows: async ({ userId, classIds, nowIso }) => {
+    const { data, error } = await supabaseAdmin
+      .from('class_unlocks')
+      .select('class_id, expires_at')
+      .eq('user_id', userId)
+      .in('class_id', classIds)
+      .or(`expires_at.is.null,expires_at.gt.${nowIso}`)
+      .limit(1);
+    if (error) {
+      console.error(error);
+      return { data: null, error };
+    }
+    return { data, error: null };
+  },
+  unlockedClassRows: async ({ userId, nowIso }) => {
+    const { data, error } = await supabaseAdmin
+      .from('class_unlocks')
+      .select('class:classes(*), expires_at')
+      .eq('user_id', userId)
+      .or(`expires_at.is.null,expires_at.gt.${nowIso}`);
+    if (error) {
+      console.error(error);
+      return { data: null, error };
+    }
+    return { data, error: null };
+  },
+  unlockedClassIdRows: async ({ userId, nowIso }) => {
+    const { data, error } = await supabaseAdmin
+      .from('class_unlocks')
+      .select('class_id')
+      .eq('user_id', userId)
+      .or(`expires_at.is.null,expires_at.gt.${nowIso}`);
+    if (error) {
+      console.error(error);
+      return { data: null, error };
+    }
+    return { data, error: null };
+  },
+  fetchClassByIdAdmin: (id) => withResult(
+    supabaseAdmin.from('classes').select('*').eq('id', id).single()
+  ),
+  fetchClassesForAgentAdmin: async (filters, actor) => {
+    let query = applyClassFilters(supabaseAdmin.from('classes').select('*'), filters);
+
+    if (actor.role !== 'admin') {
+      if (actor.profileId) {
+        query = query.or(`is_public.eq.true,created_by.eq.${actor.profileId}`);
+      } else {
+        query = query.eq('is_public', true);
+      }
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      console.error(error);
+      return { data: null, error };
+    }
+    return { data, error: null };
+  }
+};

--- a/services/class/repository.test.js
+++ b/services/class/repository.test.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const repository = require('./repository');
+
+// Guards against a missed extraction: every privileged class query must be
+// reachable through the repository, the sole consumer of supabaseAdmin for
+// this domain. Deep behavior is covered by the model/service tests that
+// already exercise these paths.
+const expectedMethods = [
+  'insertClass',
+  'updateClass',
+  'deleteClass',
+  'saveClassPdfMetadata',
+  'insertUnlockCodes',
+  'insertUnlock',
+  'fetchClassFamilyRows',
+  'activeUnlockRows',
+  'unlockedClassRows',
+  'unlockedClassIdRows',
+  'fetchClassByIdAdmin',
+  'fetchClassesForAgentAdmin'
+];
+
+test('exports every repository method', () => {
+  for (const method of expectedMethods) {
+    expect(typeof repository[method]).toBe('function');
+  }
+});

--- a/services/class/service.js
+++ b/services/class/service.js
@@ -1,33 +1,70 @@
 const { normalizeClassInput } = require('./input');
+const { AuthorizationError } = require('../../util/errors');
+const { isSystem } = require('../../util/actor');
+const { canManageClass, canMintUnlockCodes } = require('./policy');
 
-const REQUIRED_ADAPTER_METHODS = ['createClassRow', 'updateClassRow', 'deleteClassRow', 'savePdfMetadataRow'];
+const REQUIRED_REPOSITORY_METHODS = [
+  'insertClass',
+  'updateClass',
+  'deleteClass',
+  'saveClassPdfMetadata',
+  'insertUnlockCodes',
+  'fetchClassByIdAdmin'
+];
 
-/** Application boundary for class writes. Route authorization stays unchanged. */
+const requireManageable = async (repo, actor, id) => {
+  const { data: existing, error } = await repo.fetchClassByIdAdmin(id);
+  if (error) return { existing: null, error };
+  if (!existing) throw new AuthorizationError('Class not found', { reason: 'not_found' });
+  if (!canManageClass(actor, existing)) throw new AuthorizationError('Not the class owner', { reason: 'not_owner' });
+  return { existing, error: null };
+};
+
+/** Application boundary for class writes: load -> policy -> throw-or-mutate. */
 class ClassService {
-  constructor(adapter) {
-    const missing = REQUIRED_ADAPTER_METHODS.filter(method => typeof adapter?.[method] !== 'function');
-    if (missing.length) throw new TypeError(`ClassService requires adapter methods: ${missing.join(', ')}`);
-    this.adapter = adapter;
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`ClassService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
   }
 
-  async createClass(input) {
-    return this.adapter.createClassRow(normalizeClassInput(input));
+  // No ownership check — the creator becomes the owner. created_by is
+  // derived from the actor (not trusted from input) unless the actor is the
+  // system actor, which is allowed to set an explicit owner (e.g. seeding).
+  async createClass(actor, input) {
+    const created_by = isSystem(actor) ? (input?.created_by ?? null) : (actor?.profileId ?? null);
+    return this.repo.insertClass(normalizeClassInput({ ...input, created_by }));
   }
 
-  async updateClass(id, input) {
-    return this.adapter.updateClassRow(id, normalizeClassInput(input));
+  async updateClass(actor, id, input) {
+    const { error } = await requireManageable(this.repo, actor, id);
+    if (error) return { data: null, error };
+    return this.repo.updateClass(id, normalizeClassInput(input));
   }
 
-  async deleteClass(id) {
-    return this.adapter.deleteClassRow(id);
+  async deleteClass(actor, id) {
+    const { error } = await requireManageable(this.repo, actor, id);
+    if (error) return { error };
+    return this.repo.deleteClass(id);
   }
 
-  async savePdfMetadata(classId, storagePath) {
+  async savePdfMetadata(actor, classId, storagePath) {
     if (!classId) return { data: null, error: new Error('Missing class id') };
-    return this.adapter.savePdfMetadataRow(classId, {
+    const { error } = await requireManageable(this.repo, actor, classId);
+    if (error) return { data: null, error };
+    return this.repo.saveClassPdfMetadata(classId, {
       pdf_storage_path: storagePath || null,
       pdf_updated_at: storagePath ? new Date().toISOString() : null
     });
+  }
+
+  // rows are pre-built by the model (crypto-random codes, expiry, etc.);
+  // this capability only gates who may mint them.
+  async mintUnlockCodes(actor, rows) {
+    if (!canMintUnlockCodes(actor)) {
+      throw new AuthorizationError('Not authorized to mint unlock codes', { reason: 'not_admin' });
+    }
+    return this.repo.insertUnlockCodes(rows);
   }
 }
 

--- a/services/class/service.test.js
+++ b/services/class/service.test.js
@@ -1,17 +1,27 @@
 const { test, expect } = require('bun:test');
 const { normalizeClassInput } = require('./input');
 const { ClassService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
 
-const makeAdapter = () => {
+const CLASS_ROW = { id: 'class-1', created_by: 'owner-1' };
+
+const makeRepo = ({ classRow = CLASS_ROW } = {}) => {
   const calls = [];
   return {
     calls,
-    createClassRow: async data => { calls.push(['create', data]); return { data, error: null }; },
-    updateClassRow: async (id, data) => { calls.push(['update', id, data]); return { data, error: null }; },
-    deleteClassRow: async id => { calls.push(['delete', id]); return { error: null }; },
-    savePdfMetadataRow: async (id, data) => { calls.push(['pdf', id, data]); return { data, error: null }; }
+    insertClass: async data => { calls.push(['insertClass', data]); return { data, error: null }; },
+    updateClass: async (id, data) => { calls.push(['updateClass', id, data]); return { data, error: null }; },
+    deleteClass: async id => { calls.push(['deleteClass', id]); return { error: null }; },
+    saveClassPdfMetadata: async (id, data) => { calls.push(['saveClassPdfMetadata', id, data]); return { data, error: null }; },
+    insertUnlockCodes: async rows => { calls.push(['insertUnlockCodes', rows]); return { data: rows, error: null }; },
+    fetchClassByIdAdmin: async id => { calls.push(['fetchClassByIdAdmin', id]); return { data: classRow, error: null }; }
   };
 };
+
+const OWNER_ACTOR = { profileId: 'owner-1', role: 'user' };
+const OTHER_ACTOR = { profileId: 'someone-else', role: 'user' };
+const ADMIN_ACTOR = { profileId: 'admin-1', role: 'admin' };
+const SYSTEM_ACTOR = { role: 'system' };
 
 test('normalizes a class input copy without mutating the submitted payload', () => {
   const input = { name: 'Tinker', image_url: 'javascript:bad()' };
@@ -19,15 +29,105 @@ test('normalizes a class input copy without mutating the submitted payload', () 
   expect(input).toEqual({ name: 'Tinker', image_url: 'javascript:bad()' });
 });
 
-test('class service passes normalized writes through its adapter', async () => {
-  const adapter = makeAdapter();
-  const service = new ClassService(adapter);
-  await service.updateClass('class-1', { image_url: 'https://example.test/image.png' });
-  expect(adapter.calls).toEqual([['update', 'class-1', { image_url: 'https://example.test/image.png' }]]);
+test('constructor requires every repository method', () => {
+  expect(() => new ClassService({})).toThrow(TypeError);
+});
+
+test('createClass derives created_by from the actor, ignoring any input value', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.createClass(OWNER_ACTOR, { name: 'Tinker', created_by: 'forged-id' });
+  expect(repo.calls).toEqual([['insertClass', { name: 'Tinker', created_by: 'owner-1' }]]);
+});
+
+test('createClass respects an explicit created_by from the system actor', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.createClass(SYSTEM_ACTOR, { name: 'Tinker', created_by: 'admin-profile' });
+  expect(repo.calls).toEqual([['insertClass', { name: 'Tinker', created_by: 'admin-profile' }]]);
+});
+
+test('the class owner may update their class; the write reaches the repository', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.updateClass(OWNER_ACTOR, 'class-1', { image_url: 'https://example.test/image.png' });
+  expect(repo.calls).toEqual([
+    ['fetchClassByIdAdmin', 'class-1'],
+    ['updateClass', 'class-1', { image_url: 'https://example.test/image.png' }]
+  ]);
+});
+
+test('an admin may update a class they do not own', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.updateClass(ADMIN_ACTOR, 'class-1', { name: 'New name' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchClassByIdAdmin', 'updateClass']);
+});
+
+test('a non-owner non-admin updating a class throws AuthorizationError, never reaching the repository write', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await expect(service.updateClass(OTHER_ACTOR, 'class-1', { name: 'nope' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([['fetchClassByIdAdmin', 'class-1']]);
+});
+
+test('updating a class that does not exist throws AuthorizationError (not_found)', async () => {
+  const repo = makeRepo({ classRow: null });
+  const service = new ClassService(repo);
+  await expect(service.updateClass(OWNER_ACTOR, 'missing', {})).rejects.toThrow(AuthorizationError);
+});
+
+test('the class owner may delete their class', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  const result = await service.deleteClass(OWNER_ACTOR, 'class-1');
+  expect(result).toEqual({ error: null });
+  expect(repo.calls).toEqual([['fetchClassByIdAdmin', 'class-1'], ['deleteClass', 'class-1']]);
+});
+
+test('a non-owner non-admin deleting a class throws AuthorizationError', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await expect(service.deleteClass(OTHER_ACTOR, 'class-1')).rejects.toThrow(AuthorizationError);
 });
 
 test('class service rejects PDF metadata without a class id', async () => {
-  const service = new ClassService(makeAdapter());
-  const result = await service.savePdfMetadata(null, 'classes/tinker.pdf');
+  const service = new ClassService(makeRepo());
+  const result = await service.savePdfMetadata(OWNER_ACTOR, null, 'classes/tinker.pdf');
   expect(result.error.message).toBe('Missing class id');
+});
+
+test('the class owner may save PDF metadata for their class', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.savePdfMetadata(OWNER_ACTOR, 'class-1', 'classes/tinker.pdf');
+  expect(repo.calls[1][0]).toBe('saveClassPdfMetadata');
+  expect(repo.calls[1][2].pdf_storage_path).toBe('classes/tinker.pdf');
+});
+
+test('a non-owner saving PDF metadata throws AuthorizationError', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await expect(service.savePdfMetadata(OTHER_ACTOR, 'class-1', 'classes/tinker.pdf')).rejects.toThrow(AuthorizationError);
+});
+
+test('an admin may mint unlock codes', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.mintUnlockCodes(ADMIN_ACTOR, [{ code: 'abc' }]);
+  expect(repo.calls).toEqual([['insertUnlockCodes', [{ code: 'abc' }]]]);
+});
+
+test('the system actor may mint unlock codes', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await service.mintUnlockCodes(SYSTEM_ACTOR, [{ code: 'abc' }]);
+  expect(repo.calls).toEqual([['insertUnlockCodes', [{ code: 'abc' }]]]);
+});
+
+test('a non-admin minting unlock codes throws AuthorizationError, never reaching the repository', async () => {
+  const repo = makeRepo();
+  const service = new ClassService(repo);
+  await expect(service.mintUnlockCodes(OWNER_ACTOR, [{ code: 'abc' }])).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
 });

--- a/services/lfg/policy.js
+++ b/services/lfg/policy.js
@@ -1,0 +1,37 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// Only the post's creator (host of the game) — or an admin/system actor —
+// may update, delete, or close an LFG post.
+const canManagePost = (actor, post) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor?.profileId && !!post && actor.profileId === post.creator_id;
+};
+
+// Moderating (approving/rejecting) a join request is a host action: only the
+// post's creator — or an admin/system actor — may do it. Kept distinct from
+// canManagePost even though the check is identical today: this predicate is
+// about the *post the request belongs to*, not the request row itself.
+const canModerateJoinRequest = (actor, post) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor?.profileId && !!post && actor.profileId === post.creator_id;
+};
+
+// A profile may join with a character only if they own it and it is not
+// deceased. The system actor may always join (e.g. backfill/import flows);
+// there is no admin bypass here because character ownership is not an
+// admin-adjacent concern.
+const canJoinAsCharacter = (actor, character) => {
+  if (isSystem(actor)) return true;
+  return !!actor?.profileId && !!character &&
+    actor.profileId === character.creator_id && !character.is_deceased;
+};
+
+// Withdrawing/removing your own join request. An admin/system actor may
+// manage any request (moderation cleanup); the host managing another
+// profile's request goes through canModerateJoinRequest instead.
+const canManageOwnJoinRequest = (actor, request) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor?.profileId && !!request && actor.profileId === request.profile_id;
+};
+
+module.exports = { canManagePost, canModerateJoinRequest, canJoinAsCharacter, canManageOwnJoinRequest };

--- a/services/lfg/policy.test.js
+++ b/services/lfg/policy.test.js
@@ -1,0 +1,93 @@
+const { test, expect } = require('bun:test');
+const {
+  canManagePost,
+  canModerateJoinRequest,
+  canJoinAsCharacter,
+  canManageOwnJoinRequest
+} = require('./policy');
+
+const POST = { id: 'post-1', creator_id: 'creator-1' };
+const CHARACTER = { id: 'char-1', creator_id: 'owner-1', is_deceased: false };
+const REQUEST = { id: 'req-1', profile_id: 'requester-1' };
+
+// ─── canManagePost ─────────────────────────────────────────────────────────
+
+test('the post creator may manage their post', () => {
+  expect(canManagePost({ profileId: 'creator-1', role: 'user' }, POST)).toBe(true);
+});
+
+test('an admin may manage any post', () => {
+  expect(canManagePost({ profileId: 'admin-1', role: 'admin' }, POST)).toBe(true);
+});
+
+test('the system actor may manage any post', () => {
+  expect(canManagePost({ role: 'system' }, POST)).toBe(true);
+});
+
+test('a stranger may not manage the post', () => {
+  expect(canManagePost({ profileId: 'stranger', role: 'user' }, POST)).toBe(false);
+});
+
+test('canManagePost is false without a loaded post unless system/admin', () => {
+  expect(canManagePost({ profileId: 'creator-1', role: 'user' }, null)).toBe(false);
+  expect(canManagePost({ role: 'admin' }, null)).toBe(true);
+});
+
+// ─── canModerateJoinRequest ─────────────────────────────────────────────────
+
+test('the host may moderate join requests on their post', () => {
+  expect(canModerateJoinRequest({ profileId: 'creator-1', role: 'user' }, POST)).toBe(true);
+});
+
+test('an admin may moderate join requests on any post', () => {
+  expect(canModerateJoinRequest({ profileId: 'admin-1', role: 'admin' }, POST)).toBe(true);
+});
+
+test('the system actor may moderate join requests on any post', () => {
+  expect(canModerateJoinRequest({ role: 'system' }, POST)).toBe(true);
+});
+
+test('a non-host may not moderate join requests', () => {
+  expect(canModerateJoinRequest({ profileId: 'stranger', role: 'user' }, POST)).toBe(false);
+});
+
+// ─── canJoinAsCharacter ─────────────────────────────────────────────────────
+
+test('the character owner may join with their living character', () => {
+  expect(canJoinAsCharacter({ profileId: 'owner-1', role: 'user' }, CHARACTER)).toBe(true);
+});
+
+test('the system actor may always join', () => {
+  expect(canJoinAsCharacter({ role: 'system' }, CHARACTER)).toBe(true);
+});
+
+test('a non-owner may not join with someone else\'s character', () => {
+  expect(canJoinAsCharacter({ profileId: 'stranger', role: 'user' }, CHARACTER)).toBe(false);
+});
+
+test('the owner may not join with a deceased character', () => {
+  const deceased = { ...CHARACTER, is_deceased: true };
+  expect(canJoinAsCharacter({ profileId: 'owner-1', role: 'user' }, deceased)).toBe(false);
+});
+
+test('an admin has no special bypass for character ownership', () => {
+  expect(canJoinAsCharacter({ profileId: 'admin-1', role: 'admin' }, CHARACTER)).toBe(false);
+});
+
+// ─── canManageOwnJoinRequest ────────────────────────────────────────────────
+
+test('the requester may manage/withdraw their own join request', () => {
+  expect(canManageOwnJoinRequest({ profileId: 'requester-1', role: 'user' }, REQUEST)).toBe(true);
+});
+
+test('an admin may manage any join request', () => {
+  expect(canManageOwnJoinRequest({ profileId: 'admin-1', role: 'admin' }, REQUEST)).toBe(true);
+});
+
+test('the system actor may manage any join request', () => {
+  expect(canManageOwnJoinRequest({ role: 'system' }, REQUEST)).toBe(true);
+});
+
+test('a stranger may not manage someone else\'s join request', () => {
+  expect(canManageOwnJoinRequest({ profileId: 'stranger', role: 'user' }, REQUEST)).toBe(false);
+});

--- a/services/lfg/repository.js
+++ b/services/lfg/repository.js
@@ -1,0 +1,120 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin for the lfg domain. Holds every
+// privileged (service-role) query; models/lfg.js keeps the surrounding logic
+// (RLS-scoped reads, transforms, and the general-purpose `client` parameter
+// used by joinLfgPost's character-ownership read, which is not privileged).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+// Selection used by the agent-scoped post reads: the post plus its creator
+// and every join request (with joiner profile + character), mirroring
+// getLfgPost's shape closely enough for serializePostForAgent to consume.
+const AGENT_POST_SELECT = '*, creator:creator_id(id,name), lfg_join_requests(*, profile:profile_id(id,name), character:character_id(*))';
+
+module.exports = {
+  // Verbatim from the former inline adapter in models/lfg.js.
+  createPost: data => supabaseAdmin.from('lfg_posts').insert(data).select(),
+  updatePost: (id, creatorId, data) => supabaseAdmin
+    .from('lfg_posts').update(data).eq('id', id).eq('creator_id', creatorId).select(),
+  getCreatorRequest: (profileId, postId) => supabaseAdmin
+    .from('lfg_join_requests').select('*').eq('lfg_post_id', postId).eq('profile_id', profileId).single(),
+
+  // New: privileged reads used by the policy-gated capabilities. A lighter
+  // permission row than the full joined getLfgPost — only creator_id is
+  // needed to decide canManagePost/canModerateJoinRequest.
+  fetchPostPermissionRow: (postId) => withResult(
+    supabaseAdmin.from('lfg_posts').select('id, creator_id').eq('id', postId).maybeSingle()
+  ),
+  deletePost: (id, creatorId) => supabaseAdmin
+    .from('lfg_posts').delete().eq('id', id).eq('creator_id', creatorId),
+  closePost: (id, creatorId) => supabaseAdmin
+    .from('lfg_posts')
+    .update({ status: 'closed', updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('creator_id', creatorId)
+    .select()
+    .maybeSingle(),
+
+  // Join / join-request primitives (used by joinLfgPost's admin-only steps).
+  getApprovedConduit: (postId) => supabaseAdmin
+    .from('lfg_join_requests').select('id').eq('lfg_post_id', postId).eq('join_type', 'conduit').eq('status', 'approved').limit(1),
+  getPostCreatorId: (postId) => supabaseAdmin
+    .from('lfg_posts').select('creator_id').eq('id', postId).maybeSingle(),
+  insertJoinRequest: (row) => supabaseAdmin.from('lfg_join_requests').insert(row).select(),
+
+  // Conduit host_id denormalization sync (internal, no policy — see
+  // syncConduitHostId in models/lfg.js).
+  getApprovedConduitProfile: (postId) => supabaseAdmin
+    .from('lfg_join_requests').select('profile_id').eq('lfg_post_id', postId).eq('join_type', 'conduit').eq('status', 'approved').maybeSingle(),
+  updatePostHostId: async (postId, hostId) => {
+    const { error } = await supabaseAdmin.from('lfg_posts').update({ host_id: hostId }).eq('id', postId);
+    return { error };
+  },
+
+  // Join-request moderation/ownership primitives.
+  fetchJoinRequestWithPost: (requestId) => withResult(
+    supabaseAdmin
+      .from('lfg_join_requests')
+      .select('id, lfg_post_id, profile_id, post:lfg_post_id(creator_id)')
+      .eq('id', requestId)
+      .maybeSingle()
+  ),
+  getJoinRequestRow: (requestId) => withResult(
+    supabaseAdmin
+      .from('lfg_join_requests')
+      .select('id, lfg_post_id, profile_id, character_id, join_type, status')
+      .eq('id', requestId)
+      .single()
+  ),
+  updateJoinRequestStatusRow: async (requestId, status, postId) => {
+    let query = supabaseAdmin.from('lfg_join_requests').update({ status }).eq('id', requestId);
+    if (postId) query = query.eq('lfg_post_id', postId);
+    const { data, error } = await query;
+    if (error) console.error(error);
+    return { data, error };
+  },
+  deleteJoinRequestRow: async (requestId) => {
+    const { data, error } = await supabaseAdmin.from('lfg_join_requests').delete().eq('id', requestId);
+    if (error) console.error(error);
+    return { data, error };
+  },
+
+  // Agent-surface reads.
+  listPostsWithRequestsBy: async (filters, { status, dateFrom } = {}) => {
+    let query = supabaseAdmin.from('lfg_posts').select(AGENT_POST_SELECT);
+    for (const [key, value] of Object.entries(filters)) {
+      query = query.eq(key, value);
+    }
+    if (status && status !== 'all') query = query.eq('status', status);
+    if (dateFrom) query = query.gte('date', dateFrom);
+    return query;
+  },
+  listJoinedPostIds: (profileId) => supabaseAdmin
+    .from('lfg_join_requests').select('lfg_post_id').eq('profile_id', profileId).neq('status', 'rejected'),
+  listPostsByIds: (ids, { status } = {}) => {
+    let query = supabaseAdmin.from('lfg_posts').select(AGENT_POST_SELECT).in('id', ids);
+    if (status && status !== 'all') query = query.eq('status', status);
+    return query;
+  },
+  getPostForAgentRow: (postId) => supabaseAdmin
+    .from('lfg_posts').select(AGENT_POST_SELECT).eq('id', postId).maybeSingle(),
+  getCharacterForJoin: (characterId) => supabaseAdmin
+    .from('characters').select('id, creator_id, is_deceased').eq('id', characterId).maybeSingle(),
+  getExistingJoinRequest: (postId, profileId) => supabaseAdmin
+    .from('lfg_join_requests').select('id, status').eq('lfg_post_id', postId).eq('profile_id', profileId).maybeSingle(),
+  listEligibleCharacters: (profileId) => supabaseAdmin
+    .from('characters')
+    .select('id, name, class, level')
+    .eq('creator_id', profileId)
+    .eq('is_deceased', false)
+    .order('name', { ascending: true }),
+
+  AGENT_POST_SELECT
+};

--- a/services/lfg/service.js
+++ b/services/lfg/service.js
@@ -1,59 +1,387 @@
 const { normalizeLfgInput } = require('./input');
+const { AuthorizationError } = require('../../util/errors');
+const { isSystem } = require('../../util/actor');
+const {
+  canManagePost,
+  canModerateJoinRequest,
+  canJoinAsCharacter,
+  canManageOwnJoinRequest
+} = require('./policy');
 
-const REQUIRED_ADAPTER_METHODS = [
-  'getPost', 'createPost', 'updatePost', 'getCreatorRequest',
-  'deleteJoinRequest', 'joinPost'
+const REQUIRED_REPOSITORY_METHODS = [
+  'createPost', 'updatePost', 'getCreatorRequest', 'fetchPostPermissionRow',
+  'deletePost', 'closePost', 'getApprovedConduit', 'getPostCreatorId', 'insertJoinRequest',
+  'getApprovedConduitProfile', 'updatePostHostId', 'fetchJoinRequestWithPost', 'getJoinRequestRow',
+  'updateJoinRequestStatusRow', 'deleteJoinRequestRow',
+  'listPostsWithRequestsBy', 'listJoinedPostIds', 'listPostsByIds', 'getPostForAgentRow',
+  'getCharacterForJoin', 'getExistingJoinRequest', 'listEligibleCharacters'
 ];
 
-/** Owns LFG write decisions; the adapter owns Supabase reads and writes. */
+// I3 (carried over from the pre-refactor model): rename lfg_join_requests ->
+// join_requests on agent-surface rows so serializePostForAgent has one shape
+// to read regardless of which repository query produced the row.
+const normalizeJoinRequests = (rows) => {
+  for (const row of rows) {
+    row.join_requests = row.lfg_join_requests || [];
+    delete row.lfg_join_requests;
+  }
+  return rows;
+};
+
+const serializePostForAgent = (post, { agentProfileId, includePending }) => {
+  const host = post.creator || post.host || {};
+  const roster = (post.join_requests || [])
+    .filter((r) => r.status === 'approved' && r.join_type === 'player')
+    .map((r) => ({
+      character_id: r.character_id,
+      name: r.character?.name || null,
+      class_name: r.character?.class || null,
+      level: r.character?.level || null,
+      profile_id: r.profile_id,
+      profile_display_name: r.profile?.name || null
+    }));
+  const conduit = (post.join_requests || []).find(
+    (r) => r.status === 'approved' && r.join_type === 'conduit'
+  );
+  const myRequest = (post.join_requests || []).find(
+    (r) => r.profile_id === agentProfileId && r.status !== 'rejected'
+  );
+  const base = {
+    id: post.id,
+    title: post.title,
+    description: post.description,
+    date: post.date,
+    host: { id: host.id, display_name: host.name },
+    max_characters: post.max_characters,
+    is_public: post.is_public,
+    status: post.status,
+    player_count: roster.length,
+    has_conduit: !!conduit,
+    roster,
+    conduit: conduit
+      ? { profile_id: conduit.profile_id, display_name: conduit.profile?.name || null }
+      : null,
+    my_request: myRequest
+      ? { id: myRequest.id, join_type: myRequest.join_type, status: myRequest.status }
+      : null
+  };
+  if (includePending && host.id === agentProfileId) {
+    base.pending_requests = (post.join_requests || [])
+      .filter((r) => r.status === 'pending')
+      .map((r) => ({
+        id: r.id,
+        profile_id: r.profile_id,
+        profile_display_name: r.profile?.name || null,
+        join_type: r.join_type,
+        character: r.character
+          ? { id: r.character.id, name: r.character.name, class_name: r.character.class, level: r.character.level }
+          : null
+      }));
+  }
+  return base;
+};
+
+/** Coordinates LFG write decisions and authorization; the repository owns Supabase reads/writes. */
 class LfgService {
-  constructor(adapter) {
-    const missing = REQUIRED_ADAPTER_METHODS.filter(method => typeof adapter?.[method] !== 'function');
-    if (missing.length) throw new TypeError(`LfgService requires adapter methods: ${missing.join(', ')}`);
-    this.adapter = adapter;
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`LfgService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
   }
 
-  async createPost(input, actor) {
-    const normalized = normalizeLfgInput(input, { creatorId: actor.id, timezone: actor.timezone });
-    const created = await this.adapter.createPost(normalized.data);
+  // No ownership check — the creator becomes the owner, unless the system
+  // actor supplies an explicit creator_id (e.g. backfill/import flows).
+  async createPost(actor, input, { timezone } = {}) {
+    const creatorId = isSystem(actor) ? (input?.creator_id ?? actor?.profileId ?? null) : (actor?.profileId ?? null);
+    const normalized = normalizeLfgInput(input, { creatorId, timezone });
+    const created = await this.repo.createPost(normalized.data);
     if (created.error || !created.data || created.data.length === 0) {
       return created.error ? { data: null, error: created.error } : { data: null, error: 'Failed to create LFG post' };
     }
     const post = created.data[0];
-    const role = await this.reconcileCreatorRole(post.id, actor.id, normalized.role);
+    const role = await this.reconcileCreatorRole(post.id, actor, creatorId, normalized.role);
     if (role.error) return { data: null, error: role.error };
     return { data: post, error: null };
   }
 
-  async updatePost(id, input, actor) {
-    const existing = await this.adapter.getPost(id);
-    if (existing.error || !existing.data) return { data: null, error: existing.error || 'LFG post not found' };
-    if (existing.data.creator_id !== actor.id) return { data: null, error: 'Unauthorized' };
+  async updatePost(actor, id, input, { timezone } = {}) {
+    const { data: existing, error: existingError } = await this.repo.fetchPostPermissionRow(id);
+    if (existingError) return { data: null, error: existingError };
+    if (!existing) return { data: null, error: { status: 404, code: 'not_found', message: 'LFG post not found' } };
+    if (!canManagePost(actor, existing)) {
+      throw new AuthorizationError('Not authorized to update this LFG post', { reason: 'not_host' });
+    }
 
-    const normalized = normalizeLfgInput(input, { timezone: actor.timezone });
+    const normalized = normalizeLfgInput(input, { timezone });
     // Kept before the parent update to retain the historical outcome ordering.
-    const role = await this.reconcileCreatorRole(id, actor.id, normalized.role);
+    const role = await this.reconcileCreatorRole(id, actor, existing.creator_id, normalized.role);
     if (role.error) return { data: null, error: role.error };
-    const updated = await this.adapter.updatePost(id, actor.id, normalized.data);
+    const updated = await this.repo.updatePost(id, existing.creator_id, normalized.data);
     if (updated.error) return { data: null, error: updated.error };
     if (!updated.data || updated.data.length === 0) return { data: null, error: 'Update returned no rows' };
     return { data: updated.data[0], error: null };
   }
 
-  async reconcileCreatorRole(postId, profileId, { hostFlag, characterId }) {
+  async deletePost(actor, id) {
+    const { data: post, error } = await this.repo.fetchPostPermissionRow(id);
+    if (error) return { data: null, error };
+    if (!post) return { data: null, error: { status: 404, code: 'not_found', message: 'LFG post not found' } };
+    if (!canManagePost(actor, post)) {
+      throw new AuthorizationError('Not authorized to delete this LFG post', { reason: 'not_host' });
+    }
+    return this.repo.deletePost(id, post.creator_id);
+  }
+
+  async closePost(actor, id) {
+    const { data: post, error } = await this.repo.fetchPostPermissionRow(id);
+    if (error) return { data: null, error };
+    if (!post) return { data: null, error: { status: 404, code: 'not_found', message: 'Post not found' } };
+    if (!canManagePost(actor, post)) {
+      throw new AuthorizationError('Only the host can close this post', { reason: 'not_host' });
+    }
+    const result = await this.repo.closePost(id, post.creator_id);
+    if (result.error) return { data: null, error: result.error };
+    // Race guard: the row could have changed creator between the read above
+    // and the write's .eq('creator_id', ...) filter.
+    if (!result.data) throw new AuthorizationError('Only the host can close this post', { reason: 'not_host' });
+    return { data: result.data, error: null };
+  }
+
+  // Shared join logic for both the web-facing joinLfgPost (which may pass a
+  // caller-scoped `client` for the character-ownership read, preserving
+  // pre-refactor behavior) and the agent surface (which always reads via the
+  // repository/service-role client, since there is no user session to scope to).
+  async join(actor, { postId, joinType, characterId, client } = {}) {
+    if (joinType === 'player' && !characterId) {
+      return { data: null, error: 'Character is required for player join' };
+    }
+    let resolvedCharacterId = characterId;
+    if (joinType === 'player') {
+      const { data: character, error: characterError } = client
+        ? await client.from('characters').select('*').eq('id', characterId).single()
+        : await this.repo.getCharacterForJoin(characterId);
+      if (characterError) return { data: null, error: characterError };
+      if (!canJoinAsCharacter(actor, character)) {
+        return {
+          data: null,
+          error: character && character.is_deceased
+            ? 'Deceased characters cannot join games'
+            : 'You can only join with your own character'
+        };
+      }
+    }
+    if (joinType === 'conduit') resolvedCharacterId = null;
+
+    if (joinType === 'conduit') {
+      const { data: approvedConduit } = await this.repo.getApprovedConduit(postId);
+      if (approvedConduit && approvedConduit.length > 0) {
+        return { data: null, error: 'Conduit slot is already filled' };
+      }
+    }
+
+    // Auto-approve when the joiner is the post's creator — they're picking a role for their own post.
+    const { data: postRow } = await this.repo.getPostCreatorId(postId);
+    const status = postRow?.creator_id === actor.profileId ? 'approved' : 'pending';
+
+    const joinRequest = {
+      lfg_post_id: postId,
+      profile_id: actor.profileId,
+      join_type: joinType,
+      character_id: resolvedCharacterId,
+      status
+    };
+
+    const { data, error } = await this.repo.insertJoinRequest(joinRequest);
+    if (error) return { data, error };
+    if (status === 'approved' && joinType === 'conduit') await this.syncConduitHostId(postId);
+    return { data, error };
+  }
+
+  async reconcileCreatorRole(postId, actor, profileId, { hostFlag, characterId }) {
     const desired = hostFlag ? { type: 'conduit', character: null }
       : (characterId ? { type: 'player', character: characterId } : null);
     if (!desired) return { error: null };
-    const existing = await this.adapter.getCreatorRequest(profileId, postId);
+    const existing = await this.repo.getCreatorRequest(profileId, postId);
     const request = existing.data;
     if (existing.error && existing.error.code !== 'PGRST116') return { error: existing.error };
     if (request && request.join_type === desired.type && request.character_id === desired.character) return { error: null };
     if (request) {
-      const deleted = await this.adapter.deleteJoinRequest(request.id);
+      const deleted = await this.repo.deleteJoinRequestRow(request.id);
       if (deleted.error) return { error: deleted.error };
     }
-    const joined = await this.adapter.joinPost(postId, profileId, desired.type, desired.character);
+    // The role being reconciled always belongs to `profileId` (the post's
+    // creator), which may differ from actor.profileId when a system actor
+    // creates a post on another profile's behalf.
+    const joinActor = { profileId, role: actor?.role };
+    const joined = await this.join(joinActor, { postId, joinType: desired.type, characterId: desired.character });
     return { error: joined.error || null };
+  }
+
+  // Internal denormalization: keeps lfg_posts.host_id in sync with the
+  // approved conduit join_request (if any). Not policy-gated — this is
+  // system-triggered bookkeeping after an already-authorized mutation, never
+  // a direct user command.
+  async syncConduitHostId(postId) {
+    const { data: approved } = await this.repo.getApprovedConduitProfile(postId);
+    const newHostId = approved?.profile_id || null;
+    return this.repo.updatePostHostId(postId, newHostId);
+  }
+
+  // Approve/reject a join request. Closes the previously caller-enforced gap:
+  // the capability now verifies the actor is the post's host (or admin/system)
+  // itself, rather than trusting the caller to have checked.
+  async updateJoinRequest(actor, { requestId, status, postId = null }) {
+    const { data: request, error } = await this.repo.fetchJoinRequestWithPost(requestId);
+    if (error) return { data: null, error };
+    if (!request) return { data: null, error: { status: 404, code: 'not_found', message: 'Request not found' } };
+    if (!canModerateJoinRequest(actor, { creator_id: request.post?.creator_id })) {
+      throw new AuthorizationError('Only the host can moderate join requests', { reason: 'not_host' });
+    }
+    const resolvedPostId = postId || request.lfg_post_id;
+    const result = await this.repo.updateJoinRequestStatusRow(requestId, status, resolvedPostId);
+    if (result.error) return { data: null, error: result.error };
+    await this.syncConduitHostId(resolvedPostId);
+    return result;
+  }
+
+  // Withdraw/remove a join request. Closes the previously caller-enforced gap:
+  // the capability now verifies the actor owns the request (or is the post's
+  // host/admin/system moderating it), rather than trusting the caller.
+  async leave(actor, requestId) {
+    const { data: request, error } = await this.repo.fetchJoinRequestWithPost(requestId);
+    if (error) return { data: null, error };
+    if (!request) return { data: null, error: { status: 404, code: 'not_found', message: 'Join request not found' } };
+    const post = { creator_id: request.post?.creator_id };
+    if (!canManageOwnJoinRequest(actor, request) && !canModerateJoinRequest(actor, post)) {
+      throw new AuthorizationError('Not authorized to remove this join request', { reason: 'not_owner' });
+    }
+    const result = await this.repo.deleteJoinRequestRow(requestId);
+    if (!result.error && request.lfg_post_id) await this.syncConduitHostId(request.lfg_post_id);
+    return result;
+  }
+
+  // ─── Agent-scoped capabilities ─────────────────────────────────────────
+
+  async listForAgent(actor, { scope = 'public', status = 'open' } = {}) {
+    let rows;
+    let error;
+    if (scope === 'mine') {
+      ({ data: rows, error } = await this.repo.listPostsWithRequestsBy({ creator_id: actor.profileId }, { status }));
+    } else if (scope === 'joined') {
+      const { data: joined, error: joinedErr } = await this.repo.listJoinedPostIds(actor.profileId);
+      if (joinedErr) return { data: null, error: joinedErr };
+      const ids = (joined || []).map((r) => r.lfg_post_id);
+      if (ids.length === 0) return { data: [], error: null };
+      ({ data: rows, error } = await this.repo.listPostsByIds(ids, { status }));
+    } else {
+      const cutoff = new Date();
+      cutoff.setUTCHours(0, 0, 0, 0);
+      cutoff.setUTCDate(cutoff.getUTCDate() - 14);
+      ({ data: rows, error } = await this.repo.listPostsWithRequestsBy(
+        { is_public: true },
+        { status, dateFrom: cutoff.toISOString() }
+      ));
+    }
+    if (error) return { data: null, error };
+    normalizeJoinRequests(rows || []);
+    const projected = (rows || []).map((p) => {
+      const full = serializePostForAgent(p, { agentProfileId: actor.profileId, includePending: false });
+      return {
+        id: full.id,
+        title: full.title,
+        date: full.date,
+        host: full.host,
+        max_characters: full.max_characters,
+        is_public: full.is_public,
+        status: full.status,
+        player_count: full.player_count,
+        has_conduit: full.has_conduit,
+        my_request_status: full.my_request?.status || null
+      };
+    });
+    return { data: projected, error: null };
+  }
+
+  async getForAgent(actor, { postId }) {
+    const { data: raw, error } = await this.repo.getPostForAgentRow(postId);
+    if (error) return { data: null, error };
+    if (!raw) return { data: null, error: { status: 404, code: 'not_found', message: 'Post not found' } };
+    raw.join_requests = raw.lfg_join_requests || [];
+    delete raw.lfg_join_requests;
+    return {
+      data: serializePostForAgent(raw, { agentProfileId: actor.profileId, includePending: true }),
+      error: null
+    };
+  }
+
+  async joinForAgent(actor, { postId, joinType, characterId }) {
+    if (joinType === 'player') {
+      if (!characterId) {
+        return { data: null, error: { status: 400, code: 'character_required', message: 'Player joins require a character' } };
+      }
+      const { data: character, error: charErr } = await this.repo.getCharacterForJoin(characterId);
+      if (charErr) return { data: null, error: charErr };
+      if (!canJoinAsCharacter(actor, character)) {
+        return { data: null, error: { status: 400, code: 'character_ineligible', message: 'Character is deceased or not yours' } };
+      }
+    }
+
+    const { data: existing, error: existingErr } = await this.repo.getExistingJoinRequest(postId, actor.profileId);
+    if (existingErr) return { data: null, error: existingErr };
+    if (existing && existing.status !== 'rejected') {
+      return { data: null, error: { status: 409, code: 'duplicate_request', message: 'You already have a request on this post' } };
+    }
+
+    if (joinType === 'conduit') {
+      const { data: conduitRequests, error: conduitErr } = await this.repo.getApprovedConduit(postId);
+      if (conduitErr) return { data: null, error: conduitErr };
+      if (conduitRequests && conduitRequests.length > 0) {
+        return { data: null, error: { status: 409, code: 'conduit_taken', message: 'Conduit slot is already filled' } };
+      }
+    }
+
+    const { data: request, error } = await this.join(actor, { postId, joinType, characterId: characterId || null });
+    if (error) return { data: null, error };
+    const post = await this.getForAgent(actor, { postId });
+    if (post.error) return { data: null, error: post.error };
+    return { data: { request, post: post.data }, error: null };
+  }
+
+  async leaveForAgent(actor, { postId }) {
+    const { data: existing, error } = await this.repo.getExistingJoinRequest(postId, actor.profileId);
+    if (error) return { data: null, error };
+    if (!existing) {
+      const post = await this.getForAgent(actor, { postId });
+      if (post.error) return { data: null, error: post.error };
+      return { data: { deleted: false, post: post.data }, error: null };
+    }
+    const result = await this.leave(actor, existing.id);
+    if (result.error) return result;
+    const post = await this.getForAgent(actor, { postId });
+    if (post.error) return { data: null, error: post.error };
+    return { data: { deleted: true, post: post.data }, error: null };
+  }
+
+  async updateRequestForAgent(actor, { requestId, status }) {
+    if (status !== 'approved' && status !== 'rejected') {
+      return { data: null, error: { status: 400, code: 'invalid_status', message: 'status must be approved or rejected' } };
+    }
+    const updateResult = await this.updateJoinRequest(actor, { requestId, status });
+    if (updateResult.error) return updateResult;
+    const { data: updatedRequest, error: fetchErr } = await this.repo.getJoinRequestRow(requestId);
+    if (fetchErr) return { data: null, error: fetchErr };
+    const post = await this.getForAgent(actor, { postId: updatedRequest.lfg_post_id });
+    if (post.error) return { data: null, error: post.error };
+    return { data: { request: updatedRequest, post: post.data }, error: null };
+  }
+
+  async listEligibleCharactersForAgent(actor) {
+    const { data, error } = await this.repo.listEligibleCharacters(actor.profileId);
+    if (error) return { data: null, error };
+    return {
+      data: (data || []).map((c) => ({ id: c.id, name: c.name, class_name: c.class, level: c.level })),
+      error: null
+    };
   }
 }
 

--- a/services/lfg/service.js
+++ b/services/lfg/service.js
@@ -162,11 +162,15 @@ class LfgService {
         : await this.repo.getCharacterForJoin(characterId);
       if (characterError) return { data: null, error: characterError };
       if (!canJoinAsCharacter(actor, character)) {
+        // Ownership is checked before deceased status, matching the
+        // pre-refactor joinLfgPost ordering: a non-owned, deceased character
+        // must still surface the ownership message, not the deceased one.
+        const ownsCharacter = !!character && actor?.profileId === character.creator_id;
         return {
           data: null,
-          error: character && character.is_deceased
-            ? 'Deceased characters cannot join games'
-            : 'You can only join with your own character'
+          error: !ownsCharacter
+            ? 'You can only join with your own character'
+            : 'Deceased characters cannot join games'
         };
       }
     }

--- a/services/lfg/service.test.js
+++ b/services/lfg/service.test.js
@@ -1,17 +1,45 @@
 const { test, expect } = require('bun:test');
 const { normalizeLfgInput } = require('./input');
 const { LfgService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
+const { SYSTEM_ACTOR } = require('../../util/actor');
 
-const makeAdapter = () => {
+const CREATOR = { profileId: 'creator-1', role: 'user' };
+const STRANGER = { profileId: 'stranger', role: 'user' };
+const ADMIN = { profileId: 'admin-1', role: 'admin' };
+
+const makeRepo = (overrides = {}) => {
   const calls = [];
+  const state = {
+    post: { id: 'post-1', creator_id: 'creator-1' },
+    request: { id: 'req-1', lfg_post_id: 'post-1', profile_id: 'creator-1', post: { creator_id: 'creator-1' } },
+    ...overrides
+  };
   return {
     calls,
-    getPost: async () => ({ data: { id: 'post-1', creator_id: 'actor-1' }, error: null }),
-    createPost: async data => { calls.push(['createPost', data]); return { data: [{ id: 'post-1', ...data }], error: null }; },
-    updatePost: async (id, actorId, data) => { calls.push(['updatePost', id, actorId, data]); return { data: [{ id, ...data }], error: null }; },
-    getCreatorRequest: async () => ({ data: null, error: null }),
-    deleteJoinRequest: async id => { calls.push(['deleteJoinRequest', id]); return { data: null, error: null }; },
-    joinPost: async (...args) => { calls.push(['joinPost', ...args]); return { data: [], error: null }; }
+    state,
+    createPost: async (data) => { calls.push(['createPost', data]); return { data: [{ id: 'post-1', ...data }], error: null }; },
+    updatePost: async (id, creatorId, data) => { calls.push(['updatePost', id, creatorId, data]); return { data: [{ id, ...data }], error: null }; },
+    getCreatorRequest: async (profileId, postId) => { calls.push(['getCreatorRequest', profileId, postId]); return { data: null, error: null }; },
+    fetchPostPermissionRow: async (id) => { calls.push(['fetchPostPermissionRow', id]); return { data: state.post, error: null }; },
+    deletePost: async (id, creatorId) => { calls.push(['deletePost', id, creatorId]); return { data: null, error: null }; },
+    closePost: async (id, creatorId) => { calls.push(['closePost', id, creatorId]); return { data: { id, status: 'closed' }, error: null }; },
+    getApprovedConduit: async (postId) => { calls.push(['getApprovedConduit', postId]); return { data: [], error: null }; },
+    getPostCreatorId: async (postId) => { calls.push(['getPostCreatorId', postId]); return { data: { creator_id: state.post?.creator_id }, error: null }; },
+    insertJoinRequest: async (row) => { calls.push(['insertJoinRequest', row]); return { data: [{ id: 'jr-1', ...row }], error: null }; },
+    getApprovedConduitProfile: async (postId) => { calls.push(['getApprovedConduitProfile', postId]); return { data: null, error: null }; },
+    updatePostHostId: async (postId, hostId) => { calls.push(['updatePostHostId', postId, hostId]); return { error: null }; },
+    fetchJoinRequestWithPost: async (id) => { calls.push(['fetchJoinRequestWithPost', id]); return { data: state.request, error: null }; },
+    getJoinRequestRow: async (id) => { calls.push(['getJoinRequestRow', id]); return { data: { id, ...state.request }, error: null }; },
+    updateJoinRequestStatusRow: async (id, status, postId) => { calls.push(['updateJoinRequestStatusRow', id, status, postId]); return { data: null, error: null }; },
+    deleteJoinRequestRow: async (id) => { calls.push(['deleteJoinRequestRow', id]); return { data: null, error: null }; },
+    listPostsWithRequestsBy: async (filters, opts) => { calls.push(['listPostsWithRequestsBy', filters, opts]); return { data: [], error: null }; },
+    listJoinedPostIds: async (profileId) => { calls.push(['listJoinedPostIds', profileId]); return { data: [], error: null }; },
+    listPostsByIds: async (ids, opts) => { calls.push(['listPostsByIds', ids, opts]); return { data: [], error: null }; },
+    getPostForAgentRow: async (postId) => { calls.push(['getPostForAgentRow', postId]); return { data: { id: postId, creator: { id: 'creator-1' }, lfg_join_requests: [] }, error: null }; },
+    getCharacterForJoin: async (id) => { calls.push(['getCharacterForJoin', id]); return { data: { id, creator_id: 'creator-1', is_deceased: false }, error: null }; },
+    getExistingJoinRequest: async (postId, profileId) => { calls.push(['getExistingJoinRequest', postId, profileId]); return { data: null, error: null }; },
+    listEligibleCharacters: async (profileId) => { calls.push(['listEligibleCharacters', profileId]); return { data: [{ id: 'char-1', name: 'A', class: 'Warrior', level: 1 }], error: null }; }
   };
 };
 
@@ -24,19 +52,354 @@ test('normalizes LFG input without mutating the submitted request', () => {
   expect(result.role).toEqual({ hostFlag: true, characterId: 'char-1' });
 });
 
-test('creates a normalized post then reconciles the creator role', async () => {
-  const adapter = makeAdapter();
-  const service = new LfgService(adapter);
-  const result = await service.createPost({ title: 'Game', host_id: 'on', is_public: false, date: '2026-07-11' }, { id: 'actor-1', timezone: 'UTC' });
-  expect(result.error).toBeNull();
-  expect(adapter.calls.map(call => call[0])).toEqual(['createPost', 'joinPost']);
-  expect(adapter.calls[1]).toEqual(['joinPost', 'post-1', 'actor-1', 'conduit', null]);
+test('constructor requires every repository method', () => {
+  expect(() => new LfgService({})).toThrow(TypeError);
 });
 
-test('rejects an update by a non-owner without writing', async () => {
-  const adapter = makeAdapter();
-  const service = new LfgService(adapter);
-  const result = await service.updatePost('post-1', { title: 'Nope' }, { id: 'other', timezone: 'UTC' });
-  expect(result.error).toBe('Unauthorized');
-  expect(adapter.calls).toEqual([]);
+// ─── createPost / updatePost ────────────────────────────────────────────────
+
+test('creates a normalized post then reconciles the creator role', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.createPost(CREATOR, { title: 'Game', host_id: 'on', is_public: false, date: '2026-07-11' });
+  expect(result.error).toBeNull();
+  expect(repo.calls.map(c => c[0])).toEqual([
+    'createPost', 'getCreatorRequest', 'getApprovedConduit', 'getPostCreatorId', 'insertJoinRequest',
+    'getApprovedConduitProfile', 'updatePostHostId'
+  ]);
+});
+
+test('the system actor may create a post with an explicit creator_id', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await service.createPost(SYSTEM_ACTOR, { title: 'Game', is_public: false, date: '2026-07-11', creator_id: 'other-profile' });
+  expect(repo.calls[0]).toEqual(['createPost', expect.objectContaining({ creator_id: 'other-profile' })]);
+});
+
+test('the owner may update their post; the write reaches the repository', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.updatePost(CREATOR, 'post-1', { title: 'New title' });
+  expect(result.error).toBeNull();
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPostPermissionRow', 'updatePost']);
+  expect(repo.calls[1]).toEqual(['updatePost', 'post-1', 'creator-1', expect.objectContaining({ title: 'New title' })]);
+});
+
+test('an admin may update a post they do not own', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.updatePost(ADMIN, 'post-1', { title: 'New title' });
+  expect(result.error).toBeNull();
+});
+
+test('a non-owner updating a post throws AuthorizationError, never reaching the write', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await expect(service.updatePost(STRANGER, 'post-1', { title: 'Nope' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPostPermissionRow']);
+});
+
+test('updating a post that does not exist returns a structured 404, without throwing', async () => {
+  const repo = makeRepo({ post: null });
+  const service = new LfgService(repo);
+  const result = await service.updatePost(CREATOR, 'missing', { title: 'x' });
+  expect(result.data).toBeNull();
+  expect(result.error).toEqual({ status: 404, code: 'not_found', message: 'LFG post not found' });
+});
+
+// ─── deletePost ──────────────────────────────────────────────────────────────
+
+test('the owner may delete their post', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await service.deletePost(CREATOR, 'post-1');
+  expect(repo.calls).toEqual([['fetchPostPermissionRow', 'post-1'], ['deletePost', 'post-1', 'creator-1']]);
+});
+
+test('the system actor may delete any post', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await service.deletePost(SYSTEM_ACTOR, 'post-1');
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPostPermissionRow', 'deletePost']);
+});
+
+test('a stranger deleting a post throws AuthorizationError, never reaching the delete', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await expect(service.deletePost(STRANGER, 'post-1')).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([['fetchPostPermissionRow', 'post-1']]);
+});
+
+test('deleting a post that does not exist returns a structured 404', async () => {
+  const repo = makeRepo({ post: null });
+  const service = new LfgService(repo);
+  const result = await service.deletePost(CREATOR, 'missing');
+  expect(result.error).toEqual({ status: 404, code: 'not_found', message: 'LFG post not found' });
+});
+
+// ─── closePost ───────────────────────────────────────────────────────────────
+
+test('the host may close their post', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.closePost(CREATOR, 'post-1');
+  expect(result.error).toBeNull();
+  expect(result.data.status).toBe('closed');
+});
+
+test('a non-host closing a post throws AuthorizationError with reason not_host', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  try {
+    await service.closePost(STRANGER, 'post-1');
+    throw new Error('expected throw');
+  } catch (err) {
+    expect(err).toBeInstanceOf(AuthorizationError);
+    expect(err.reason).toBe('not_host');
+    expect(err.status).toBe(403);
+  }
+});
+
+test('closing a post that does not exist returns a structured 404, without throwing', async () => {
+  const repo = makeRepo({ post: null });
+  const service = new LfgService(repo);
+  const result = await service.closePost(STRANGER, 'missing');
+  expect(result.error).toEqual({ status: 404, code: 'not_found', message: 'Post not found' });
+});
+
+// ─── join (shared by joinLfgPost and joinForAgent) ──────────────────────────
+
+test('join uses the passed client for the character-ownership read when provided', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const clientCalls = [];
+  const client = {
+    from: (table) => {
+      clientCalls.push(table);
+      return { select: () => ({ eq: () => ({ single: async () => ({ data: { id: 'char-1', creator_id: 'creator-1', is_deceased: false }, error: null }) }) }) };
+    }
+  };
+  const result = await service.join(CREATOR, { postId: 'post-1', joinType: 'player', characterId: 'char-1', client });
+  expect(result.error).toBeNull();
+  expect(clientCalls).toEqual(['characters']);
+  expect(repo.calls.some(c => c[0] === 'getCharacterForJoin')).toBe(false);
+});
+
+test('join falls back to the repository for the character read with no client', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.join(CREATOR, { postId: 'post-1', joinType: 'player', characterId: 'char-1' });
+  expect(result.error).toBeNull();
+  expect(repo.calls.some(c => c[0] === 'getCharacterForJoin')).toBe(true);
+});
+
+test('join rejects a character the actor does not own', async () => {
+  const repo = makeRepo();
+  repo.getCharacterForJoin = async () => ({ data: { id: 'char-1', creator_id: 'someone-else', is_deceased: false }, error: null });
+  const service = new LfgService(repo);
+  const result = await service.join(CREATOR, { postId: 'post-1', joinType: 'player', characterId: 'char-1' });
+  expect(result.data).toBeNull();
+  expect(result.error).toBe('You can only join with your own character');
+});
+
+test('join rejects a deceased character', async () => {
+  const repo = makeRepo();
+  repo.getCharacterForJoin = async () => ({ data: { id: 'char-1', creator_id: 'creator-1', is_deceased: true }, error: null });
+  const service = new LfgService(repo);
+  const result = await service.join(CREATOR, { postId: 'post-1', joinType: 'player', characterId: 'char-1' });
+  expect(result.data).toBeNull();
+  expect(result.error).toBe('Deceased characters cannot join games');
+});
+
+test('join auto-approves when the joiner is the post creator', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.join(CREATOR, { postId: 'post-1', joinType: 'conduit' });
+  expect(result.data[0].status).toBe('approved');
+});
+
+test('join stays pending for a non-creator joiner', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.join(STRANGER, { postId: 'post-1', joinType: 'conduit' });
+  expect(result.data[0].status).toBe('pending');
+});
+
+test('join rejects a conduit request when the slot is already filled', async () => {
+  const repo = makeRepo();
+  repo.getApprovedConduit = async () => ({ data: [{ id: 'existing' }], error: null });
+  const service = new LfgService(repo);
+  const result = await service.join(STRANGER, { postId: 'post-1', joinType: 'conduit' });
+  expect(result.data).toBeNull();
+  expect(result.error).toBe('Conduit slot is already filled');
+});
+
+// ─── updateJoinRequest (previously caller-enforced — now gated here) ────────
+
+test('the host may approve a join request', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.updateJoinRequest(CREATOR, { requestId: 'req-1', status: 'approved' });
+  expect(result.error).toBeNull();
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchJoinRequestWithPost', 'updateJoinRequestStatusRow', 'getApprovedConduitProfile', 'updatePostHostId']);
+});
+
+test('the system actor may update any join request', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.updateJoinRequest(SYSTEM_ACTOR, { requestId: 'req-1', status: 'rejected' });
+  expect(result.error).toBeNull();
+});
+
+test('a non-host updating a join request throws AuthorizationError(not_host), never writing', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await expect(service.updateJoinRequest(STRANGER, { requestId: 'req-1', status: 'approved' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchJoinRequestWithPost']);
+});
+
+test('updating an unknown join request returns a structured 404', async () => {
+  const repo = makeRepo({ request: null });
+  const service = new LfgService(repo);
+  const result = await service.updateJoinRequest(CREATOR, { requestId: 'missing', status: 'approved' });
+  expect(result.error).toEqual({ status: 404, code: 'not_found', message: 'Request not found' });
+});
+
+// ─── leave (previously caller-enforced — now gated here) ────────────────────
+
+test('the request owner may withdraw their own request', async () => {
+  const repo = makeRepo({ request: { id: 'req-1', lfg_post_id: 'post-1', profile_id: 'stranger', post: { creator_id: 'creator-1' } } });
+  const service = new LfgService(repo);
+  const result = await service.leave(STRANGER, 'req-1');
+  expect(result.error).toBeNull();
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchJoinRequestWithPost', 'deleteJoinRequestRow', 'getApprovedConduitProfile', 'updatePostHostId']);
+});
+
+test('the host may remove a join request they do not own (moderation)', async () => {
+  const repo = makeRepo({ request: { id: 'req-1', lfg_post_id: 'post-1', profile_id: 'stranger', post: { creator_id: 'creator-1' } } });
+  const service = new LfgService(repo);
+  const result = await service.leave(CREATOR, 'req-1');
+  expect(result.error).toBeNull();
+});
+
+test('the system actor may remove any join request', async () => {
+  const repo = makeRepo({ request: { id: 'req-1', lfg_post_id: 'post-1', profile_id: 'stranger', post: { creator_id: 'creator-1' } } });
+  const service = new LfgService(repo);
+  const result = await service.leave(SYSTEM_ACTOR, 'req-1');
+  expect(result.error).toBeNull();
+});
+
+test('a third party may NOT remove someone else\'s join request', async () => {
+  const repo = makeRepo({ request: { id: 'req-1', lfg_post_id: 'post-1', profile_id: 'stranger', post: { creator_id: 'creator-1' } } });
+  const service = new LfgService(repo);
+  await expect(service.leave({ profileId: 'third-party', role: 'user' }, 'req-1')).rejects.toThrow(AuthorizationError);
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchJoinRequestWithPost']);
+});
+
+test('leaving an unknown join request returns a structured 404', async () => {
+  const repo = makeRepo({ request: null });
+  const service = new LfgService(repo);
+  const result = await service.leave(CREATOR, 'missing');
+  expect(result.error).toEqual({ status: 404, code: 'not_found', message: 'Join request not found' });
+});
+
+// ─── agent surface ──────────────────────────────────────────────────────────
+
+test('joinForAgent rejects an ineligible character with a 400', async () => {
+  const repo = makeRepo();
+  repo.getCharacterForJoin = async () => ({ data: { id: 'char-1', creator_id: 'someone-else', is_deceased: false }, error: null });
+  const service = new LfgService(repo);
+  const result = await service.joinForAgent(CREATOR, { postId: 'post-1', joinType: 'player', characterId: 'char-1' });
+  expect(result.data).toBeNull();
+  expect(result.error).toEqual({ status: 400, code: 'character_ineligible', message: 'Character is deceased or not yours' });
+});
+
+test('joinForAgent rejects a duplicate active request with a 409', async () => {
+  const repo = makeRepo();
+  repo.getExistingJoinRequest = async () => ({ data: { id: 'existing', status: 'pending' }, error: null });
+  const service = new LfgService(repo);
+  const result = await service.joinForAgent(CREATOR, { postId: 'post-1', joinType: 'conduit' });
+  expect(result.error).toEqual({ status: 409, code: 'duplicate_request', message: 'You already have a request on this post' });
+});
+
+test('joinForAgent rejects a conduit join when the slot is filled with a 409', async () => {
+  const repo = makeRepo();
+  repo.getApprovedConduit = async () => ({ data: [{ id: 'existing' }], error: null });
+  const service = new LfgService(repo);
+  const result = await service.joinForAgent(CREATOR, { postId: 'post-1', joinType: 'conduit' });
+  expect(result.error).toEqual({ status: 409, code: 'conduit_taken', message: 'Conduit slot is already filled' });
+});
+
+test('joinForAgent succeeds and returns the request plus the refreshed post', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.joinForAgent(CREATOR, { postId: 'post-1', joinType: 'conduit' });
+  expect(result.error).toBeNull();
+  expect(result.data.request).toBeDefined();
+  expect(result.data.post).toBeDefined();
+});
+
+test('updateRequestForAgent rejects an invalid status with a 400, before touching the repository', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.updateRequestForAgent(CREATOR, { requestId: 'req-1', status: 'bogus' });
+  expect(result.error).toEqual({ status: 400, code: 'invalid_status', message: 'status must be approved or rejected' });
+  expect(repo.calls).toEqual([]);
+});
+
+test('updateRequestForAgent: non-host gets error.status 403 / error.code not_host (thrown, not returned)', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  await expect(service.updateRequestForAgent(STRANGER, { requestId: 'req-1', status: 'approved' })).rejects.toThrow(AuthorizationError);
+});
+
+test('updateRequestForAgent succeeds for the host and returns the updated request plus post', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.updateRequestForAgent(CREATOR, { requestId: 'req-1', status: 'approved' });
+  expect(result.error).toBeNull();
+  expect(result.data.request).toBeDefined();
+  expect(result.data.post).toBeDefined();
+});
+
+test('leaveForAgent reports deleted:false and still returns the post when there is no active request', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.leaveForAgent(STRANGER, { postId: 'post-1' });
+  expect(result.error).toBeNull();
+  expect(result.data.deleted).toBe(false);
+  expect(result.data.post).toBeDefined();
+});
+
+test('leaveForAgent deletes the caller\'s own active request', async () => {
+  const repo = makeRepo();
+  repo.getExistingJoinRequest = async () => ({ data: { id: 'req-1', status: 'pending' }, error: null });
+  const service = new LfgService(repo);
+  const result = await service.leaveForAgent(CREATOR, { postId: 'post-1' });
+  expect(result.error).toBeNull();
+  expect(result.data.deleted).toBe(true);
+});
+
+test('listEligibleCharactersForAgent projects the eligible characters', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.listEligibleCharactersForAgent(CREATOR);
+  expect(result.error).toBeNull();
+  expect(result.data).toEqual([{ id: 'char-1', name: 'A', class_name: 'Warrior', level: 1 }]);
+});
+
+test('getForAgent 404s on a missing post', async () => {
+  const repo = makeRepo();
+  repo.getPostForAgentRow = async () => ({ data: null, error: null });
+  const service = new LfgService(repo);
+  const result = await service.getForAgent(CREATOR, { postId: 'missing' });
+  expect(result.error).toEqual({ status: 404, code: 'not_found', message: 'Post not found' });
+});
+
+test('listForAgent returns an empty list for scope=joined with no joined posts', async () => {
+  const repo = makeRepo();
+  const service = new LfgService(repo);
+  const result = await service.listForAgent(CREATOR, { scope: 'joined' });
+  expect(result.error).toBeNull();
+  expect(result.data).toEqual([]);
 });

--- a/services/lfg/service.test.js
+++ b/services/lfg/service.test.js
@@ -211,6 +211,15 @@ test('join rejects a deceased character', async () => {
   expect(result.error).toBe('Deceased characters cannot join games');
 });
 
+test('join reports the ownership message (not the deceased message) when a character is both not-owned and deceased', async () => {
+  const repo = makeRepo();
+  repo.getCharacterForJoin = async () => ({ data: { id: 'char-1', creator_id: 'someone-else', is_deceased: true }, error: null });
+  const service = new LfgService(repo);
+  const result = await service.join(CREATOR, { postId: 'post-1', joinType: 'player', characterId: 'char-1' });
+  expect(result.data).toBeNull();
+  expect(result.error).toBe('You can only join with your own character');
+});
+
 test('join auto-approves when the joiner is the post creator', async () => {
   const repo = makeRepo();
   const service = new LfgService(repo);

--- a/services/mission/policy.js
+++ b/services/mission/policy.js
@@ -1,0 +1,21 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// A mission may be edited by its creator, its host, an editor, or an
+// admin/system actor. Operates over pre-loaded rows (no I/O) so the
+// repository owns every privileged read.
+const canEditMission = (actor, { mission, editorRow } = {}) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  const isCreatorOrHost = !!actor?.profileId && !!mission &&
+    (actor.profileId === mission.creator_id || actor.profileId === mission.host_id);
+  return isCreatorOrHost || !!editorRow;
+};
+
+// Only the mission's creator (or an admin/system actor) may manage editors
+// or delete the mission — narrower than canEditMission, which also admits
+// the host and any editor.
+const isMissionCreator = (actor, mission) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor?.profileId && !!mission && actor.profileId === mission.creator_id;
+};
+
+module.exports = { canEditMission, isMissionCreator };

--- a/services/mission/policy.test.js
+++ b/services/mission/policy.test.js
@@ -1,0 +1,54 @@
+const { test, expect } = require('bun:test');
+const { canEditMission, isMissionCreator } = require('./policy');
+
+const MISSION = { creator_id: 'creator-1', host_id: 'host-1' };
+
+test('the creator may edit their mission', () => {
+  expect(canEditMission({ profileId: 'creator-1', role: 'user' }, { mission: MISSION })).toBe(true);
+});
+
+test('the host may edit the mission', () => {
+  expect(canEditMission({ profileId: 'host-1', role: 'user' }, { mission: MISSION })).toBe(true);
+});
+
+test('an editor (pre-loaded editor row) may edit the mission', () => {
+  const editorRow = { profile_id: 'editor-1' };
+  expect(canEditMission({ profileId: 'editor-1', role: 'user' }, { mission: MISSION, editorRow })).toBe(true);
+});
+
+test('an admin may edit any mission', () => {
+  expect(canEditMission({ profileId: 'admin-1', role: 'admin' }, { mission: MISSION })).toBe(true);
+});
+
+test('the system actor may edit any mission', () => {
+  expect(canEditMission({ role: 'system' }, { mission: MISSION })).toBe(true);
+});
+
+test('a stranger with no editor row may not edit the mission', () => {
+  expect(canEditMission({ profileId: 'stranger', role: 'user' }, { mission: MISSION })).toBe(false);
+});
+
+test('canEditMission is false without a loaded mission unless system/admin', () => {
+  expect(canEditMission({ profileId: 'creator-1', role: 'user' }, {})).toBe(false);
+  expect(canEditMission({ role: 'admin' }, {})).toBe(true);
+});
+
+test('the creator is the mission creator', () => {
+  expect(isMissionCreator({ profileId: 'creator-1', role: 'user' }, MISSION)).toBe(true);
+});
+
+test('the host is NOT the mission creator', () => {
+  expect(isMissionCreator({ profileId: 'host-1', role: 'user' }, MISSION)).toBe(false);
+});
+
+test('an admin counts as the mission creator', () => {
+  expect(isMissionCreator({ profileId: 'admin-1', role: 'admin' }, MISSION)).toBe(true);
+});
+
+test('the system actor counts as the mission creator', () => {
+  expect(isMissionCreator({ role: 'system' }, MISSION)).toBe(true);
+});
+
+test('a stranger is not the mission creator', () => {
+  expect(isMissionCreator({ profileId: 'stranger', role: 'user' }, MISSION)).toBe(false);
+});

--- a/services/mission/repository.js
+++ b/services/mission/repository.js
@@ -1,0 +1,76 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin for the mission domain. Holds every
+// privileged (service-role) query verbatim; models/mission.js keeps the
+// surrounding logic (transforms, search, badge orchestration via the service).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+module.exports = {
+  // Verbatim from the former inline adapter in models/mission.js.
+  getHost: id => supabaseAdmin.from('missions').select('host_id').eq('id', id).maybeSingle(),
+  createMissionRow: data => supabaseAdmin.from('missions').insert(data).select(),
+  updateMissionRow: (id, data) => supabaseAdmin.from('missions').update(data).eq('id', id).select(),
+  deleteMissionRow: (id, creatorId) => supabaseAdmin
+    .from('missions').delete().eq('id', id).eq('creator_id', creatorId),
+  getCharacterCreator: id => supabaseAdmin
+    .from('characters').select('creator_id').eq('id', id).maybeSingle(),
+  upsertMissionCharacter: (missionId, characterId) => supabaseAdmin
+    .from('mission_characters').upsert({ mission_id: missionId, character_id: characterId }).select(),
+  deleteMissionCharacter: (missionId, characterId) => supabaseAdmin
+    .from('mission_characters').delete().eq('mission_id', missionId).eq('character_id', characterId),
+  mergeMissions: (primaryId, secondaryId, actorId) => supabaseAdmin.rpc('merge_missions', {
+    primary_id: primaryId, secondary_id: secondaryId, actor_profile_id: actorId
+  }),
+
+  // New: privileged reads/writes used by the policy-gated capabilities.
+  updateUnregisteredNames: (missionId, names) => withResult(
+    supabaseAdmin.from('missions').update({ unregistered_character_names: names }).eq('id', missionId).select()
+  ),
+  upsertEditor: (row) => withResult(
+    supabaseAdmin.from('mission_editors').upsert(row).select()
+  ),
+  deleteEditor: async ({ missionId, profileId }) => {
+    const { error } = await supabaseAdmin
+      .from('mission_editors')
+      .delete()
+      .eq('mission_id', missionId)
+      .eq('profile_id', profileId);
+    if (error) {
+      console.error(error);
+      return { error };
+    }
+    return { error: null };
+  },
+  // Permission checks use supabaseAdmin to bypass RLS — this is a decision
+  // read for application-level authorization, not a data-visibility read.
+  // Without admin, the anon client (no JWT) would fail-closed for private
+  // missions and lock creators out of their own mission edit pages.
+  fetchMissionPermissionRow: (missionId) => withResult(
+    supabaseAdmin.from('missions').select('creator_id, host_id').eq('id', missionId).single()
+  ),
+  fetchCreatorId: (missionId) => withResult(
+    supabaseAdmin.from('missions').select('creator_id').eq('id', missionId).single()
+  ),
+  fetchEditorRow: async ({ missionId, profileId }) => {
+    const { data, error } = await supabaseAdmin
+      .from('mission_editors')
+      .select('profile_id')
+      .eq('mission_id', missionId)
+      .eq('profile_id', profileId)
+      .single();
+    if (error) {
+      // PGRST116 is "no rows" — not being an editor is a normal outcome, not a failure.
+      if (error.code === 'PGRST116') return { data: null, error: null };
+      console.error(error);
+      return { data: null, error };
+    }
+    return { data, error: null };
+  }
+};

--- a/services/mission/repository.test.js
+++ b/services/mission/repository.test.js
@@ -1,0 +1,34 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const repository = require('./repository');
+
+// Guards against a missed extraction: every privileged mission query must be
+// reachable through the repository, the sole consumer of supabaseAdmin for
+// this domain. Deep behavior is covered by the service/model tests that
+// already exercise these paths.
+const expectedMethods = [
+  'getHost',
+  'createMissionRow',
+  'updateMissionRow',
+  'deleteMissionRow',
+  'getCharacterCreator',
+  'upsertMissionCharacter',
+  'deleteMissionCharacter',
+  'mergeMissions',
+  'updateUnregisteredNames',
+  'upsertEditor',
+  'deleteEditor',
+  'fetchMissionPermissionRow',
+  'fetchCreatorId',
+  'fetchEditorRow'
+];
+
+test('exports every repository method', () => {
+  for (const method of expectedMethods) {
+    expect(typeof repository[method]).toBe('function');
+  }
+});

--- a/services/mission/service.js
+++ b/services/mission/service.js
@@ -1,76 +1,154 @@
 const { normalizeMissionInput } = require('./input');
+const { AuthorizationError } = require('../../util/errors');
+const { isSystem, isAdmin } = require('../../util/actor');
+const { canEditMission: policyCanEdit, isMissionCreator: policyIsCreator } = require('./policy');
 
-const REQUIRED_ADAPTER_METHODS = [
-  'canEdit', 'getHost', 'createMissionRow', 'updateMissionRow', 'deleteMissionRow',
+const REQUIRED_REPOSITORY_METHODS = [
+  'getHost', 'createMissionRow', 'updateMissionRow', 'deleteMissionRow',
   'getMissionProfileIds', 'getCharacterCreator', 'upsertMissionCharacter',
-  'deleteMissionCharacter', 'mergeMissions', 'getMission', 'recalcBadges'
+  'deleteMissionCharacter', 'mergeMissions', 'getMission', 'recalcBadges',
+  'updateUnregisteredNames', 'upsertEditor', 'deleteEditor',
+  'fetchMissionPermissionRow', 'fetchEditorRow', 'fetchCreatorId'
 ];
 
-/** Coordinates mission writes and badge side effects independently of Supabase. */
+const loadEditorRow = async (repo, missionId, actor) => {
+  // System/admin never need the editor lookup — the policy already admits
+  // them — and a bare profileId with no other relation gains nothing from it.
+  if (!actor?.profileId || isSystem(actor) || isAdmin(actor)) return null;
+  const { data } = await repo.fetchEditorRow({ missionId, profileId: actor.profileId });
+  return data;
+};
+
+// Loads the permission row and throws unless the actor can edit (creator,
+// host, editor, or admin/system). Returns the loaded mission row so callers
+// don't have to fetch it twice (e.g. deleteMission's SQL safety filter).
+const requireEditable = async (repo, actor, missionId) => {
+  const { data: mission, error } = await repo.fetchMissionPermissionRow(missionId);
+  if (error) throw error;
+  if (!mission) throw new AuthorizationError('Mission not found', { reason: 'not_found' });
+  const editorRow = await loadEditorRow(repo, missionId, actor);
+  if (!policyCanEdit(actor, { mission, editorRow })) {
+    throw new AuthorizationError('Not authorized to edit this mission', { reason: 'not_editor' });
+  }
+  return mission;
+};
+
+// Narrower than requireEditable: only the creator (or admin/system) passes.
+const requireMissionCreator = async (repo, actor, missionId) => {
+  const { data: mission, error } = await repo.fetchMissionPermissionRow(missionId);
+  if (error) throw error;
+  if (!mission) throw new AuthorizationError('Mission not found', { reason: 'not_found' });
+  if (!policyIsCreator(actor, mission)) {
+    throw new AuthorizationError('Not authorized: mission creator only', { reason: 'not_creator' });
+  }
+  return mission;
+};
+
+/** Coordinates mission writes, authorization, and badge side effects independently of Supabase. */
 class MissionService {
-  constructor(adapter) {
-    const missing = REQUIRED_ADAPTER_METHODS.filter(method => typeof adapter?.[method] !== 'function');
-    if (missing.length) throw new TypeError(`MissionService requires adapter methods: ${missing.join(', ')}`);
-    this.adapter = adapter;
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`MissionService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
   }
 
-  async createMission(input, actor) {
-    const data = normalizeMissionInput(input, { creatorId: actor.id });
-    const result = await this.adapter.createMissionRow(data);
-    if (!result.error && data.host_id) await this.adapter.recalcBadges([data.host_id]);
+  // No ownership check — the creator becomes the owner. creator_id is
+  // derived from the actor (not trusted from input) unless the actor is the
+  // system actor, which is allowed to set an explicit creator (e.g. backfill
+  // missions created on a user's behalf).
+  async createMission(actor, input) {
+    const creatorId = isSystem(actor) ? (input?.creator_id ?? null) : (actor?.profileId ?? null);
+    const data = normalizeMissionInput(input, { creatorId });
+    const result = await this.repo.createMissionRow(data);
+    if (!result.error && data.host_id) await this.repo.recalcBadges([data.host_id]);
     return result;
   }
 
-  async updateMission(id, input, actor) {
-    if (!await this.adapter.canEdit(id, actor)) {
-      return { data: null, error: 'Unauthorized: You do not have permission to edit this mission' };
-    }
-    const existing = await this.adapter.getHost(id);
+  async updateMission(actor, id, input) {
+    await requireEditable(this.repo, actor, id);
+    const existing = await this.repo.getHost(id);
     const data = normalizeMissionInput(input);
-    const result = await this.adapter.updateMissionRow(id, data);
-    if (!result.error) await this.adapter.recalcBadges([existing.data?.host_id, data.host_id]);
+    const result = await this.repo.updateMissionRow(id, data);
+    if (!result.error) await this.repo.recalcBadges([existing.data?.host_id, data.host_id]);
     return result;
   }
 
-  async deleteMission(id, actor) {
-    const affected = await this.adapter.getMissionProfileIds(id);
-    const result = await this.adapter.deleteMissionRow(id, actor.id);
-    if (!result.error) await this.adapter.recalcBadges(affected);
+  async deleteMission(actor, id) {
+    const mission = await requireMissionCreator(this.repo, actor, id);
+    const affected = await this.repo.getMissionProfileIds(id);
+    // The SQL filter (.eq('creator_id', ...)) is preserved as defense in
+    // depth; use the loaded creator_id (not actor.profileId) so admin/system
+    // deletions of another user's mission still match a row.
+    const result = await this.repo.deleteMissionRow(id, mission.creator_id);
+    if (!result.error) await this.repo.recalcBadges(affected);
     return result;
   }
 
-  async addCharacter(id, characterId) {
-    const result = await this.adapter.upsertMissionCharacter(id, characterId);
+  async addCharacter(actor, { missionId, characterId }) {
+    await requireEditable(this.repo, actor, missionId);
+    const result = await this.repo.upsertMissionCharacter(missionId, characterId);
     if (!result.error) await this.recalcCharacterCreator(characterId);
     return result;
   }
 
-  async removeCharacter(id, characterId) {
-    const result = await this.adapter.deleteMissionCharacter(id, characterId);
+  async removeCharacter(actor, { missionId, characterId }) {
+    await requireEditable(this.repo, actor, missionId);
+    const result = await this.repo.deleteMissionCharacter(missionId, characterId);
     if (!result.error) await this.recalcCharacterCreator(characterId);
     return result;
   }
 
   async recalcCharacterCreator(characterId) {
-    const character = await this.adapter.getCharacterCreator(characterId);
-    await this.adapter.recalcBadges([character.data?.creator_id]);
+    const character = await this.repo.getCharacterCreator(characterId);
+    await this.repo.recalcBadges([character.data?.creator_id]);
   }
 
-  async mergeMissions(primaryId, secondaryId, actor) {
-    const [canPrimary, canSecondary] = await Promise.all([
-      this.adapter.canEdit(primaryId, actor), this.adapter.canEdit(secondaryId, actor)
+  async setUnregisteredNames(actor, missionId, names) {
+    await requireEditable(this.repo, actor, missionId);
+    const cleanedNames = (Array.isArray(names) ? names : [])
+      .map(n => (typeof n === 'string' ? n.trim() : ''))
+      .filter(n => n.length > 0);
+    return this.repo.updateUnregisteredNames(missionId, cleanedNames);
+  }
+
+  async addEditor(actor, { missionId, profileId }) {
+    await requireMissionCreator(this.repo, actor, missionId);
+    return this.repo.upsertEditor({ mission_id: missionId, profile_id: profileId, added_by: actor?.profileId ?? null });
+  }
+
+  async removeEditor(actor, { missionId, profileId }) {
+    await requireMissionCreator(this.repo, actor, missionId);
+    return this.repo.deleteEditor({ missionId, profileId });
+  }
+
+  async mergeMissions(actor, primaryId, secondaryId) {
+    await Promise.all([
+      requireEditable(this.repo, actor, primaryId),
+      requireEditable(this.repo, actor, secondaryId)
     ]);
-    if (!canPrimary || !canSecondary) {
-      return { data: null, error: 'You must be able to edit both missions to merge them' };
-    }
     const affected = [
-      ...(await this.adapter.getMissionProfileIds(primaryId)),
-      ...(await this.adapter.getMissionProfileIds(secondaryId))
+      ...(await this.repo.getMissionProfileIds(primaryId)),
+      ...(await this.repo.getMissionProfileIds(secondaryId))
     ];
-    const result = await this.adapter.mergeMissions(primaryId, secondaryId, actor.id);
+    const result = await this.repo.mergeMissions(primaryId, secondaryId, actor?.profileId ?? null);
     if (result.error) return { data: null, error: result.error };
-    await this.adapter.recalcBadges(affected);
-    return this.adapter.getMission(primaryId);
+    await this.repo.recalcBadges(affected);
+    return this.repo.getMission(primaryId);
+  }
+
+  // Non-throwing compatibility checks for read/render call sites (e.g. "can
+  // this profile see the edit page") that predate the throw-on-deny capabilities.
+  async canEditMission(actor, missionId) {
+    const { data: mission, error } = await this.repo.fetchMissionPermissionRow(missionId);
+    if (error || !mission) return false;
+    const editorRow = await loadEditorRow(this.repo, missionId, actor);
+    return policyCanEdit(actor, { mission, editorRow });
+  }
+
+  async isCreator(actor, missionId) {
+    const { data: mission, error } = await this.repo.fetchCreatorId(missionId);
+    if (error || !mission) return false;
+    return policyIsCreator(actor, mission);
   }
 }
 

--- a/services/mission/service.test.js
+++ b/services/mission/service.test.js
@@ -1,23 +1,41 @@
 const { test, expect } = require('bun:test');
 const { normalizeMissionInput } = require('./input');
 const { MissionService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
+const { SYSTEM_ACTOR } = require('../../util/actor');
 
-const makeAdapter = () => {
+const MISSION_ID = 'mission-1';
+
+const CREATOR = { profileId: 'creator-1', role: 'user' };
+const HOST = { profileId: 'host-1', role: 'user' };
+const EDITOR = { profileId: 'editor-1', role: 'user' };
+const STRANGER = { profileId: 'stranger', role: 'user' };
+const ADMIN = { profileId: 'admin-1', role: 'admin' };
+
+const makeRepo = ({ mission = { creator_id: 'creator-1', host_id: 'host-1' }, editorProfileIds = ['editor-1'] } = {}) => {
   const calls = [];
   return {
     calls,
-    canEdit: async () => true,
     getHost: async () => ({ data: { host_id: 'old-host' }, error: null }),
     createMissionRow: async data => { calls.push(['create', data]); return { data: [data], error: null }; },
     updateMissionRow: async (id, data) => { calls.push(['update', id, data]); return { data: [data], error: null }; },
-    deleteMissionRow: async (id, actorId) => { calls.push(['delete', id, actorId]); return { data: null, error: null }; },
+    deleteMissionRow: async (id, creatorId) => { calls.push(['delete', id, creatorId]); return { data: null, error: null }; },
     getMissionProfileIds: async id => { calls.push(['affected', id]); return ['host', 'character-owner']; },
-    getCharacterCreator: async () => ({ data: { creator_id: 'character-owner' }, error: null }),
+    getCharacterCreator: async () => { calls.push(['getCharacterCreator']); return { data: { creator_id: 'character-owner' }, error: null }; },
     upsertMissionCharacter: async (id, charId) => { calls.push(['add', id, charId]); return { data: [], error: null }; },
     deleteMissionCharacter: async (id, charId) => { calls.push(['remove', id, charId]); return { data: null, error: null }; },
-    mergeMissions: async (primary, secondary, actor) => { calls.push(['merge', primary, secondary, actor]); return { error: null }; },
+    mergeMissions: async (primary, secondary, actorId) => { calls.push(['merge', primary, secondary, actorId]); return { error: null }; },
     getMission: async id => ({ data: { id }, error: null }),
-    recalcBadges: async ids => { calls.push(['recalc', ids]); }
+    recalcBadges: async ids => { calls.push(['recalc', ids]); },
+    updateUnregisteredNames: async (id, names) => { calls.push(['setNames', id, names]); return { data: [{ id, unregistered_character_names: names }], error: null }; },
+    upsertEditor: async row => { calls.push(['upsertEditor', row]); return { data: [row], error: null }; },
+    deleteEditor: async ({ missionId, profileId }) => { calls.push(['deleteEditor', missionId, profileId]); return { error: null }; },
+    fetchMissionPermissionRow: async id => { calls.push(['fetchPermission', id]); return { data: mission, error: null }; },
+    fetchCreatorId: async id => { calls.push(['fetchCreatorId', id]); return { data: mission ? { creator_id: mission.creator_id } : null, error: null }; },
+    fetchEditorRow: async ({ profileId }) => {
+      calls.push(['fetchEditorRow', profileId]);
+      return { data: editorProfileIds.includes(profileId) ? { profile_id: profileId } : null, error: null };
+    }
   };
 };
 
@@ -28,21 +46,257 @@ test('normalizes mission input without modifying the caller payload', () => {
   expect(data).toEqual({ name: 'Mission', media_url: null, creator_id: 'creator-1' });
 });
 
-test('updates a mission then recalculates both affected hosts', async () => {
-  const adapter = makeAdapter();
-  const service = new MissionService(adapter);
-  await service.updateMission('mission-1', { host_id: 'new-host' }, { id: 'actor-1' });
-  expect(adapter.calls).toEqual([
-    ['update', 'mission-1', { host_id: 'new-host' }],
+test('constructor requires every repository method', () => {
+  expect(() => new MissionService({})).toThrow(TypeError);
+});
+
+test('createMission derives creator_id from the actor', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.createMission(CREATOR, { name: 'Mission' });
+  expect(repo.calls).toEqual([['create', { name: 'Mission', creator_id: 'creator-1' }]]);
+});
+
+test('createMission recalcs the host when one is set', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.createMission(CREATOR, { name: 'Mission', host_id: 'host-9' });
+  expect(repo.calls).toEqual([
+    ['create', { name: 'Mission', host_id: 'host-9', creator_id: 'creator-1' }],
+    ['recalc', ['host-9']]
+  ]);
+});
+
+test('the system actor may set an explicit creator_id on create', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.createMission(SYSTEM_ACTOR, { name: 'Mission', creator_id: 'explicit-creator' });
+  expect(repo.calls).toEqual([['create', { name: 'Mission', creator_id: 'explicit-creator' }]]);
+});
+
+test('the creator may update their mission; the write reaches the repository', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.updateMission(CREATOR, MISSION_ID, { host_id: 'new-host' });
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['fetchEditorRow', 'creator-1'],
+    ['update', MISSION_ID, { host_id: 'new-host' }],
     ['recalc', ['old-host', 'new-host']]
   ]);
 });
 
-test('does not write an unauthorized mission update', async () => {
-  const adapter = makeAdapter();
-  adapter.canEdit = async () => false;
-  const service = new MissionService(adapter);
-  const result = await service.updateMission('mission-1', { name: 'Nope' }, { id: 'actor-1' });
-  expect(result.error).toMatch('Unauthorized');
-  expect(adapter.calls).toEqual([]);
+test('the host may update the mission', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.updateMission(HOST, MISSION_ID, { name: 'New name' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'fetchEditorRow', 'update', 'recalc']);
+});
+
+test('an editor may update the mission', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.updateMission(EDITOR, MISSION_ID, { name: 'New name' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'fetchEditorRow', 'update', 'recalc']);
+});
+
+test('an admin may update a mission they do not own', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.updateMission(ADMIN, MISSION_ID, { name: 'New name' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'update', 'recalc']);
+});
+
+test('the system actor may update any mission', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.updateMission(SYSTEM_ACTOR, MISSION_ID, { name: 'New name' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'update', 'recalc']);
+});
+
+test('a stranger updating a mission throws AuthorizationError, never reaching the write', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.updateMission(STRANGER, MISSION_ID, { name: 'Nope' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'fetchEditorRow']);
+});
+
+test('updating a mission that does not exist throws AuthorizationError (not_found)', async () => {
+  const repo = makeRepo({ mission: null });
+  const service = new MissionService(repo);
+  await expect(service.updateMission(CREATOR, 'missing', {})).rejects.toThrow(AuthorizationError);
+});
+
+test('the creator may delete their mission; the SQL filter uses the loaded creator_id', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.deleteMission(CREATOR, MISSION_ID);
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['affected', MISSION_ID],
+    ['delete', MISSION_ID, 'creator-1'],
+    ['recalc', ['host', 'character-owner']]
+  ]);
+});
+
+test('an admin may delete a mission they do not own; the filter uses the actual creator_id', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.deleteMission(ADMIN, MISSION_ID);
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['affected', MISSION_ID],
+    ['delete', MISSION_ID, 'creator-1'],
+    ['recalc', ['host', 'character-owner']]
+  ]);
+});
+
+test('the host may NOT delete the mission (delete is creator-only)', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.deleteMission(HOST, MISSION_ID)).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([['fetchPermission', MISSION_ID]]);
+});
+
+test('a stranger deleting a mission throws AuthorizationError, never reaching the delete', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.deleteMission(STRANGER, MISSION_ID)).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([['fetchPermission', MISSION_ID]]);
+});
+
+test('the creator may add a character to their mission', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.addCharacter(CREATOR, { missionId: MISSION_ID, characterId: 'char-1' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'fetchEditorRow', 'add', 'getCharacterCreator', 'recalc']);
+});
+
+test('the system actor may add a character (internal backfill path)', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.addCharacter(SYSTEM_ACTOR, { missionId: MISSION_ID, characterId: 'char-1' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'add', 'getCharacterCreator', 'recalc']);
+});
+
+test('a stranger may NOT add a character to a mission they cannot edit', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.addCharacter(STRANGER, { missionId: MISSION_ID, characterId: 'char-1' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'fetchEditorRow']);
+});
+
+test('the creator may remove a character from their mission', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.removeCharacter(CREATOR, { missionId: MISSION_ID, characterId: 'char-1' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'fetchEditorRow', 'remove', 'getCharacterCreator', 'recalc']);
+});
+
+test('the system actor may remove a character (internal path)', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.removeCharacter(SYSTEM_ACTOR, { missionId: MISSION_ID, characterId: 'char-1' });
+  expect(repo.calls.map(c => c[0])).toEqual(['fetchPermission', 'remove', 'getCharacterCreator', 'recalc']);
+});
+
+test('a stranger may NOT remove a character from a mission they cannot edit', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.removeCharacter(STRANGER, { missionId: MISSION_ID, characterId: 'char-1' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([['fetchPermission', MISSION_ID], ['fetchEditorRow', 'stranger']]);
+});
+
+test('the creator (via canEditMission) may set unregistered character names', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.setUnregisteredNames(CREATOR, MISSION_ID, [' Alice ', '', 'Bob']);
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['fetchEditorRow', 'creator-1'],
+    ['setNames', MISSION_ID, ['Alice', 'Bob']]
+  ]);
+});
+
+test('a stranger may NOT set unregistered character names', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.setUnregisteredNames(STRANGER, MISSION_ID, ['Nope'])).rejects.toThrow(AuthorizationError);
+});
+
+test('the mission creator may add an editor', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.addEditor(CREATOR, { missionId: MISSION_ID, profileId: 'new-editor' });
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['upsertEditor', { mission_id: MISSION_ID, profile_id: 'new-editor', added_by: 'creator-1' }]
+  ]);
+});
+
+test('the host may NOT add an editor (addEditor is creator-only)', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.addEditor(HOST, { missionId: MISSION_ID, profileId: 'new-editor' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([['fetchPermission', MISSION_ID]]);
+});
+
+test('the system actor may add an editor', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.addEditor(SYSTEM_ACTOR, { missionId: MISSION_ID, profileId: 'new-editor' });
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['upsertEditor', { mission_id: MISSION_ID, profile_id: 'new-editor', added_by: null }]
+  ]);
+});
+
+test('the mission creator may remove an editor', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await service.removeEditor(CREATOR, { missionId: MISSION_ID, profileId: 'editor-1' });
+  expect(repo.calls).toEqual([
+    ['fetchPermission', MISSION_ID],
+    ['deleteEditor', MISSION_ID, 'editor-1']
+  ]);
+});
+
+test('an editor may NOT remove another editor (removeEditor is creator-only)', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.removeEditor(EDITOR, { missionId: MISSION_ID, profileId: 'editor-1' })).rejects.toThrow(AuthorizationError);
+});
+
+test('merging requires the actor to edit BOTH missions; success recalculates and returns the merged mission', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  const result = await service.mergeMissions(CREATOR, 'primary', 'secondary');
+  expect(repo.calls.filter(c => c[0] !== 'fetchPermission' && c[0] !== 'fetchEditorRow')).toEqual([
+    ['affected', 'primary'],
+    ['affected', 'secondary'],
+    ['merge', 'primary', 'secondary', 'creator-1'],
+    ['recalc', ['host', 'character-owner', 'host', 'character-owner']]
+  ]);
+  expect(result).toEqual({ data: { id: 'primary' }, error: null });
+});
+
+test('a stranger cannot merge missions they cannot edit; no writes occur', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  await expect(service.mergeMissions(STRANGER, 'primary', 'secondary')).rejects.toThrow(AuthorizationError);
+  expect(repo.calls.some(c => c[0] === 'merge')).toBe(false);
+});
+
+test('canEditMission compatibility check returns a boolean without throwing', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  expect(await service.canEditMission(CREATOR, MISSION_ID)).toBe(true);
+  expect(await service.canEditMission(STRANGER, MISSION_ID)).toBe(false);
+});
+
+test('isCreator compatibility check returns a boolean without throwing', async () => {
+  const repo = makeRepo();
+  const service = new MissionService(repo);
+  expect(await service.isCreator(CREATOR, MISSION_ID)).toBe(true);
+  expect(await service.isCreator(HOST, MISSION_ID)).toBe(false);
 });

--- a/services/pdf/repository.js
+++ b/services/pdf/repository.js
@@ -1,0 +1,13 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin.storage for the pdf domain. pdf storage
+// is a persistence adapter; authorization belongs to the owning domain's
+// policy (class/rules) — this repository has no policy or actor of its own.
+module.exports = {
+  uploadObject: (bucket, storagePath, bytes, opts = {}) =>
+    supabaseAdmin.storage.from(bucket).upload(storagePath, bytes, opts),
+  removeObject: (bucket, storagePath) =>
+    supabaseAdmin.storage.from(bucket).remove([storagePath]),
+  createSignedUrl: (bucket, storagePath, ttl) =>
+    supabaseAdmin.storage.from(bucket).createSignedUrl(storagePath, ttl)
+};

--- a/services/pdf/repository.test.js
+++ b/services/pdf/repository.test.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const repository = require('./repository');
+
+// Guards against a missed extraction: every privileged storage call must be
+// reachable through the repository, the sole consumer of supabaseAdmin.storage
+// for the pdf domain. Deep behavior is covered by the class/library PDF tests
+// that already exercise these paths through models/pdf.js.
+const expectedMethods = ['uploadObject', 'removeObject', 'createSignedUrl'];
+
+test('exports every repository method', () => {
+  for (const method of expectedMethods) {
+    expect(typeof repository[method]).toBe('function');
+  }
+});

--- a/services/profile/policy.js
+++ b/services/profile/policy.js
@@ -1,0 +1,9 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// Actor may mutate the profile owned by targetUserId (self), or is admin/system.
+const canMutateOwnProfile = (actor, targetUserId) => {
+  if (isSystem(actor) || isAdmin(actor)) return true;
+  return !!actor && !!actor.userId && actor.userId === targetUserId;
+};
+
+module.exports = { canMutateOwnProfile };

--- a/services/profile/policy.test.js
+++ b/services/profile/policy.test.js
@@ -1,0 +1,23 @@
+const { test, expect } = require('bun:test');
+const { canMutateOwnProfile } = require('./policy');
+
+test('a user may mutate their own profile', () => {
+  expect(canMutateOwnProfile({ userId: 'u1', role: 'user' }, 'u1')).toBe(true);
+});
+
+test('a user may not mutate another user\'s profile', () => {
+  expect(canMutateOwnProfile({ userId: 'u1', role: 'user' }, 'u2')).toBe(false);
+});
+
+test('admin may mutate any profile', () => {
+  expect(canMutateOwnProfile({ userId: 'admin-1', role: 'admin' }, 'u2')).toBe(true);
+});
+
+test('system actor may mutate any profile', () => {
+  expect(canMutateOwnProfile({ role: 'system' }, 'u2')).toBe(true);
+});
+
+test('a missing/anonymous actor may not mutate a profile', () => {
+  expect(canMutateOwnProfile(null, 'u2')).toBe(false);
+  expect(canMutateOwnProfile({ role: 'user' }, 'u2')).toBe(false);
+});

--- a/services/profile/repository.js
+++ b/services/profile/repository.js
@@ -12,9 +12,21 @@ const withResult = async (query) => {
   return { data, error: null };
 };
 
+// Like withResult, but silent on PGRST116 (row-not-found): fetchOwnProfile hits
+// this on every first sign-in (models/profile.js getProfile provisions a new
+// profile in that branch), so logging it is expected-noise, not an error.
+const withResultQuiet404 = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    if (error.code !== 'PGRST116') console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
 module.exports = {
   // Reads
-  fetchOwnProfile: (userId) => withResult(
+  fetchOwnProfile: (userId) => withResultQuiet404(
     supabaseAdmin.from('profiles').select('*').eq('user_id', userId).single()
   ),
   fetchStarterUnlockRows: (userId) => withResult(

--- a/services/profile/repository.js
+++ b/services/profile/repository.js
@@ -1,0 +1,51 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin for the profile domain. Holds every
+// privileged (service-role) query verbatim; models/profile.js keeps the
+// surrounding logic (starter-unlock granting via RPC, input sanitization).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+module.exports = {
+  // Reads
+  fetchOwnProfile: (userId) => withResult(
+    supabaseAdmin.from('profiles').select('*').eq('user_id', userId).single()
+  ),
+  fetchStarterUnlockRows: (userId) => withResult(
+    supabaseAdmin.from('class_unlocks').select('class_id').eq('user_id', userId).limit(1)
+  ),
+  // Admin variants bypass RLS — only call from routes already gated by requireAdmin.
+  fetchProfileByIdAdmin: (id) => withResult(
+    supabaseAdmin.from('profiles').select('*').eq('id', id).single()
+  ),
+  fetchProfileByNameAdmin: (name) => withResult(
+    supabaseAdmin.from('profiles').select('*').eq('name', name).single()
+  ),
+  searchProfilesAdmin: (likePattern, limit = 10) => withResult(
+    supabaseAdmin.from('profiles').select('id, name, image_url').ilike('name', likePattern).limit(limit)
+  ),
+
+  // Writes
+  insertProfile: (row) => withResult(
+    supabaseAdmin.from('profiles').insert(row).select()
+  ),
+  updateAuthUser: async (userId, attrs) => {
+    const { error } = await supabaseAdmin.auth.admin.updateUserById(userId, attrs);
+    if (error) console.error(error);
+    return { error: error || null };
+  },
+  updateProfileByUserId: async (userId, fields) => {
+    const { data, error } = await supabaseAdmin.from('profiles').update(fields).eq('user_id', userId);
+    if (error) console.error(error);
+    return { data, error: error || null };
+  },
+  updateDiscord: (userId, discordId, discordEmail) => withResult(
+    supabaseAdmin.from('profiles').update({ discord_id: discordId, discord_email: discordEmail }).eq('user_id', userId).select()
+  )
+};

--- a/services/profile/repository.test.js
+++ b/services/profile/repository.test.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://test.invalid';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const repository = require('./repository');
+
+// Guards against a missed extraction: every privileged profile query must be
+// reachable through the repository, the sole consumer of supabaseAdmin for
+// this domain. Deep behavior is covered by the model/service tests that
+// already exercise these paths.
+const expectedMethods = [
+  'fetchOwnProfile',
+  'fetchStarterUnlockRows',
+  'fetchProfileByIdAdmin',
+  'fetchProfileByNameAdmin',
+  'searchProfilesAdmin',
+  'insertProfile',
+  'updateAuthUser',
+  'updateProfileByUserId',
+  'updateDiscord'
+];
+
+test('exports every repository method', () => {
+  for (const method of expectedMethods) {
+    expect(typeof repository[method]).toBe('function');
+  }
+});

--- a/services/profile/service.js
+++ b/services/profile/service.js
@@ -1,0 +1,63 @@
+const { AuthorizationError } = require('../../util/errors');
+const { canMutateOwnProfile } = require('./policy');
+const { sanitizeUrlFields } = require('../../util/url');
+
+const REQUIRED_REPOSITORY_METHODS = [
+  'fetchOwnProfile',
+  'fetchStarterUnlockRows',
+  'fetchProfileByIdAdmin',
+  'fetchProfileByNameAdmin',
+  'searchProfilesAdmin',
+  'insertProfile',
+  'updateAuthUser',
+  'updateProfileByUserId',
+  'updateDiscord'
+];
+
+const requireSelf = (actor, targetUserId) => {
+  if (!canMutateOwnProfile(actor, targetUserId)) {
+    throw new AuthorizationError('Not authorized to modify this profile', { reason: 'not_self' });
+  }
+};
+
+/** Application boundary for profile writes: policy -> throw-or-mutate. All
+ * profile mutations act on a single user's own record (self, or admin/system
+ * acting on behalf of a user). */
+class ProfileService {
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`ProfileService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
+  }
+
+  async updateUser(actor, userId, email, password, fields) {
+    requireSelf(actor, userId);
+
+    if (password === '') password = null;
+    const attrs = {};
+    if (email) attrs.email = email;
+    if (password) attrs.password = password;
+
+    if (attrs.email || attrs.password) {
+      const { error } = await this.repo.updateAuthUser(userId, attrs);
+      if (error) return { data: null, error };
+    }
+
+    sanitizeUrlFields(fields, ['image_url']);
+    return this.repo.updateProfileByUserId(userId, fields);
+  }
+
+  async setDiscordId(actor, userId, discordId, discordEmail = null) {
+    requireSelf(actor, userId);
+    return this.repo.updateDiscord(userId, discordId, discordEmail);
+  }
+
+  // Self-provisioning: called on first sign-in (PGRST116 on the self-read).
+  // The system actor drives this on behalf of the just-verified user.
+  async createProfileForUser(actor, user) {
+    requireSelf(actor, user.id);
+    return this.repo.insertProfile({ user_id: user.id, name: `Agent #${user.id}`, role: 'user' });
+  }
+}
+
+module.exports = { ProfileService };

--- a/services/profile/service.test.js
+++ b/services/profile/service.test.js
@@ -1,0 +1,92 @@
+const { test, expect } = require('bun:test');
+const { ProfileService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
+
+const makeRepo = () => {
+  const calls = [];
+  return {
+    calls,
+    fetchOwnProfile: async userId => { calls.push(['fetchOwnProfile', userId]); return { data: null, error: null }; },
+    fetchStarterUnlockRows: async userId => { calls.push(['fetchStarterUnlockRows', userId]); return { data: [], error: null }; },
+    fetchProfileByIdAdmin: async id => { calls.push(['fetchProfileByIdAdmin', id]); return { data: null, error: null }; },
+    fetchProfileByNameAdmin: async name => { calls.push(['fetchProfileByNameAdmin', name]); return { data: null, error: null }; },
+    searchProfilesAdmin: async pattern => { calls.push(['searchProfilesAdmin', pattern]); return { data: [], error: null }; },
+    insertProfile: async row => { calls.push(['insertProfile', row]); return { data: [{ id: 'profile-1', ...row }], error: null }; },
+    updateAuthUser: async (userId, attrs) => { calls.push(['updateAuthUser', userId, attrs]); return { error: null }; },
+    updateProfileByUserId: async (userId, fields) => { calls.push(['updateProfileByUserId', userId, fields]); return { data: fields, error: null }; },
+    updateDiscord: async (userId, discordId, discordEmail) => { calls.push(['updateDiscord', userId, discordId, discordEmail]); return { data: [{ discord_id: discordId }], error: null }; }
+  };
+};
+
+const SELF_ACTOR = { userId: 'u1', role: 'user' };
+const OTHER_ACTOR = { userId: 'u2', role: 'user' };
+const ADMIN_ACTOR = { userId: 'admin-1', role: 'admin' };
+const SYSTEM_ACTOR = { role: 'system' };
+
+test('constructor requires every repository method', () => {
+  expect(() => new ProfileService({})).toThrow(TypeError);
+});
+
+test('a user may update their own profile', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await service.updateUser(SELF_ACTOR, 'u1', 'new@example.test', '', { name: 'Agent' });
+  expect(repo.calls).toEqual([
+    ['updateAuthUser', 'u1', { email: 'new@example.test' }],
+    ['updateProfileByUserId', 'u1', { name: 'Agent' }]
+  ]);
+});
+
+test('updateUser skips the auth update when no email/password is given', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await service.updateUser(SELF_ACTOR, 'u1', undefined, undefined, { name: 'Agent' });
+  expect(repo.calls).toEqual([
+    ['updateProfileByUserId', 'u1', { name: 'Agent' }]
+  ]);
+});
+
+test('a mismatched actor updating another profile throws AuthorizationError, never reaching the repository', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await expect(service.updateUser(OTHER_ACTOR, 'u1', 'x@example.test', '', {})).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('an admin may update another user\'s profile', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await service.updateUser(ADMIN_ACTOR, 'u1', undefined, undefined, { name: 'Agent' });
+  expect(repo.calls).toEqual([
+    ['updateProfileByUserId', 'u1', { name: 'Agent' }]
+  ]);
+});
+
+test('a user may sync their own discord id', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await service.setDiscordId(SELF_ACTOR, 'u1', 'discord-1', 'd@example.test');
+  expect(repo.calls).toEqual([['updateDiscord', 'u1', 'discord-1', 'd@example.test']]);
+});
+
+test('a mismatched actor setting another user\'s discord id throws AuthorizationError', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await expect(service.setDiscordId(OTHER_ACTOR, 'u1', 'discord-1')).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});
+
+test('the system actor may create a profile for a newly-verified user', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  const { data } = await service.createProfileForUser(SYSTEM_ACTOR, { id: 'u1' });
+  expect(repo.calls).toEqual([['insertProfile', { user_id: 'u1', name: 'Agent #u1', role: 'user' }]]);
+  expect(data).toEqual([{ id: 'profile-1', user_id: 'u1', name: 'Agent #u1', role: 'user' }]);
+});
+
+test('a mismatched actor creating a profile for another user throws AuthorizationError', async () => {
+  const repo = makeRepo();
+  const service = new ProfileService(repo);
+  await expect(service.createProfileForUser(OTHER_ACTOR, { id: 'u1' })).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});

--- a/services/rules/policy.js
+++ b/services/rules/policy.js
@@ -1,0 +1,7 @@
+const { isAdmin, isSystem } = require('../../util/actor');
+
+// Only admins (or the system actor) mint unlock codes for a rules PDF
+// (today's requireAdmin route).
+const canMintRulesUnlockCodes = (actor) => isAdmin(actor) || isSystem(actor);
+
+module.exports = { canMintRulesUnlockCodes };

--- a/services/rules/policy.test.js
+++ b/services/rules/policy.test.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('bun:test');
+const { canMintRulesUnlockCodes } = require('./policy');
+
+test('admin may mint rules unlock codes', () => {
+  expect(canMintRulesUnlockCodes({ profileId: 'admin-1', role: 'admin' })).toBe(true);
+});
+
+test('system actor may mint rules unlock codes', () => {
+  expect(canMintRulesUnlockCodes({ role: 'system' })).toBe(true);
+});
+
+test('a regular user may not mint rules unlock codes', () => {
+  expect(canMintRulesUnlockCodes({ profileId: 'p1', role: 'user' })).toBe(false);
+});
+
+test('a missing/anonymous actor may not mint rules unlock codes', () => {
+  expect(canMintRulesUnlockCodes(null)).toBe(false);
+  expect(canMintRulesUnlockCodes(undefined)).toBe(false);
+});

--- a/services/rules/repository.js
+++ b/services/rules/repository.js
@@ -1,0 +1,57 @@
+const { supabaseAdmin } = require('../../models/_base');
+
+// The only consumer of supabaseAdmin for the rules domain. Holds every
+// privileged (service-role) query verbatim; models/rules.js keeps the
+// surrounding logic (code generation, family-id fallback, view gating).
+const withResult = async (query) => {
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+  return { data, error: null };
+};
+
+module.exports = {
+  // Admin-only: embedded profile/granter joins require bypassing RLS so
+  // non-public grantee profiles still resolve in the manage UI.
+  listUnlockGrantsAdmin: (rulesPdfId) => withResult(
+    supabaseAdmin
+      .from('rules_pdf_unlocks')
+      .select(`
+        user_id,
+        profile_id,
+        granted_by,
+        unlocked_at,
+        expires_at,
+        profile:profiles!rules_pdf_unlocks_profile_id_fkey(id, name),
+        granter:profiles!rules_pdf_unlocks_granted_by_fkey(id, name)
+      `)
+      .eq('rules_pdf_id', rulesPdfId)
+      .order('unlocked_at', { ascending: false })
+  ),
+
+  insertUnlockCodes: (rows) => withResult(
+    supabaseAdmin.from('rules_pdf_unlock_codes').insert(rows).select()
+  ),
+
+  // Admin client so the lookup isn't RLS-filtered.
+  fetchPdfFamilyIdsByTitle: (title) => withResult(
+    supabaseAdmin.from('rules_pdfs').select('id').eq('title', title)
+  ),
+
+  // Admin read mirrors isClassUnlocked: the shared anon client carries no
+  // JWT, so RLS would hide the user's own unlock rows.
+  fetchActiveUnlockForUser: ({ userId, familyIds }) => {
+    const now = new Date().toISOString();
+    return withResult(
+      supabaseAdmin
+        .from('rules_pdf_unlocks')
+        .select('rules_pdf_id, expires_at')
+        .eq('user_id', userId)
+        .in('rules_pdf_id', familyIds)
+        .or(`expires_at.is.null,expires_at.gt.${now}`)
+        .limit(1)
+    );
+  }
+};

--- a/services/rules/service.js
+++ b/services/rules/service.js
@@ -1,0 +1,30 @@
+const { AuthorizationError } = require('../../util/errors');
+const { canMintRulesUnlockCodes } = require('./policy');
+
+const REQUIRED_REPOSITORY_METHODS = [
+  'insertUnlockCodes'
+];
+
+/** Application boundary for rules-PDF-unlock-code minting: policy ->
+ * throw-or-mutate. The remaining privileged rules reads (admin unlock
+ * listing, family-id resolution, active-unlock lookup) are pure reads with
+ * no capability to gate; models/rules.js calls the repository for those
+ * directly, mirroring services/class. */
+class RulesService {
+  constructor(repository) {
+    const missing = REQUIRED_REPOSITORY_METHODS.filter(method => typeof repository?.[method] !== 'function');
+    if (missing.length) throw new TypeError(`RulesService requires repository methods: ${missing.join(', ')}`);
+    this.repo = repository;
+  }
+
+  // rows are pre-built by the model (crypto-random codes, expiry, etc.);
+  // this capability only gates who may mint them.
+  async mintUnlockCodes(actor, rows) {
+    if (!canMintRulesUnlockCodes(actor)) {
+      throw new AuthorizationError('Not authorized to mint unlock codes', { reason: 'not_admin' });
+    }
+    return this.repo.insertUnlockCodes(rows);
+  }
+}
+
+module.exports = { RulesService };

--- a/services/rules/service.test.js
+++ b/services/rules/service.test.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('bun:test');
+const { RulesService } = require('./service');
+const { AuthorizationError } = require('../../util/errors');
+
+const makeRepo = () => {
+  const calls = [];
+  return {
+    calls,
+    insertUnlockCodes: async rows => { calls.push(['insertUnlockCodes', rows]); return { data: rows, error: null }; }
+  };
+};
+
+const ADMIN_ACTOR = { profileId: 'admin-1', role: 'admin' };
+const SYSTEM_ACTOR = { role: 'system' };
+const USER_ACTOR = { profileId: 'p1', role: 'user' };
+
+test('constructor requires every repository method', () => {
+  expect(() => new RulesService({})).toThrow(TypeError);
+});
+
+test('an admin may mint unlock codes', async () => {
+  const repo = makeRepo();
+  const service = new RulesService(repo);
+  await service.mintUnlockCodes(ADMIN_ACTOR, [{ code: 'abc' }]);
+  expect(repo.calls).toEqual([['insertUnlockCodes', [{ code: 'abc' }]]]);
+});
+
+test('the system actor may mint unlock codes', async () => {
+  const repo = makeRepo();
+  const service = new RulesService(repo);
+  await service.mintUnlockCodes(SYSTEM_ACTOR, [{ code: 'abc' }]);
+  expect(repo.calls).toEqual([['insertUnlockCodes', [{ code: 'abc' }]]]);
+});
+
+test('a non-admin minting unlock codes throws AuthorizationError, never reaching the repository', async () => {
+  const repo = makeRepo();
+  const service = new RulesService(repo);
+  await expect(service.mintUnlockCodes(USER_ACTOR, [{ code: 'abc' }])).rejects.toThrow(AuthorizationError);
+  expect(repo.calls).toEqual([]);
+});

--- a/util/actor.js
+++ b/util/actor.js
@@ -10,7 +10,15 @@ const actorFromLocals = (locals = {}) => ({
 // (badge recalculation, backfill, denormalization). Never built from input.
 const SYSTEM_ACTOR = Object.freeze({ userId: null, profileId: null, role: 'system' });
 
+// Some call sites (import utilities) receive a bare `profile` row rather than
+// `res.locals`; this builds the same actor shape from that row.
+const actorFromProfile = (profile) => ({
+  userId: (profile && profile.user_id) || null,
+  profileId: (profile && profile.id) || null,
+  role: (profile && profile.role) || null,
+});
+
 const isAdmin = (actor) => !!actor && actor.role === 'admin';
 const isSystem = (actor) => !!actor && actor.role === 'system';
 
-module.exports = { actorFromLocals, SYSTEM_ACTOR, isAdmin, isSystem };
+module.exports = { actorFromLocals, actorFromProfile, SYSTEM_ACTOR, isAdmin, isSystem };

--- a/util/actor.js
+++ b/util/actor.js
@@ -1,0 +1,16 @@
+// Who is performing a privileged command, derived from the request.
+// Shape matches the existing agent-read convention ({ userId, profileId, role }).
+const actorFromLocals = (locals = {}) => ({
+  userId: (locals && locals.user && locals.user.id) || null,
+  profileId: (locals && locals.profile && locals.profile.id) || null,
+  role: (locals && locals.profile && locals.profile.role) || null,
+});
+
+// Trusted actor for internal, non-user-triggered privileged commands
+// (badge recalculation, backfill, denormalization). Never built from input.
+const SYSTEM_ACTOR = Object.freeze({ userId: null, profileId: null, role: 'system' });
+
+const isAdmin = (actor) => !!actor && actor.role === 'admin';
+const isSystem = (actor) => !!actor && actor.role === 'system';
+
+module.exports = { actorFromLocals, SYSTEM_ACTOR, isAdmin, isSystem };

--- a/util/actor.test.js
+++ b/util/actor.test.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('bun:test');
-const { actorFromLocals, SYSTEM_ACTOR, isAdmin, isSystem } = require('./actor');
+const { actorFromLocals, actorFromProfile, SYSTEM_ACTOR, isAdmin, isSystem } = require('./actor');
 
 test('actorFromLocals reads user id, profile id, and role', () => {
   const actor = actorFromLocals({ user: { id: 'u1' }, profile: { id: 'p1', role: 'admin' } });
@@ -21,4 +21,20 @@ test('isAdmin / isSystem discriminate on role', () => {
   expect(isAdmin({ role: 'user' })).toBe(false);
   expect(isSystem(SYSTEM_ACTOR)).toBe(true);
   expect(isSystem({ role: 'admin' })).toBe(false);
+});
+
+test('actorFromProfile reads user_id, id, and role from a profile row', () => {
+  const actor = actorFromProfile({ user_id: 'u1', id: 'p1', role: 'admin' });
+  expect(actor).toEqual({ userId: 'u1', profileId: 'p1', role: 'admin' });
+});
+
+test('actorFromProfile tolerates missing/null profile', () => {
+  expect(actorFromProfile({})).toEqual({ userId: null, profileId: null, role: null });
+  expect(actorFromProfile(null)).toEqual({ userId: null, profileId: null, role: null });
+  expect(actorFromProfile(undefined)).toEqual({ userId: null, profileId: null, role: null });
+});
+
+test('actorFromProfile tolerates a profile missing individual fields', () => {
+  expect(actorFromProfile({ id: 'p1' })).toEqual({ userId: null, profileId: 'p1', role: null });
+  expect(actorFromProfile({ user_id: 'u1', role: 'user' })).toEqual({ userId: 'u1', profileId: null, role: 'user' });
 });

--- a/util/actor.test.js
+++ b/util/actor.test.js
@@ -1,0 +1,24 @@
+const { test, expect } = require('bun:test');
+const { actorFromLocals, SYSTEM_ACTOR, isAdmin, isSystem } = require('./actor');
+
+test('actorFromLocals reads user id, profile id, and role', () => {
+  const actor = actorFromLocals({ user: { id: 'u1' }, profile: { id: 'p1', role: 'admin' } });
+  expect(actor).toEqual({ userId: 'u1', profileId: 'p1', role: 'admin' });
+});
+
+test('actorFromLocals tolerates missing user/profile', () => {
+  expect(actorFromLocals({})).toEqual({ userId: null, profileId: null, role: null });
+  expect(actorFromLocals(undefined)).toEqual({ userId: null, profileId: null, role: null });
+});
+
+test('SYSTEM_ACTOR is a frozen system-role actor', () => {
+  expect(SYSTEM_ACTOR.role).toBe('system');
+  expect(Object.isFrozen(SYSTEM_ACTOR)).toBe(true);
+});
+
+test('isAdmin / isSystem discriminate on role', () => {
+  expect(isAdmin({ role: 'admin' })).toBe(true);
+  expect(isAdmin({ role: 'user' })).toBe(false);
+  expect(isSystem(SYSTEM_ACTOR)).toBe(true);
+  expect(isSystem({ role: 'admin' })).toBe(false);
+});

--- a/util/async-handler.js
+++ b/util/async-handler.js
@@ -1,0 +1,7 @@
+// Forward a rejected async route handler to Express's error pipeline so a
+// thrown AuthorizationError reaches the central handler (app.js) and maps to 403.
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+module.exports = { asyncHandler };

--- a/util/async-handler.test.js
+++ b/util/async-handler.test.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('bun:test');
+const { asyncHandler } = require('./async-handler');
+
+test('asyncHandler forwards a rejected promise to next', async () => {
+  const boom = new Error('boom');
+  let passed = null;
+  const handler = asyncHandler(async () => { throw boom; });
+  await handler({}, {}, (e) => { passed = e; });
+  await new Promise((r) => setImmediate(r));
+  expect(passed).toBe(boom);
+});
+
+test('asyncHandler does not call next on success', async () => {
+  let called = false;
+  const handler = asyncHandler(async (req, res) => { res.ok = true; });
+  const res = {};
+  await handler({}, res, () => { called = true; });
+  await new Promise((r) => setImmediate(r));
+  expect(res.ok).toBe(true);
+  expect(called).toBe(false);
+});

--- a/util/auth.js
+++ b/util/auth.js
@@ -1,4 +1,4 @@
-const { supabase, supabaseAdmin, createUserClient } = require('../models/_base');
+const { supabase, createUserClient } = require('../models/_base');
 const { getUserFromToken } = require('../models/auth');
 const { getProfile } = require('../models/profile');
 const { getSystemMessage } = require('./system-message');
@@ -146,7 +146,7 @@ const isAgentAuthenticated = async (req, res, next) => {
   }
 
   res.locals.user = { id: data.userId };
-  res.locals.supabase = supabaseAdmin;
+  res.locals.supabase = supabase;
   res.locals.profile = data.profile;
   res.locals.agentToken = {
     id: data.tokenId,

--- a/util/auth.test.js
+++ b/util/auth.test.js
@@ -85,9 +85,9 @@ test('authOptional with a token attaches the user-scoped client', async () => {
   expect(res.locals.supabase.__name).toBe('user');
 });
 
-test('isAgentAuthenticated attaches the admin client', async () => {
+test('isAgentAuthenticated attaches the anon client (agent reads go through *ForAgent repositories, not res.locals.supabase)', async () => {
   const req = makeReq({ 'x-agent-token': 'aat_stub' });
   const res = makeRes();
   await isAgentAuthenticated(req, res, () => {});
-  expect(res.locals.supabase.__name).toBe('admin');
+  expect(res.locals.supabase.__name).toBe('anon');
 });

--- a/util/character-import.js
+++ b/util/character-import.js
@@ -7,6 +7,7 @@ const { adventClassList, aspirantPreviewClassList, playerCreatedClassList, class
 const { processMissionImport } = require('./mission-import');
 const { addCharacterToMission } = require('../models/mission');
 const { assertNonEmptyImportText } = require('./validate');
+const { actorFromProfile } = require('./actor');
 
 const openai = new OpenAIChatApi(
   { apiKey: process.env.OPENAI_API_KEY },
@@ -145,7 +146,7 @@ JSON output:`;
               // Try to add the character to the mission
               // The mission import might not have matched the character name correctly
               // since it was just created, so we'll add it explicitly
-              await addCharacterToMission(mission.id, importedCharacter.id);
+              await addCharacterToMission(actorFromProfile(profile), mission.id, importedCharacter.id);
             }
           }
           

--- a/util/class-filters.js
+++ b/util/class-filters.js
@@ -1,0 +1,30 @@
+// Pure query-shaping helper shared by the public (anon/user) class read in
+// models/class.js and the admin-client read in services/class/repository.js.
+// Operates on any Postgrest-shaped query builder (chainable .eq/.order).
+const applyClassFilters = (query, filters = {}) => {
+    if (filters.name) {
+        query = query.eq('name', filters.name);
+    }
+    if (filters.is_public !== undefined) {
+        query = query.eq('is_public', filters.is_public);
+    }
+    if (filters.created_by) {
+        query = query.eq('created_by', filters.created_by);
+    }
+    if (filters.rules_edition) {
+        query = query.eq('rules_edition', filters.rules_edition);
+    }
+    if (filters.rules_version) {
+        query = query.eq('rules_version', filters.rules_version);
+    }
+    if (filters.status) {
+        query = query.eq('status', filters.status);
+    }
+    if (filters.is_player_created !== undefined) {
+        query = query.eq('is_player_created', filters.is_player_created);
+    }
+
+    return query.order('name', { ascending: true });
+};
+
+module.exports = { applyClassFilters };

--- a/util/class-import.js
+++ b/util/class-import.js
@@ -81,7 +81,7 @@ const normalizeGear = (gear, limit = 6) => {
     .slice(0, limit);
 };
 
-async function processClassImport(inputText, profile) {
+async function processClassImport(inputText, actor) {
   const text = assertNonEmptyImportText(inputText, 'class writeup');
   const prompt = `Parse the following class writeup into the JSON schema described below. Focus on creating a PCC (player-created class) entry.
 
@@ -107,10 +107,9 @@ JSON output:`;
       rules_edition: parsed.rules_edition || "advent",
       rules_version: parsed.rules_version || "v1",
       is_player_created: true,
-      created_by: profile?.id,
     };
 
-    if (!classData.created_by) {
+    if (!actor?.profileId) {
       throw new Error("Missing profile id for PCC creation");
     }
 
@@ -122,7 +121,7 @@ JSON output:`;
       throw new Error("At least one gear item is required to import a PCC");
     }
 
-    const { data: createdClass, error } = await createClass(classData);
+    const { data: createdClass, error } = await createClass(actor, classData);
     if (error) throw new Error(error.message);
     return createdClass;
   } catch (error) {

--- a/util/errors.js
+++ b/util/errors.js
@@ -1,0 +1,11 @@
+class AuthorizationError extends Error {
+  constructor(message = 'Not authorized', { reason = null } = {}) {
+    super(message);
+    this.name = 'AuthorizationError';
+    this.code = 'forbidden';
+    this.status = 403;
+    if (reason) this.reason = reason;
+  }
+}
+
+module.exports = { AuthorizationError };

--- a/util/errors.test.js
+++ b/util/errors.test.js
@@ -1,0 +1,16 @@
+const { test, expect } = require('bun:test');
+const { AuthorizationError } = require('./errors');
+
+test('AuthorizationError carries a forbidden code and 403 status', () => {
+  const err = new AuthorizationError('nope', { reason: 'not_owner' });
+  expect(err).toBeInstanceOf(Error);
+  expect(err.name).toBe('AuthorizationError');
+  expect(err.code).toBe('forbidden');
+  expect(err.status).toBe(403);
+  expect(err.reason).toBe('not_owner');
+  expect(err.message).toBe('nope');
+});
+
+test('AuthorizationError has a default message', () => {
+  expect(new AuthorizationError().message).toBe('Not authorized');
+});

--- a/util/http-error.js
+++ b/util/http-error.js
@@ -14,6 +14,9 @@ function classifyError(error, fallback = {}) {
     case '42501':
       base = { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND };
       break;
+    case 'forbidden':
+      base = { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND };
+      break;
     case '23505':
       base = { status: 409, title: 'Already exists', message: 'That already exists.' };
       break;

--- a/util/http-error.test.js
+++ b/util/http-error.test.js
@@ -1,6 +1,7 @@
 // util/http-error.test.js
 const { test, expect } = require('bun:test');
 const { classifyError } = require('./http-error');
+const { AuthorizationError } = require('./errors');
 
 const FRIENDLY = "We couldn't find that, or you don't have access to it.";
 
@@ -35,6 +36,13 @@ test('fallback overrides win over the default mapping', () => {
   expect(d.status).toBe(403);
   expect(d.title).toBe('No access');
   expect(d.message).toBe('Custom.');
+});
+
+test('a forbidden-coded error (AuthorizationError) classifies as 403', () => {
+  const d = classifyError(new AuthorizationError('denied'));
+  expect(d.status).toBe(403);
+  expect(d.title).toBe('No access');
+  expect(d.message).toBe(FRIENDLY);
 });
 
 test('unknown error is 500; non-production exposes the raw message', () => {

--- a/util/mission-import.js
+++ b/util/mission-import.js
@@ -4,6 +4,7 @@ const { completion } = require("zod-gpt");
 const { createMission, addCharacterToMission, updateMission } = require('../models/mission');
 const { getOwnCharacters, searchPublicCharacters } = require('../models/character');
 const { assertNonEmptyImportText } = require('./validate');
+const { actorFromProfile } = require('./actor');
 
 const openai = new OpenAIChatApi(
   { apiKey: process.env.OPENAI_API_KEY },
@@ -152,6 +153,7 @@ const findCharacterMatch = async (name, ownCharactersCache) => {
 };
 
 async function processMissionImport(inputText, profile, client) {
+  const actor = actorFromProfile(profile);
   const text = assertNonEmptyImportText(inputText, 'mission log');
   const prompt = `Parse the following mission log and try to structure the data following the provided JSON schema info.
 
@@ -177,7 +179,7 @@ JSON output:`;
       unregistered_character_names: []
     };
 
-    const { data: created, error } = await createMission(missionData, profile);
+    const { data: created, error } = await createMission(actor, missionData);
     if (error) throw new Error(error.message);
 
     const mission = Array.isArray(created) ? created[0] : created;
@@ -193,7 +195,7 @@ JSON output:`;
       const { match, ambiguous } = await findCharacterMatch(name, ownList);
       if (match && match.id) {
         if (!addedIds.has(match.id)) {
-          const { error: addErr } = await addCharacterToMission(mission.id, match.id);
+          const { error: addErr } = await addCharacterToMission(actor, mission.id, match.id);
           if (addErr) {
             unresolved.push(name);
             continue;
@@ -211,7 +213,7 @@ JSON output:`;
 
     if (unresolved.length > 0) {
       const unregisteredNames = dedupe(unresolved);
-      const { error: updateError } = await updateMission(mission.id, { unregistered_character_names: unregisteredNames }, profile);
+      const { error: updateError } = await updateMission(actor, mission.id, { unregistered_character_names: unregisteredNames });
       if (!updateError) {
         mission.unregistered_character_names = unregisteredNames;
       }

--- a/util/seed-classes.js
+++ b/util/seed-classes.js
@@ -1,6 +1,7 @@
 require('./env');
 const { createClient } = require('@supabase/supabase-js');
 const ClassModel = require('../models/class');
+const { SYSTEM_ACTOR } = require('./actor');
 const { adventClassList, aspirantPreviewClassList, playerCreatedClassList, classStatSpread } = require('./enclave-consts');
 
 // Initialize Supabase client
@@ -71,7 +72,7 @@ async function seedClasses() {
         // Insert classes
         for (const classData of classesWithAdmin) {
             try {
-                await ClassModel.createClass(classData);
+                await ClassModel.createClass(SYSTEM_ACTOR, classData);
                 console.log(`Successfully seeded class: ${classData.name}`);
             } catch (error) {
                 console.error(`Failed to seed class ${classData.name}:`, error.message);


### PR DESCRIPTION
## ar-ezes — Consolidate service-role access behind repositories

Moves **every** `supabaseAdmin` (service-role, RLS-bypassing) usage across 11 models and 3 routes behind per-domain **repository** modules, and routes every privileged command through an **actor-aware, policy-guarded service** capability. Denials throw a typed `AuthorizationError` mapped to HTTP 403.

Stacked on `remove-supabase-barrel` (#133); base is that branch.

### Layered seam (per domain)
- `services/<domain>/repository.js` — the **only** consumer of `supabaseAdmin`; all privileged reads + writes; returns `{data,error}`, never throws.
- `services/<domain>/policy.js` — pure authorization predicates over a loaded row.
- `services/<domain>/service.js` — capability methods `(actor, …)`: load → policy → **throw** `AuthorizationError` on denial → mutate.
- Routes build `actorFromLocals(res.locals)` and never import the service-role client.

Shared foundation: `util/actor.js` (`actorFromLocals`, `SYSTEM_ACTOR`, `isAdmin`/`isSystem`), `util/errors.js` (`AuthorizationError`), `util/async-handler.js`, and a `forbidden`→403 case in `util/http-error.js`.

### Acceptance criteria
- **(a) No route imports the service-role client** — grep-verified: `supabaseAdmin` in app code (`routes/`, `util/`, `models/`, `services/`) appears **only** in `models/_base.js` (definition) and the 10 `services/*/repository.js`.
- **(b) Repositories encapsulate privileged persistence** — one repository per domain (class, profile, rules, pdf, badge, agent-token, bot-link, mission, character, lfg).
- **(c) Services receive actor context + capability methods** — every privileged command takes an explicit actor; `SYSTEM_ACTOR` (frozen, never built from request input) for internal/system callers.
- **(d) Authorization tests per privileged command** — per-domain `policy.test.js` + service throw-tests; the test runner now scans `services/` so they run in the gate.

### Security hardening (beyond the mechanical move)
Closed previously-unauthorized mutations, enforced on both web and agent paths:
- mission `addCharacter`/`removeCharacter` (require `canEditMission`), editor management (require creator);
- lfg join-request approve/reject (require host) and leave/withdraw (require owner).

Internal callers (badge recalc, backfill, conduit sync) use `SYSTEM_ACTOR` so hardening doesn't break them.

### Behavioral change
Removed `res.locals.supabase = supabaseAdmin` on the agent path; agent reads go through repository privileged reads keyed on the actor, preserving admin/owner visibility (confirmed by the `*-agent` integration tests).

### Verification
- `test:unit` and `test:http` both exit 0; integration (`lfg-agent`, `character-atomic`) green.
- Delivered via subagent-driven development (12 tasks, per-task spec+quality review, whole-branch review). Final whole-branch review (opus): **ready to merge**, no Critical/Important.

### Out of scope / follow-ups
- `scripts/backfill-badges.js` (offline admin CLI) still imports `supabaseAdmin` directly — outside the ticket's app-runtime scope; optional future cleanup.
- Design: `docs/superpowers/specs/2026-07-10-consolidate-service-role-design.md`; Plan: `docs/superpowers/plans/2026-07-10-consolidate-service-role.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
