### PR TITLE
Complete character mutation service boundary (ar-m8ai)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ supabase/.branches/
 .cursor/
 .DS_Store
 backups/
+public/img/badges/
 *.log
 logs/
 bun.lockb

--- a/.tickets/ar-m8ai.md
+++ b/.tickets/ar-m8ai.md
@@ -1,6 +1,6 @@
 ---
 id: ar-m8ai
-status: in_progress
+status: closed
 deps: [ar-ezes]
 links: []
 created: 2026-07-10T21:28:57Z

--- a/.tickets/ar-m8ai.md
+++ b/.tickets/ar-m8ai.md
@@ -1,6 +1,6 @@
 ---
 id: ar-m8ai
-status: open
+status: in_progress
 deps: [ar-ezes]
 links: []
 created: 2026-07-10T21:28:57Z

--- a/README.md
+++ b/README.md
@@ -108,7 +108,19 @@ script).
    supabase db reset
    ```
 
-4. Start the app:
+4. Seed the local app data (admin user, classes, and badges). `db reset`
+   only loads `nav_items`; this one idempotent command fills in the rest in
+   the right order and is safe to re-run (each step is skipped when its table
+   is already populated):
+   ```sh
+   bun run seed:local
+   ```
+   It seeds a `dummy@testing.com` / `dummypassword` admin, the class
+   definitions, and the badge catalog. Badge art is pulled from the public
+   prod storage bucket on first run (no credentials needed); override the
+   source with `BADGE_ART_SOURCE_URL`.
+
+5. Start the app:
    ```sh
    bun run dev
    ```
@@ -203,19 +215,26 @@ script. **It does not apply `supabase/seed.sql`** (the CLI reserves seed
 files for `supabase db reset`); for nav items seeding either run `bun run
 setup` once or apply `supabase/seed.sql` manually.
 
-### (Optional) Seed class data
+### Seeding app data (admin, classes, badges)
 
-To (re)load class definitions from the seed util:
+For a local stack, `bun run seed:local` seeds everything `supabase db reset`
+doesn't — an admin user, class definitions, and the badge catalog — in
+dependency order and idempotently. It's the recommended one-command path.
+
+The individual seeds can also be run directly:
 
 ```sh
-# If you haven't populated an admin user, populate one now:
-bun run seed:admin
-
-# Seed classes
-bun run seed:classes
+bun run seed:admin      # dummy@testing.com / dummypassword admin (dev only)
+bun run seed:classes    # class definitions — requires an admin profile first
+bun run fetch:badges    # download badge art from the public prod bucket
+bun run seed:badges     # upload art to the badges bucket + upsert catalog rows
 ```
 
-#### 5. (Optional) Check schema and tables
+`seed:classes` sets each class's `created_by` to the admin profile, so
+`seed:admin` (or an existing admin) must run first. `seed:badges` reads art
+from `public/img/badges/`, which `fetch:badges` populates.
+
+### Checking the schema and tables
 
 You can see a visual representation of the database schema on the Supabase
 dashboard for your project under Database > Schema Visualizser.
@@ -224,7 +243,7 @@ You can check the rows of your table from the Supabase dashboard for your
 project under Table Editor. If you ran `seed:admin` and `seed:classes` above,
 you should see them in your database.
 
-#### Backups
+### Backups
 
 `scripts/db-backup.sh` runs `pg_dump` against your project's Supabase pooler
 and writes a compressed dump to `backups/`. It derives the host and user from

--- a/docs/superpowers/plans/2026-07-28-complete-character-service-boundary.md
+++ b/docs/superpowers/plans/2026-07-28-complete-character-service-boundary.md
@@ -1,0 +1,1037 @@
+# Complete Character Mutation Service Boundary — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every character mutation a named `CharacterService` use-case with a tested authorization contract and (for level-up) a transaction boundary, so `routes/characters.js` handlers only translate HTTP and render responses.
+
+**Architecture:** Continues the ar-ezes seam — `routes → CharacterService (actor-first capability methods, policy-gated, throw AuthorizationError) → repository (sole supabaseAdmin consumer) → policy (pure predicates)`. Four extractions: (1) wizard validation → `input.js`; (2) form-array reshaping → `input.js`; (3) offscreen-mission writes → `CharacterService` methods; (4) level-up terminal writes → an atomic Postgres RPC.
+
+**Tech Stack:** Node.js/CommonJS, Express 4 (needs `asyncHandler` for async throws), Supabase (`supabaseAdmin` service-role client), Bun test runner (`bun:test`, `mock.module`), Postgres plpgsql `SECURITY DEFINER` RPCs.
+
+## Global Constraints
+
+- `supabaseAdmin` is imported ONLY in `models/_base.js` and `services/*/repository.js`. New privileged reads/writes go in `services/character/repository.js`, never in routes/models.
+- Authorization denials **throw** `AuthorizationError` (`code: 'forbidden'` → 403 via `util/http-error.js#classifyError`). Business-rule failures keep returning `{ data, error }`.
+- Every touched route handler is wrapped in `asyncHandler` (`util/async-handler.js`) — Express 4 does not catch async throws; an unwrapped throw hangs the request (this exact regression bit three times during ar-ezes).
+- Double-guard preserved: creator-only writes keep BOTH the JS policy check (`canMutateCharacter`) AND the SQL `.eq('creator_id', …)` / `WHERE creator_id = …` filter.
+- Actor for the newly-seamed mutations is built via `actorFromLocals(res.locals)` → `{ userId, profileId, role }`. `canMutateCharacter(actor, character)` (in `services/character/policy.js`) already allows creator, admin, or system.
+- No dead code: when a route helper or repository method is fully replaced, delete it in the same task.
+- Test gate green after each task: `bun run test:unit` and `bun run test:http` exit 0. Integration tests (`node scripts/run-tests.mjs integration`) run only where local Supabase is up.
+- One Bun process per test file (`scripts/run-tests.mjs`); `mock.module` is process-global — capture real modules up front and restore in `afterAll`, mirroring `routes/character-wizard.test.js`.
+
+---
+
+## Task 1: Extract wizard payload normalization into `input.js`
+
+The `POST /wizard` handler (`routes/characters.js:345-384`) does inline validation/coercion. Move it verbatim into a pure, unit-tested `normalizeWizardPayload` in `services/character/input.js`; the handler keeps only JSON parsing and delegation.
+
+**Files:**
+- Modify: `services/character/input.js`
+- Test: `services/character/input.test.js`
+- Modify: `routes/characters.js:328-402`
+
+**Interfaces:**
+- Produces: `normalizeWizardPayload(rawBody) → { data, error }` where `data` is the coerced body ready for `createCharacter`, and `error` is a string message (or `null`). Exported from `services/character/input.js`.
+- Consumes: existing `statList` (already imported in `input.js`), existing `parseInteger` (already defined in `input.js`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `services/character/input.test.js`:
+
+```js
+const { normalizeWizardPayload } = require('./input');
+
+test('normalizeWizardPayload rejects a missing name', () => {
+  const { data, error } = normalizeWizardPayload({ name: '   ' });
+  expect(data).toBeNull();
+  expect(error).toBe('Character name is required.');
+});
+
+test('normalizeWizardPayload rejects an over-long name', () => {
+  const { error } = normalizeWizardPayload({ name: 'x'.repeat(121) });
+  expect(error).toBe('Character name is too long (max 120 characters).');
+});
+
+test('normalizeWizardPayload rejects an unknown creator_mode', () => {
+  const { error } = normalizeWizardPayload({ name: 'Hero', creator_mode: 'bogus' });
+  expect(error).toBe('Invalid mode: bogus');
+});
+
+test('normalizeWizardPayload coerces stats, clamps level/missions, defaults reward and booleans', () => {
+  const { data, error } = normalizeWizardPayload({
+    name: '  Hero  ',
+    might: '7',
+    level: '99',
+    completed_missions: '-3',
+    is_public: false,
+    hide_from_search: true
+  });
+  expect(error).toBeNull();
+  expect(data.name).toBe('Hero');
+  expect(data.might).toBe(7);
+  expect(data.level).toBe(20);
+  expect(data.completed_missions).toBe(0);
+  expect(data.commissary_reward).toBe(0);
+  expect(data.is_public).toBe(false);
+  expect(data.hide_from_search).toBe(true);
+});
+
+test('normalizeWizardPayload defaults is_public to true when unset', () => {
+  const { data } = normalizeWizardPayload({ name: 'Hero' });
+  expect(data.is_public).toBe(true);
+  expect(data.hide_from_search).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test services/character/input.test.js`
+Expected: FAIL — `normalizeWizardPayload is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/character/input.js`, add (verbatim port of the route logic, using the file's existing `parseInteger` and `statList`):
+
+```js
+const normalizeWizardPayload = (rawBody) => {
+  const body = cloneInput(rawBody);
+
+  const trimmedName = (body.name || '').toString().trim();
+  if (!trimmedName) return { data: null, error: 'Character name is required.' };
+  if (trimmedName.length > 120) {
+    return { data: null, error: 'Character name is too long (max 120 characters).' };
+  }
+
+  if (body.creator_mode != null && body.creator_mode !== '' && !CREATOR_MODES.includes(body.creator_mode)) {
+    return { data: null, error: `Invalid mode: ${body.creator_mode}` };
+  }
+
+  const knownStats = new Set(statList);
+  for (const k of Object.keys(body)) {
+    if (knownStats.has(k)) body[k] = parseInteger(body[k], 0);
+  }
+
+  if (body.level != null) body.level = Math.max(1, Math.min(20, parseInteger(body.level, 1)));
+  if (body.completed_missions != null) body.completed_missions = Math.max(0, parseInteger(body.completed_missions, 0));
+  body.commissary_reward = Math.max(0, parseInteger(body.commissary_reward, 0));
+  body.name = trimmedName;
+  body.is_public = body.is_public === false ? false : true;
+  body.hide_from_search = !!body.hide_from_search;
+
+  return { data: body, error: null };
+};
+```
+
+Add `normalizeWizardPayload` to the `module.exports` block.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test services/character/input.test.js`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Rewire the route to delegate**
+
+In `routes/characters.js`: add `normalizeWizardPayload` to the `require('../services/character/input')` import (check whether the file already imports from that module; if not, add `const { normalizeWizardPayload } = require('../services/character/input');`). Replace lines `345-384` (everything between the `JSON.parse` block and the `const { data, error } = await createCharacter(...)` call) with:
+
+```js
+  const { data: normalized, error: wizardError } = normalizeWizardPayload(body);
+  if (wizardError) {
+    return sendError(req, res, null, { status: 400, message: wizardError });
+  }
+
+  const { data, error } = await createCharacter(normalized, profile);
+```
+
+Then delete the now-unused route-local `parseInteger` (`routes/characters.js:73-76`) **only if** `grep -n 'parseInteger' routes/characters.js` shows no other uses; otherwise leave it.
+
+- [ ] **Step 6: Run the gate**
+
+Run: `bun run test:unit && bun run test:http`
+Expected: both exit 0 (in particular `routes/character-wizard.test.js` and `services/character/input.test.js`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/character/input.js services/character/input.test.js routes/characters.js
+git commit -m "refactor: move wizard payload validation into character input layer (ar-m8ai)"
+```
+
+---
+
+## Task 2: Extract form-array collection into `input.js`
+
+`collectAbilityPerks` / `collectNamed` / `asArray` (`routes/characters.js:38-71`) reshape parallel HTML form arrays into domain sub-entities and duplicate `normalizeAbilityPerks`. Move them behind one input helper the create/update handlers call once.
+
+**Files:**
+- Modify: `services/character/input.js`
+- Test: `services/character/input.test.js`
+- Modify: `routes/characters.js:38-71, 744-755, 1170-1181`
+
+**Interfaces:**
+- Produces: `collectCharacterFormArrays(body) → newBody` (a shallow copy with `ability_perks`, `quirks`, `accessories` assembled from the parallel `ability_perk_*` / `quirk_*` / `accessory_*` keys, and those raw keys removed). Exported from `services/character/input.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `services/character/input.test.js`:
+
+```js
+const { collectCharacterFormArrays } = require('./input');
+
+test('collectCharacterFormArrays assembles perks/quirks/accessories and strips raw keys', () => {
+  const out = collectCharacterFormArrays({
+    name: 'Hero',
+    ability_perk_class_ability_id: ['a1', 'a2'],
+    ability_perk_text: ['first', ''],          // blank text row is dropped
+    ability_perk_position: ['0', '1'],
+    ability_perk_compounds_with: ['', 'new:x'],
+    quirk_name: ['Brave', '  '],               // blank name dropped
+    quirk_description: ['bold', ''],
+    accessory_name: ['Ring'],
+    accessory_description: ['']
+  });
+  expect(out.name).toBe('Hero');
+  expect(out.ability_perks).toEqual([{ class_ability_id: 'a1', text: 'first', position: 0, compounds_with: null }]);
+  expect(out.quirks).toEqual([{ name: 'Brave', description: 'bold' }]);
+  expect(out.accessories).toEqual([{ name: 'Ring' }]);
+  expect(out.ability_perk_class_ability_id).toBeUndefined();
+  expect(out.quirk_name).toBeUndefined();
+  expect(out.accessory_description).toBeUndefined();
+});
+
+test('collectCharacterFormArrays tolerates single (non-array) form values', () => {
+  const out = collectCharacterFormArrays({
+    ability_perk_class_ability_id: 'a1',
+    ability_perk_text: 'solo',
+    ability_perk_position: '3',
+    ability_perk_compounds_with: ''
+  });
+  expect(out.ability_perks).toEqual([{ class_ability_id: 'a1', text: 'solo', position: 3, compounds_with: null }]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test services/character/input.test.js`
+Expected: FAIL — `collectCharacterFormArrays is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `services/character/input.js`, add (verbatim port of the route helpers):
+
+```js
+const asArray = (v) => (Array.isArray(v) ? v : (v == null || v === '' ? [] : [v]));
+
+const collectAbilityPerksFromForm = (body) => {
+  const ids = asArray(body.ability_perk_class_ability_id);
+  const texts = asArray(body.ability_perk_text);
+  const pos = asArray(body.ability_perk_position);
+  const cw = asArray(body.ability_perk_compounds_with);
+  const n = Math.max(ids.length, texts.length, pos.length, cw.length);
+  const perks = [];
+  for (let i = 0; i < n; i++) {
+    const id = ids[i];
+    const text = texts[i];
+    if (!id || !text) continue;
+    perks.push({
+      class_ability_id: id,
+      text: String(text),
+      position: Number(pos[i]) || i,
+      compounds_with: cw[i] || null
+    });
+  }
+  return perks;
+};
+
+const collectNamedFromForm = (body, nameKey, descKey) => {
+  const names = asArray(body[nameKey]);
+  const descs = asArray(body[descKey]);
+  const out = [];
+  for (let i = 0; i < names.length; i++) {
+    const name = (names[i] || '').toString().trim();
+    if (!name) continue;
+    const desc = (descs[i] || '').toString().trim();
+    out.push(desc ? { name, description: desc } : { name });
+  }
+  return out;
+};
+
+const FORM_ARRAY_KEYS = [
+  'ability_perk_class_ability_id', 'ability_perk_text', 'ability_perk_position',
+  'ability_perk_compounds_with', 'quirk_name', 'quirk_description',
+  'accessory_name', 'accessory_description'
+];
+
+const collectCharacterFormArrays = (body) => {
+  const out = { ...body };
+  out.ability_perks = collectAbilityPerksFromForm(body);
+  out.quirks = collectNamedFromForm(body, 'quirk_name', 'quirk_description');
+  out.accessories = collectNamedFromForm(body, 'accessory_name', 'accessory_description');
+  for (const key of FORM_ARRAY_KEYS) delete out[key];
+  return out;
+};
+```
+
+Add `collectCharacterFormArrays` to `module.exports`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test services/character/input.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Rewire the create and update routes**
+
+In `routes/characters.js`:
+- Add `collectCharacterFormArrays` to the `services/character/input` import.
+- In `POST /` (738), replace lines `744-755` with:
+
+```js
+  req.body = collectCharacterFormArrays(req.body);
+```
+
+(keep the `image_crop` handling above it and the `createCharacter(req.body, profile)` call below it unchanged).
+- In `PUT /:id/:name?` (1163), replace lines `1170-1181` with the same single line.
+- Delete the now-unused route-local helpers `asArray` (38), `collectAbilityPerks` (40-58), `collectNamed` (60-71).
+
+- [ ] **Step 6: Run the gate**
+
+Run: `bun run test:unit && bun run test:http`
+Expected: both exit 0 (`routes/characters.test.js`, `routes/character-wizard.test.js` green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/character/input.js services/character/input.test.js routes/characters.js
+git commit -m "refactor: move character form-array reshaping into input layer (ar-m8ai)"
+```
+
+---
+
+## Task 3: Offscreen-mission repository methods + `CharacterService` capabilities
+
+Give the three offscreen-mission mutations a policy-gated service seam. Repository gains privileged offscreen reads/writes; the service gains three capability methods carrying the source-resolution and credit-gate workflow. Unit-tested with a mock adapter.
+
+**Files:**
+- Modify: `services/character/repository.js`
+- Modify: `services/character/service.js`
+- Test: `services/character/service.test.js`
+
+**Interfaces:**
+- Produces on the repository (added to `module.exports`), all returning `{ data, error }` and never throwing:
+  - `getOffscreenMissionRow(id)` — admin read of one `offscreen_missions` row.
+  - `getSourceMissionForCredit(missionId)` — admin read `{ id, name, date, host_id }` from `missions`.
+  - `getConduitCredits(profileId)` — delegates to `getProfileConduitCredits` with the admin client.
+  - `insertOffscreenMission({ characterId, profileId, payload })` — delegates to `models/offscreen-mission#createOffscreenMission` with the admin client.
+  - `updateOffscreenMissionRow({ id, payload })` — delegates to `models/offscreen-mission#updateOffscreenMission` with the admin client.
+  - `deleteOffscreenMissionRow(id)` — delegates to `models/offscreen-mission#removeOffscreenMission` with the admin client.
+- Produces on `CharacterService` (each takes `actor` first, loads the character via `requireOwnedCharacter` which throws on non-owner/not-found, then applies business rules and returns `{ data, error }`):
+  - `createOffscreenMission(actor, characterId, body)`
+  - `updateOffscreenMission(actor, characterId, omId, body)`
+  - `deleteOffscreenMission(actor, characterId, omId)`
+- Consumes: existing `requireOwnedCharacter(this.adapter, actor, id)` and `canMutateCharacter`; new adapter methods above added to `REQUIRED_ADAPTER_METHODS`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `services/character/service.test.js` (reuse the file's `makeAdapter`/`CREATOR`/`STRANGER`; extend `makeAdapter` overrides with the new methods as the tests need them):
+
+```js
+const offscreenAdapter = (overrides = {}) => ({
+  getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', name: 'Hero', abilities: [] }),
+  getOffscreenMissionRow: async () => ok({ id: 'om-1', character_id: 'character-1' }),
+  getSourceMissionForCredit: async () => ok({ id: 'm-1', name: 'Raid', date: '2026-01-01', host_id: 'profile-1' }),
+  getConduitCredits: async () => ok({ balance: 3 }),
+  insertOffscreenMission: async () => ({ error: null }),
+  updateOffscreenMissionRow: async () => ({ error: null }),
+  deleteOffscreenMissionRow: async () => ({ error: null }),
+  // plus the REQUIRED_ADAPTER_METHODS the constructor validates — spread makeAdapter([]) or a minimal stub:
+  ...minimalRequiredAdapter(),
+  ...overrides
+});
+
+test('createOffscreenMission refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  await expect(svc.createOffscreenMission(STRANGER, 'character-1', { name: 'x', summary: 'y' }))
+    .rejects.toBeInstanceOf(AuthorizationError);
+});
+
+test('createOffscreenMission requires name and summary', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', { name: '', summary: '' });
+  expect(error).toEqual({ status: 400, message: 'Name and summary are required.' });
+});
+
+test('createOffscreenMission rejects a source mission the actor does not host', async () => {
+  const svc = new CharacterService(offscreenAdapter({
+    getSourceMissionForCredit: async () => ok({ id: 'm-1', name: 'Raid', date: '2026-01-01', host_id: 'someone-else' })
+  }));
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: 'n', summary: 's', source_mission_id: 'm-1'
+  });
+  expect(error.status).toBe(400);
+});
+
+test('createOffscreenMission gates a hosted source on the credit balance', async () => {
+  const svc = new CharacterService(offscreenAdapter({
+    getConduitCredits: async () => ok({ balance: 0 })
+  }));
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: 'n', summary: 's', source_mission_id: 'm-1'
+  });
+  expect(error).toEqual({ status: 400, message: 'No Conduit Credits available.' });
+});
+
+test('createOffscreenMission inserts on the happy path', async () => {
+  const calls = [];
+  const svc = new CharacterService(offscreenAdapter({
+    insertOffscreenMission: async (args) => { calls.push(args); return { error: null }; }
+  }));
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: 'n', summary: 's', source_mission_name_other: 'Freeform', source_mission_date_other: '2026-02-02'
+  });
+  expect(error).toBeNull();
+  expect(calls[0].characterId).toBe('character-1');
+});
+
+test('updateOffscreenMission 404s when the row belongs to another character', async () => {
+  const svc = new CharacterService(offscreenAdapter({
+    getOffscreenMissionRow: async () => ok({ id: 'om-1', character_id: 'other-char' })
+  }));
+  const { error } = await svc.updateOffscreenMission(CREATOR, 'character-1', 'om-1', { name: 'n', summary: 's' });
+  expect(error.status).toBe(404);
+});
+
+test('deleteOffscreenMission refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  await expect(svc.deleteOffscreenMission(STRANGER, 'character-1', 'om-1'))
+    .rejects.toBeInstanceOf(AuthorizationError);
+});
+```
+
+Add a `minimalRequiredAdapter()` helper near the top of the test file that returns an object with every name in `REQUIRED_ADAPTER_METHODS` as an `async () => ok(null)` stub, so `new CharacterService(...)` passes constructor validation. (If the file already has a full `makeAdapter`, build `minimalRequiredAdapter` by calling `makeAdapter([])` and returning it.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test services/character/service.test.js`
+Expected: FAIL — `createOffscreenMission is not a function` (and constructor errors for missing adapter methods).
+
+- [ ] **Step 3: Add the repository methods**
+
+In `services/character/repository.js`, add these to `module.exports` (import surface: `getProfileConduitCredits` from `../../models/profile`, and the offscreen model functions already imported at the top — extend that import to include `updateOffscreenMission`, `removeOffscreenMission`, `getOffscreenMissionById`):
+
+```js
+  getOffscreenMissionRow: (id) => getOffscreenMissionById({ id, supabase: supabaseAdmin }),
+  getSourceMissionForCredit: async (missionId) => {
+    const { data, error } = await supabaseAdmin
+      .from('missions')
+      .select('id, name, date, host_id')
+      .eq('id', missionId)
+      .maybeSingle();
+    return { data, error };
+  },
+  getConduitCredits: (profileId) => getProfileConduitCredits({ profileId, supabase: supabaseAdmin }),
+  insertOffscreenMission: ({ characterId, profileId, payload }) => createOffscreenMission({
+    characterId, profileId, payload, supabase: supabaseAdmin
+  }),
+  updateOffscreenMissionRow: ({ id, payload }) => updateOffscreenMission({ id, payload, supabase: supabaseAdmin }),
+  deleteOffscreenMissionRow: (id) => removeOffscreenMission({ id, supabase: supabaseAdmin }),
+```
+
+Note: `createOffscreenMission` is already imported at the top of the repository (line 4). Extend that destructure and add the `getProfileConduitCredits` require.
+
+- [ ] **Step 4: Add the service methods**
+
+In `services/character/service.js`, add a private source-resolver and the three capabilities inside the `CharacterService` class (port of `resolveOffscreenSource` + the route workflow; the source resolver is pure over adapter reads):
+
+```js
+  async resolveOffscreenSource(actor, body) {
+    if (body.source_mission_id && body.source_mission_id !== '__other__') {
+      const { data: srcMission, error } = await this.adapter.getSourceMissionForCredit(body.source_mission_id);
+      if (error || !srcMission) return { error: 'Source mission not found.' };
+      if (srcMission.host_id !== actor.profileId) {
+        return { error: 'Only the host of a mission can use it as a credit source.' };
+      }
+      return {
+        source_mission_id: srcMission.id,
+        source_mission_name: srcMission.name,
+        source_mission_date: typeof srcMission.date === 'string'
+          ? srcMission.date.slice(0, 10)
+          : new Date(srcMission.date).toISOString().slice(0, 10)
+      };
+    }
+    const name = (body.source_mission_name_other || '').trim();
+    const date = (body.source_mission_date_other || '').trim();
+    if (!name || !date) return { error: 'Source mission name and date are required.' };
+    return { source_mission_id: null, source_mission_name: name, source_mission_date: date };
+  }
+
+  async createOffscreenMission(actor, characterId, body) {
+    await requireOwnedCharacter(this.adapter, actor, characterId);
+
+    if (!body.name || !body.summary) {
+      return { data: null, error: { status: 400, message: 'Name and summary are required.' } };
+    }
+    const src = await this.resolveOffscreenSource(actor, body);
+    if (src.error) return { data: null, error: { status: 400, message: src.error } };
+
+    if (src.source_mission_id) {
+      const { data: credits } = await this.adapter.getConduitCredits(actor.profileId);
+      if (!credits || credits.balance <= 0) {
+        return { data: null, error: { status: 400, message: 'No Conduit Credits available.' } };
+      }
+    }
+
+    const { error } = await this.adapter.insertOffscreenMission({
+      characterId,
+      profileId: actor.profileId,
+      payload: {
+        name: body.name,
+        summary: body.summary,
+        merx_gained: body.merx_gained,
+        source_mission_id: src.source_mission_id,
+        source_mission_name: src.source_mission_name,
+        source_mission_date: src.source_mission_date
+      }
+    });
+    if (error) {
+      if (error.code === '23505' || error.message === 'duplicate_source_mission') {
+        return { data: null, error: { status: 400, message: 'That mission has already funded a credit.' } };
+      }
+      return { data: null, error };
+    }
+    return { data: { characterId }, error: null };
+  }
+
+  async updateOffscreenMission(actor, characterId, omId, body) {
+    await requireOwnedCharacter(this.adapter, actor, characterId);
+
+    const { data: existing, error: omError } = await this.adapter.getOffscreenMissionRow(omId);
+    if (omError) return { data: null, error: omError };
+    if (!existing || existing.character_id !== characterId) {
+      return { data: null, error: { status: 404, message: 'Not found' } };
+    }
+    if (!body.name || !body.summary) {
+      return { data: null, error: { status: 400, message: 'Name and summary are required.' } };
+    }
+    const src = await this.resolveOffscreenSource(actor, body);
+    if (src.error) return { data: null, error: { status: 400, message: src.error } };
+
+    const { error } = await this.adapter.updateOffscreenMissionRow({
+      id: omId,
+      payload: {
+        name: body.name,
+        summary: body.summary,
+        merx_gained: body.merx_gained,
+        source_mission_id: src.source_mission_id,
+        source_mission_name: src.source_mission_name,
+        source_mission_date: src.source_mission_date
+      }
+    });
+    if (error) {
+      if (error.code === '23505' || error.message === 'duplicate_source_mission') {
+        return { data: null, error: { status: 400, message: 'That mission has already funded a credit.' } };
+      }
+      return { data: null, error };
+    }
+    return { data: { characterId }, error: null };
+  }
+
+  async deleteOffscreenMission(actor, characterId, omId) {
+    await requireOwnedCharacter(this.adapter, actor, characterId);
+
+    const { data: existing, error: omError } = await this.adapter.getOffscreenMissionRow(omId);
+    if (omError) return { data: null, error: omError };
+    if (!existing || existing.character_id !== characterId) {
+      return { data: null, error: { status: 404, message: 'Not found' } };
+    }
+    const { error } = await this.adapter.deleteOffscreenMissionRow(omId);
+    if (error) return { data: null, error };
+    return { data: { characterId }, error: null };
+  }
+```
+
+Add the six new method names to `REQUIRED_ADAPTER_METHODS`: `getOffscreenMissionRow`, `getSourceMissionForCredit`, `getConduitCredits`, `insertOffscreenMission`, `updateOffscreenMissionRow`, `deleteOffscreenMissionRow`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test services/character/service.test.js`
+Expected: PASS (all offscreen cases + existing cases still green).
+
+- [ ] **Step 6: Run the gate**
+
+Run: `bun run test:unit`
+Expected: exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/character/repository.js services/character/service.js services/character/service.test.js
+git commit -m "feat: add offscreen-mission capabilities to CharacterService (ar-m8ai)"
+```
+
+---
+
+## Task 4: Rewire offscreen routes to the service + thin the handlers
+
+Wire the three offscreen POST handlers to the new capabilities via `models/character.js` re-exports, drop the inline authz/validation/workflow and the route-local `resolveOffscreenSource`, and add an HTTP regression test asserting a non-owner gets 403 (and the request does not hang).
+
+**Files:**
+- Modify: `models/character.js` (add re-exports)
+- Modify: `routes/characters.js` (rewire 3 handlers; delete `resolveOffscreenSource`; prune now-unused imports)
+- Test: `routes/character-offscreen.test.js` (create)
+- Modify: `scripts/run-tests.mjs` (register the new HTTP test file)
+
+**Interfaces:**
+- Consumes: `characterService.createOffscreenMission/updateOffscreenMission/deleteOffscreenMission` (Task 3).
+- Produces (from `models/character.js`, added to `module.exports`):
+  - `createCharacterOffscreenMission(actor, characterId, body)`
+  - `updateCharacterOffscreenMission(actor, characterId, omId, body)`
+  - `deleteCharacterOffscreenMission(actor, characterId, omId)`
+
+- [ ] **Step 1: Write the failing HTTP test**
+
+Create `routes/character-offscreen.test.js`, mirroring the mocking recipe in `routes/character-level-up.test.js` / `routes/character-wizard.test.js` (real `isAuthenticated` + real handler over a mocked data layer). Mock `../models/character` so `createCharacterOffscreenMission` throws `AuthorizationError` for a stranger and resolves `{ error: null }` for the owner. Core assertions:
+
+```js
+const { AuthorizationError } = require('../util/errors');
+
+// ...standard mock.module setup for _base, auth (getUserFromToken → { id: 'u1' } for 'valid-jwt'),
+// profile (getProfile → { id: 'p1', user_id: 'u1' }), system-message, lfg, nav-loader...
+
+mock.module('../models/character', () => ({
+  createCharacterOffscreenMission: async (actor) => {
+    if (actor.profileId !== 'owner') throw new AuthorizationError('nope', { reason: 'not_owner' });
+    return { data: { characterId: CHAR_ID }, error: null };
+  }
+}));
+
+test('POST /:id/offscreen-missions returns 403 for a non-owner (and does not hang)', async () => {
+  const res = await Promise.race([
+    request(app).post(`/characters/${CHAR_ID}/offscreen-missions`)
+      .set('Authorization', 'Bearer valid-jwt')
+      .send({ name: 'n', summary: 's' }),
+    new Promise((_, rej) => setTimeout(() => rej(new Error('request hung')), 2000))
+  ]);
+  expect(res.status).toBe(403);
+});
+```
+
+(Set `res.locals.profile.id` in the profile mock so `actorFromLocals` yields a non-`'owner'` `profileId`, exercising the deny path. Use the same `app`/`request` harness the sibling tests use.)
+
+- [ ] **Step 2: Register and run the test to verify it fails**
+
+Add `'routes/character-offscreen.test.js'` to the `httpFiles` set in `scripts/run-tests.mjs`.
+Run: `bun test routes/character-offscreen.test.js`
+Expected: FAIL — `createCharacterOffscreenMission is not a function` (route still uses inline logic / old imports).
+
+- [ ] **Step 3: Add the model re-exports**
+
+In `models/character.js`, after the existing mutation re-exports (near line 420), add:
+
+```js
+const createCharacterOffscreenMission = (actor, characterId, body) => characterService.createOffscreenMission(actor, characterId, body);
+const updateCharacterOffscreenMission = (actor, characterId, omId, body) => characterService.updateOffscreenMission(actor, characterId, omId, body);
+const deleteCharacterOffscreenMission = (actor, characterId, omId) => characterService.deleteOffscreenMission(actor, characterId, omId);
+```
+
+and add all three names to `module.exports`.
+
+- [ ] **Step 4: Rewire the three route handlers**
+
+In `routes/characters.js`, import the three new functions from `../models/character`. Replace the handler bodies:
+
+`POST /:id/offscreen-missions` (576-627) →
+
+```js
+router.post('/:id/offscreen-missions', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { id: characterId } = req.params;
+  const { error } = await createCharacterOffscreenMission(actor, characterId, req.body);
+  if (error) return sendRouteError(req, res, error);
+  return res.redirect(`/characters/${characterId}`);
+}));
+```
+
+`POST /:id/offscreen-missions/:omId` (667-713) →
+
+```js
+router.post('/:id/offscreen-missions/:omId', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { id: characterId, omId } = req.params;
+  const { error } = await updateCharacterOffscreenMission(actor, characterId, omId, req.body);
+  if (error) return sendRouteError(req, res, error);
+  return res.redirect(`/characters/${characterId}`);
+}));
+```
+
+`POST /:id/offscreen-missions/:omId/delete` (715-736) →
+
+```js
+router.post('/:id/offscreen-missions/:omId/delete', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
+  const { id: characterId, omId } = req.params;
+  const { error } = await deleteCharacterOffscreenMission(actor, characterId, omId);
+  if (error) return sendRouteError(req, res, error);
+  return res.redirect(`/characters/${characterId}`);
+}));
+```
+
+Note the redirect drops the trailing `/${encodeURIComponent(character.name)}` segment because the handler no longer loads the character. `/characters/:id` is a valid canonical route (the app redirects/renders by id); confirm by grep that a bare `/characters/:id` GET or the name-optional route (`/:id/:name?`) resolves — the existing `GET /:id/:name?` handler treats `:name` as optional, so `/characters/<id>` matches. If any test asserts the exact redirect target, update it to the id-only path.
+
+Then delete the route-local `resolveOffscreenSource` helper (`routes/characters.js:157-178`). Prune imports now unused **only after grep confirms zero remaining references in the file**: `getMission` (mission model), and from the `offscreen-mission` model import, `createOffscreenMission`, `getOffscreenMissionById`, `updateOffscreenMission`, `removeOffscreenMission` (the GET form routes still use `listOffscreenMissions` and `getAvailableHostedMissionsForPicker`, and `getProfileConduitCredits` — keep whatever the GET handlers reference). Run `grep -n 'resolveOffscreenSource\|getMission\b\|getOffscreenMissionById\|removeOffscreenMission' routes/characters.js` and remove only names with no hits.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bun test routes/character-offscreen.test.js`
+Expected: PASS (403, no hang).
+
+- [ ] **Step 6: Run the gate**
+
+Run: `bun run test:unit && bun run test:http`
+Expected: both exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add models/character.js routes/characters.js routes/character-offscreen.test.js scripts/run-tests.mjs
+git commit -m "refactor: route offscreen-mission writes through CharacterService (ar-m8ai)"
+```
+
+---
+
+## Task 5: `level_up_character_atomic` migration (RPC + permissions + grant)
+
+Add the transactional terminal-write function mirroring the `save_character_atomic` migration triple. Applied only when local Supabase is running; the service refactor (Task 6) consumes it.
+
+**Files:**
+- Create: `supabase/migrations/20260728000000_level_up_character_atomic.sql`
+- Create: `supabase/migrations/20260728000001_level_up_character_atomic_permissions.sql`
+- Create: `supabase/migrations/20260728000002_level_up_character_atomic_service_role.sql`
+
+**Interfaces:**
+- Produces the RPC `public.level_up_character_atomic(p_character_id uuid, p_creator_id uuid, p_fields jsonb, p_perks jsonb) RETURNS public.characters`, where `p_fields` is the owned-field patch (stats + level + completed_missions + commissary_reward) and `p_perks` is an ordered array of NEW perks `{ class_ability_id, text, position, compounds_with }` — `compounds_with` is either `'position-<n>'` (another new perk in this batch, same ability) or an existing perk UUID string, or null.
+
+- [ ] **Step 1: Write the migration (RPC)**
+
+Create `supabase/migrations/20260728000000_level_up_character_atomic.sql`:
+
+```sql
+-- Atomically apply a level-up's terminal writes: update the character's owned
+-- counters/stats, insert the newly-submitted ability perks, and resolve their
+-- compound links — all in one transaction. Service-role only; authorization
+-- stays in CharacterService. Backfill missions and offscreen-credit rows are
+-- created upstream (cross-domain) and are intentionally NOT part of this
+-- transaction — they are additive and re-derivable.
+CREATE OR REPLACE FUNCTION public.level_up_character_atomic(
+  p_character_id uuid,
+  p_creator_id uuid,
+  p_fields jsonb,
+  p_perks jsonb
+)
+RETURNS public.characters
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  saved public.characters;
+  item jsonb;
+  source_id uuid;
+  target_id uuid;
+BEGIN
+  UPDATE public.characters AS current
+  SET
+    vitality = COALESCE((p_fields->>'vitality')::int, current.vitality),
+    might = COALESCE((p_fields->>'might')::int, current.might),
+    resilience = COALESCE((p_fields->>'resilience')::int, current.resilience),
+    spirit = COALESCE((p_fields->>'spirit')::int, current.spirit),
+    arcane = COALESCE((p_fields->>'arcane')::int, current.arcane),
+    will = COALESCE((p_fields->>'will')::int, current.will),
+    sensory = COALESCE((p_fields->>'sensory')::int, current.sensory),
+    reflex = COALESCE((p_fields->>'reflex')::int, current.reflex),
+    vigor = COALESCE((p_fields->>'vigor')::int, current.vigor),
+    skill = COALESCE((p_fields->>'skill')::int, current.skill),
+    intelligence = COALESCE((p_fields->>'intelligence')::int, current.intelligence),
+    luck = COALESCE((p_fields->>'luck')::int, current.luck),
+    level = COALESCE((p_fields->>'level')::int, current.level),
+    completed_missions = COALESCE((p_fields->>'completed_missions')::int, current.completed_missions),
+    commissary_reward = COALESCE((p_fields->>'commissary_reward')::int, current.commissary_reward)
+  WHERE current.id = p_character_id AND current.creator_id = p_creator_id
+  RETURNING current.* INTO saved;
+
+  IF saved.id IS NULL THEN
+    RAISE EXCEPTION 'Character update returned no rows';
+  END IF;
+
+  IF p_perks IS NOT NULL THEN
+    -- Insert the new perk rows.
+    FOR item IN SELECT value FROM jsonb_array_elements(p_perks)
+    LOOP
+      INSERT INTO public.character_perks (character_id, class_ability_id, text, position)
+      VALUES (
+        saved.id,
+        (item->>'class_ability_id')::uuid,
+        item->>'text',
+        COALESCE((item->>'position')::integer, 0)
+      );
+    END LOOP;
+
+    -- Resolve compound links. A link is either 'position-<n>' (another perk in
+    -- this batch on the SAME ability) or an existing perk UUID on the same
+    -- ability. Anything else is left null.
+    FOR item IN SELECT value FROM jsonb_array_elements(p_perks)
+    LOOP
+      IF item->>'compounds_with' IS NULL THEN CONTINUE; END IF;
+
+      SELECT cp.id INTO source_id
+      FROM public.character_perks cp
+      WHERE cp.character_id = saved.id
+        AND cp.class_ability_id = (item->>'class_ability_id')::uuid
+        AND cp.position = COALESCE((item->>'position')::integer, 0)
+      LIMIT 1;
+      IF source_id IS NULL THEN CONTINUE; END IF;
+
+      target_id := NULL;
+      IF item->>'compounds_with' LIKE 'position-%' THEN
+        SELECT cp.id INTO target_id
+        FROM public.character_perks cp
+        WHERE cp.character_id = saved.id
+          AND cp.class_ability_id = (item->>'class_ability_id')::uuid
+          AND cp.position = substring(item->>'compounds_with' FROM 'position-(.*)')::integer
+        LIMIT 1;
+      ELSIF item->>'compounds_with' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+        SELECT cp.id INTO target_id
+        FROM public.character_perks cp
+        WHERE cp.id = (item->>'compounds_with')::uuid
+          AND cp.character_id = saved.id
+          AND cp.class_ability_id = (item->>'class_ability_id')::uuid
+        LIMIT 1;
+      END IF;
+
+      IF target_id IS NOT NULL AND target_id <> source_id THEN
+        UPDATE public.character_perks SET compounds_with = target_id WHERE id = source_id;
+      END IF;
+    END LOOP;
+  END IF;
+
+  RETURN saved;
+END;
+$$;
+```
+
+- [ ] **Step 2: Write the permission migrations**
+
+Create `supabase/migrations/20260728000001_level_up_character_atomic_permissions.sql`:
+
+```sql
+REVOKE ALL ON FUNCTION public.level_up_character_atomic(uuid, uuid, jsonb, jsonb) FROM PUBLIC, anon, authenticated;
+```
+
+Create `supabase/migrations/20260728000002_level_up_character_atomic_service_role.sql`:
+
+```sql
+GRANT EXECUTE ON FUNCTION public.level_up_character_atomic(uuid, uuid, jsonb, jsonb) TO service_role;
+```
+
+- [ ] **Step 3: Apply and smoke-check (only if local Supabase is running)**
+
+Run: `supabase migration up` (or `supabase db reset` if the local stack allows). If local Supabase is NOT available in this environment, skip application — Task 6's unit tests do not need the live RPC, and the integration test self-skips without local Supabase.
+Expected: migrations apply with no SQL error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260728000000_level_up_character_atomic.sql supabase/migrations/20260728000001_level_up_character_atomic_permissions.sql supabase/migrations/20260728000002_level_up_character_atomic_service_role.sql
+git commit -m "feat: add level_up_character_atomic transactional RPC (ar-m8ai)"
+```
+
+---
+
+## Task 6: Refactor `levelUp`/`appendPerks` onto the atomic RPC
+
+Replace the level-up tail (`updateOwnedFields` + `appendPerks`'s direct insert/link writes) with a single `repo.levelUpAtomic` call. The JS keeps validation, position assignment, and `new:<ref>`→`position-<n>` link translation; the RPC does the atomic write. Remove the now-dead `insertPerks`/`updatePerkLinks` repository methods.
+
+**Files:**
+- Modify: `services/character/repository.js`
+- Modify: `services/character/service.js`
+- Test: `services/character/service.test.js`
+- Test: `models/character-level-up.integration.test.js` (create)
+- Modify: `scripts/run-tests.mjs` (register the integration test)
+
+**Interfaces:**
+- Produces on the repository: `levelUpAtomic({ characterId, creatorId, fields, perks }) → { data, error }` calling `supabaseAdmin.rpc('level_up_character_atomic', …)` (guarded by `typeof supabaseAdmin.rpc === 'function'`, matching `saveCharacterAtomic`).
+- Changes `CharacterService`: `appendPerks(characterId, submittedPerks)` becomes `buildPerkRows(characterId, submittedPerks) → { data: rows, error }` returning the ordered perk-row payload (with `compounds_with` as `'position-<n>'` or existing UUID) instead of writing. `levelUp` calls `buildPerkRows`, then one `adapter.levelUpAtomic(...)`.
+- Removed: adapter methods `insertPerks`, `updatePerkLinks` (dead after this task) — drop from `repository.js` exports and from `REQUIRED_ADAPTER_METHODS`. Add `levelUpAtomic` to `REQUIRED_ADAPTER_METHODS`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to `services/character/service.test.js`:
+
+```js
+test('levelUp persists via a single levelUpAtomic call (not updateOwnedFields + insertPerks)', async () => {
+  const calls = [];
+  const adapter = {
+    ...minimalRequiredAdapter(),
+    getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', class_id: 'class-1', level: 1, completed_missions: 0, commissary_reward: 0, abilities: [] }),
+    getRealMissions: async () => ok([]),
+    listOffscreenMissions: async () => ok([]),
+    getClassRulesVersion: async () => ok('v2'),
+    fetchAllowedAbilityIds: async () => ok([{ id: 'ab-1' }]),
+    fetchExistingPerks: async () => ok([]),
+    levelUpAtomic: async (args) => { calls.push(args); return ok({ id: 'character-1', name: 'Hero', level: 2, completed_missions: 0, commissary_reward: 0 }); },
+    updateOwnedFields: async () => { throw new Error('updateOwnedFields must not be called by levelUp'); },
+  };
+  const svc = new CharacterService(adapter);
+  const { data, error } = await svc.levelUp(CREATOR, 'character-1', {
+    level: 2,
+    ability_perks: [{ class_ability_id: 'ab-1', text: 'New perk', ref: 'r1' }]
+  });
+  expect(error).toBeNull();
+  expect(data.level).toBe(2);
+  expect(calls).toHaveLength(1);
+  expect(calls[0].characterId).toBe('character-1');
+  expect(calls[0].creatorId).toBe('profile-1');
+  expect(calls[0].perks[0]).toMatchObject({ class_ability_id: 'ab-1', text: 'New perk', position: 0 });
+});
+
+test('levelUp still refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService({ ...minimalRequiredAdapter(),
+    getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', abilities: [] }) });
+  await expect(svc.levelUp(STRANGER, 'character-1', {})).rejects.toBeInstanceOf(AuthorizationError);
+});
+```
+
+Add `levelUpAtomic: async () => ok({ id: 'character-1' })` to `minimalRequiredAdapter()`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test services/character/service.test.js`
+Expected: FAIL — `levelUp` still calls `updateOwnedFields` (throws) / adapter missing `levelUpAtomic`.
+
+- [ ] **Step 3: Add the repository method**
+
+In `services/character/repository.js`, inside the `typeof supabaseAdmin.rpc === 'function' ? { … } : {}` block (alongside `saveCharacterAtomic`), add:
+
+```js
+    levelUpAtomic: async ({ characterId, creatorId, fields, perks }) => {
+      const { data, error } = await supabaseAdmin.rpc('level_up_character_atomic', {
+        p_character_id: characterId,
+        p_creator_id: creatorId,
+        p_fields: fields,
+        p_perks: perks
+      });
+      return { data, error };
+    },
+```
+
+Delete the `insertPerks` and `updatePerkLinks` methods from `module.exports`.
+
+- [ ] **Step 4: Refactor the service**
+
+In `services/character/service.js`:
+- Rename `appendPerks` to `buildPerkRows`, keeping the allowed-ability filter, existing-position offsets, `validateAbilityPerks`, and ref bookkeeping — but instead of calling `insertPerks`/re-reading/`updatePerkLinks`, RETURN `{ data: rows, error }` where each row is `{ class_ability_id, text, position, compounds_with }`. Translate each new-perk link: `new:<ref>` → the target row's `'position-<n>'` (look the ref up in the batch and use its assigned `position`); an existing-perk UUID that maps to the same ability → keep the UUID; otherwise `null`. (No adapter writes; no id re-read — positions are assigned in JS and are the RPC's join key.)
+- In `levelUp`, replace the tail (from `const { data, error } = await this.adapter.updateOwnedFields(...)` through the `appendPerks` call, lines ~512-516) with:
+
+```js
+    const { data: perkRows, error: perkBuildError } = await this.buildPerkRows(id, Array.isArray(body.ability_perks) ? body.ability_perks : []);
+    if (perkBuildError) return { data: null, error: perkBuildError };
+
+    const { data, error } = await this.adapter.levelUpAtomic({
+      characterId: id,
+      creatorId: character.creator_id,
+      fields,
+      perks: perkRows
+    });
+    if (error) return { data: null, error };
+    if (!data) return { data: null, error: { status: 404, message: 'Character update returned no rows' } };
+```
+
+Keep the existing final `return { data: { id: data.id, name: data.name || character.name, level: data.level, completed_missions: data.completed_missions, commissary_reward: data.commissary_reward }, error: null };`.
+- Update `REQUIRED_ADAPTER_METHODS`: remove `insertPerks`, `updatePerkLinks`; add `levelUpAtomic`. Keep `fetchAllowedAbilityIds` and `fetchExistingPerks` (still used by `buildPerkRows`).
+
+- [ ] **Step 5: Run unit tests to verify they pass**
+
+Run: `bun test services/character/service.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Write the integration rollback test**
+
+Create `models/character-level-up.integration.test.js`, mirroring `models/character-atomic.integration.test.js` (same `pg` client + `supabaseAdmin` setup/teardown). Assert:
+1. A successful level-up with a new perk bumps `level` AND inserts the `character_perks` row (both present).
+2. A rollback case: force a failure inside the RPC (e.g. submit a perk row with a `class_ability_id` that violates the FK / not-null) and assert the character's `level` was NOT changed and no partial perk row exists — proving the terminal writes commit or roll back together.
+
+```js
+test('level-up terminal writes commit together', async () => {
+  await setup();
+  const character = await createOwnedCharacter();     // helper: createCharacter(...) then read back
+  const { data, error } = await levelUpCharacter(ACTOR, character.id, {
+    level: 2,
+    ability_perks: [{ class_ability_id: character.abilityId, text: 'Perk A', ref: 'r1' }]
+  });
+  expect(error).toBeNull();
+  expect(data.level).toBe(2);
+  const { data: perks } = await supabaseAdmin.from('character_perks').select('*').eq('character_id', character.id);
+  expect(perks.length).toBe(1);
+});
+
+test('level-up rolls back the counter when a perk write fails', async () => {
+  await setup();
+  const character = await createOwnedCharacter();
+  const { error } = await levelUpCharacter(ACTOR, character.id, {
+    level: 2,
+    ability_perks: [{ class_ability_id: '00000000-0000-4000-8000-000000000000', text: 'Bad perk', ref: 'r1' }]
+  });
+  // buildPerkRows filters to ALLOWED ability ids, so a bogus id is dropped and
+  // the write succeeds cleanly — to exercise a true RPC rollback, insert a
+  // duplicate (class_ability_id, position) that violates a constraint, OR
+  // assert the filtered-out case leaves a consistent state (level bumped, 0 perks).
+  // Choose whichever the schema makes reachable; the point is: after any failure,
+  // level and character_perks agree (no half-applied terminal write).
+  const { data: char } = await supabaseAdmin.from('characters').select('level').eq('id', character.id).single();
+  const { data: perks } = await supabaseAdmin.from('character_perks').select('id').eq('character_id', character.id);
+  expect(char.level === 1 || perks.length === 0).toBe(true);
+});
+```
+
+`ACTOR` = `{ userId, profileId: profile.id, role: null }`. Build `createOwnedCharacter` from the `input(...)` helper in the sibling integration test, then read back the character (and its inserted `class_abilities` id for a valid perk `class_ability_id`).
+
+- [ ] **Step 7: Register and run the integration test (if local Supabase is up)**
+
+Add `'models/character-level-up.integration.test.js'` to `integrationFiles` in `scripts/run-tests.mjs`.
+Run (only with local Supabase): `SUPABASE_URL=http://127.0.0.1:54321 node scripts/run-tests.mjs integration`
+Expected: PASS. If local Supabase is unavailable, note it and skip — the runner refuses integration mode without it.
+
+- [ ] **Step 8: Run the full gate**
+
+Run: `bun run test:unit && bun run test:http`
+Expected: both exit 0. Confirm `routes/character-level-up.test.js` still passes (the HTTP contract is unchanged — the route still returns `{ character }` JSON).
+
+- [ ] **Step 9: Verify no `supabaseAdmin` leak and no dead perk methods**
+
+Run: `grep -rn "supabaseAdmin" routes/ util/ models/ services/ | grep -v "_base.js" | grep -v "repository.js"`
+Expected: zero hits.
+Run: `grep -rn "insertPerks\|updatePerkLinks\|appendPerks" services/ models/ routes/`
+Expected: no references to the removed methods (only `buildPerkRows` remains).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add services/character/repository.js services/character/service.js services/character/service.test.js models/character-level-up.integration.test.js scripts/run-tests.mjs
+git commit -m "refactor: make level-up terminal writes atomic via level_up_character_atomic (ar-m8ai)"
+```
+
+---
+
+## Final verification (after Task 6)
+
+Run the acceptance gate and confirm each criterion:
+
+- [ ] `bun run test:unit && bun run test:http` → both exit 0.
+- [ ] `grep -n "resolveOffscreenSource\|collectAbilityPerks\|collectNamed\|creator_id !== profile.id\|creator_id != profile.id" routes/characters.js` → zero hits (no inline workflow/authz left in the route).
+- [ ] Every character mutation — create, update, delete, stats, level-up, upgrade, deceased, offscreen create/update/delete — is a named `CharacterService` method with a service-level authz test (non-owner refused via `AuthorizationError`, owner/admin succeeds).
+- [ ] `grep -rn "supabaseAdmin" routes/ util/ models/ services/ | grep -vE "_base.js|repository.js"` → zero hits.
+- [ ] Level-up rollback integration test present and (where local Supabase is available) green.
+
+## Self-Review notes
+
+- **Spec coverage:** item 1 → Task 1; item 2 → Task 2; item 3 → Tasks 3-4; item 4 → Tasks 5-6. Verification clauses 1-4 → Final verification checklist.
+- **Type consistency:** `levelUpAtomic({ characterId, creatorId, fields, perks })` used identically in repository (Task 6 Step 3), service call (Step 4), and unit test (Step 1). `buildPerkRows` return shape `{ data: rows, error }` matches its consumer in `levelUp`. RPC arg names (`p_character_id`, `p_creator_id`, `p_fields`, `p_perks`) match between the migration (Task 5) and the repository call (Task 6).
+- **Actor convention:** offscreen capabilities use `actorFromLocals` (`{ userId, profileId, role }`) + `canMutateCharacter` — matching delete/stats/level-up. create/update keep their pre-existing `profile`-as-actor convention (out of scope to unify; not introducing new inconsistency).

--- a/docs/superpowers/specs/2026-07-28-complete-character-service-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-28-complete-character-service-boundary-design.md
@@ -50,13 +50,20 @@ isolation value), add `createOffscreenMission`/`updateOffscreenMission`/
 with reads/writes in `character/repository.js` and authorization reusing the
 existing `canMutateCharacter` policy predicate.
 
-**Level-up atomicity: compute in JS, persist in one RPC.** Keep the derivation
-and credit-sourcing workflow in `service.js#levelUp` (business logic stays
-testable in JS), but hand the fully-computed payload to a new
-`level_up_character_atomic(payload jsonb)` Postgres RPC that performs every write
-— missions, offscreen rows, owned fields, perks, perk-links — in a single
-transaction. This mirrors the existing `save_character_atomic` pattern rather
-than porting business logic into plpgsql.
+**Level-up atomicity: compute in JS, persist terminal writes in one RPC.** Keep
+the derivation and credit-sourcing workflow in `service.js#levelUp` (business
+logic stays testable in JS). The backfill-mission and offscreen-credit creation
+stay **sequential and upstream** — they are cross-domain (mission service +
+offscreen model, each with its own RPC) and cannot join a single Postgres
+function without re-implementing them in plpgsql (rejected). They are additive
+and re-derivable: their rows represent real events, and the stored counters are
+re-derived from them, so a later failure self-heals on the next save. The
+*terminal* persistence — owned-field counters + perk insert + perk-link update —
+moves into a new `level_up_character_atomic` RPC that runs as one transaction.
+This is exactly where the flagged partial-state risk lives ("missions created
+but perks not linked"): after the change, if the terminal step aborts, no perks
+are half-written and counters heal on next save. Mirrors the existing
+`save_character_atomic` pattern rather than porting business logic into plpgsql.
 
 ## Scope — the four extractions
 
@@ -65,7 +72,7 @@ than porting business logic into plpgsql.
 | 1 | Wizard validation/coercion | `routes/characters.js:345-384` | `services/character/input.js` (extend `normalizeCharacterInput`/`normalizeStatsPayload`); handler delegates to existing `createCharacter` |
 | 2 | `collectAbilityPerks`/`collectNamed` reshaping | `routes/characters.js:40-71` (used 744-755, 1170-1181) | `services/character/input.js` (extend `normalizeAbilityPerks`); create/update handlers pass raw body to the service |
 | 3 | Offscreen-mission authz + validation + workflow | `routes/characters.js:576, 667, 715` (+157-178, 582-603) | `CharacterService.{create,update,delete}OffscreenMission`; repo methods; reuse `canMutateCharacter`; `asyncHandler`-wrapped handlers |
-| 4 | Non-atomic level-up | `services/character/service.js:424-528` | new `level_up_character_atomic` RPC (migration) + `repository.js#levelUpAtomic`; JS computes payload, one transactional call |
+| 4 | Non-atomic level-up (terminal writes) | `services/character/service.js:424-528` | new `level_up_character_atomic` RPC (migration) + `repository.js#levelUpAtomic` wrapping owned-fields + perk insert + perk-links in one transaction; backfill/offscreen stay sequential upstream (cross-domain, re-derivable) |
 
 ## Layered shape (unchanged from ar-ezes)
 

--- a/docs/superpowers/specs/2026-07-28-complete-character-service-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-28-complete-character-service-boundary-design.md
@@ -1,0 +1,129 @@
+# Complete character mutation service boundary
+
+- **Ticket:** ar-m8ai (P1, epic; blocks ar-g8y7 "Sustainability hardening program")
+- **Depends on:** ar-ezes (service-role consolidation) — shipped as PR #141
+- **Date:** 2026-07-28
+- **Type:** architecture refactor of already-tested code + one atomicity fix
+
+## Problem
+
+ar-ezes moved the character domain's privileged writes and authorization behind
+`services/character/{repository,policy,service}.js`, and the headline level-up
+workflow and multi-step perk persistence into the service. But the ticket's
+acceptance criterion — *"All character mutations are implemented as named use
+cases/services with tested contracts and transaction boundaries; route handlers
+only translate HTTP and render responses"* — is not yet met. An audit of
+`routes/characters.js` and `services/character/` found four residual gaps:
+
+1. **Wizard validation in the route.** `POST /wizard` re-implements input
+   validation/coercion (`routes/characters.js:345-384`) that
+   `services/character/input.js` already owns — name trim/length cap,
+   `creator_mode` whitelist, per-stat integer coercion, `level`/
+   `completed_missions` clamping, `commissary_reward` default, boolean coercion.
+2. **Perk/named-array reshaping in the route.** Route-local helpers
+   `collectAbilityPerks`/`collectNamed` (`routes/characters.js:40-71`, used by
+   `POST /` at 744-755 and `PUT /:id` at 1170-1181) assemble domain sub-entities
+   from parallel form arrays, duplicating `normalizeAbilityPerks` in `input.js`.
+3. **Offscreen-mission writes have no service seam.** The three
+   `POST /:id/offscreen-missions*` handlers (`routes/characters.js:576, 667,
+   715`) do inline authorization (`creator_id !== profile.id` at 582/635/673/721),
+   inline validation (589/684), and inline workflow (`resolveOffscreenSource`
+   157-178, conduit-credit balance gate 595-603) entirely in the route.
+4. **Level-up is not atomic.** `service.js#levelUp` (424-528) issues many
+   independent privileged writes — backfill missions, offscreen rows, owned-field
+   update, perk insert, then a separate perk-link update loop — with no
+   transaction. A mid-sequence failure leaves partial state (e.g. missions
+   created but perks not linked). Create/update are already atomic via the
+   `save_character_atomic` RPC; level-up is not.
+
+## Decisions
+
+Two design decisions were made explicitly during brainstorming; the rest follow
+the pattern ar-ezes established.
+
+**Offscreen missions: methods on `CharacterService`.** Offscreen missions are
+character-scoped sub-entities — they cannot exist without a parent character and
+their authorization *is* character ownership. Rather than a standalone
+`services/offscreen-mission/` domain (boilerplate for a boundary that adds no
+isolation value), add `createOffscreenMission`/`updateOffscreenMission`/
+`deleteOffscreenMission(actor, charId, …)` to the existing character service,
+with reads/writes in `character/repository.js` and authorization reusing the
+existing `canMutateCharacter` policy predicate.
+
+**Level-up atomicity: compute in JS, persist in one RPC.** Keep the derivation
+and credit-sourcing workflow in `service.js#levelUp` (business logic stays
+testable in JS), but hand the fully-computed payload to a new
+`level_up_character_atomic(payload jsonb)` Postgres RPC that performs every write
+— missions, offscreen rows, owned fields, perks, perk-links — in a single
+transaction. This mirrors the existing `save_character_atomic` pattern rather
+than porting business logic into plpgsql.
+
+## Scope — the four extractions
+
+| # | Gap | From | To |
+| --- | --- | --- | --- |
+| 1 | Wizard validation/coercion | `routes/characters.js:345-384` | `services/character/input.js` (extend `normalizeCharacterInput`/`normalizeStatsPayload`); handler delegates to existing `createCharacter` |
+| 2 | `collectAbilityPerks`/`collectNamed` reshaping | `routes/characters.js:40-71` (used 744-755, 1170-1181) | `services/character/input.js` (extend `normalizeAbilityPerks`); create/update handlers pass raw body to the service |
+| 3 | Offscreen-mission authz + validation + workflow | `routes/characters.js:576, 667, 715` (+157-178, 582-603) | `CharacterService.{create,update,delete}OffscreenMission`; repo methods; reuse `canMutateCharacter`; `asyncHandler`-wrapped handlers |
+| 4 | Non-atomic level-up | `services/character/service.js:424-528` | new `level_up_character_atomic` RPC (migration) + `repository.js#levelUpAtomic`; JS computes payload, one transactional call |
+
+## Layered shape (unchanged from ar-ezes)
+
+```
+route handler (thin: parse HTTP → actorFromLocals → service call → render)
+  → CharacterService.capability(actor, …)
+      → repo.load…()                          // privileged read
+      → policy.canMutateCharacter(actor, char) // pure predicate
+          denied  → throw AuthorizationError → asyncHandler → 403
+          allowed → repo.write…() / repo.levelUpAtomic(payload) → { data, error }
+```
+
+## Non-goals
+
+- No change to RLS policies or the anon/RLS-scoped read paths.
+- No new offscreen-mission features; behavior is preserved, only relocated.
+- No change to create/update atomicity (already handled by `save_character_atomic`).
+- No standalone offscreen-mission domain (decided against — see Decisions).
+- No dependency injection; actor remains passed as data (ar-ezes convention).
+
+## Constraints (carried from ar-ezes)
+
+- `supabaseAdmin` imported only in `models/_base.js` and `services/*/repository.js`.
+- Authorization denials **throw** `AuthorizationError` (`code: 'forbidden'` → 403).
+- Double-guard preserved: creator-only writes keep BOTH the JS policy check AND
+  the SQL `creator_id` filter.
+- Every touched route handler is `asyncHandler`-wrapped (Express 4 does not catch
+  async throws) — the same regression class fixed three times during ar-ezes.
+- Test gate green after each task: `bun run test:unit` and `bun run test:http`
+  (exit 0); integration (`character-atomic.integration.test.js` + the new
+  level-up rollback test) run where local Supabase is available.
+
+## Verification
+
+Done when all hold:
+
+1. `routes/characters.js` contains no inline validation/coercion, no authz
+   comparison, no multi-step persistence, and no workflow helpers beyond HTTP
+   request/response shaping. Grep confirms `collectAbilityPerks`/`collectNamed`/
+   `resolveOffscreenSource` and the `creator_id !==` checks are gone from the route.
+2. Every character mutation — create, update, delete, stats, level-up, upgrade,
+   deceased, and all three offscreen-mission operations — is a named
+   `CharacterService` method with a tested contract: a non-owner is refused
+   (`AuthorizationError` → 403) and an owner succeeds.
+3. A level-up rollback integration test proves atomicity: a mid-sequence failure
+   leaves no partial state (mirrors `models/character-atomic.integration.test.js`).
+4. `bun run test:unit` and `bun run test:http` exit 0.
+
+## Risks
+
+- **Behavioral drift in wizard/perk reshaping.** The route helpers encode subtle
+  form-array pairing. Mitigated by moving the logic verbatim into `input.js`
+  under unit tests that pin the current input→normalized-shape mapping before the
+  route is rewired.
+- **Level-up RPC correctness.** A single transactional function replacing several
+  writes is the highest-risk change. Mitigated by the rollback integration test
+  and by keeping derivation in JS (only persistence moves to SQL).
+- **Offscreen credit-gate regression.** The conduit-credit balance gate is
+  business logic; moving it into the service must preserve the exact refusal
+  behavior. Mitigated by a service contract test covering the insufficient-credit
+  path.

--- a/models/character-level-up.integration.test.js
+++ b/models/character-level-up.integration.test.js
@@ -1,0 +1,138 @@
+// Local-Supabase integration coverage for the transactional level-up RPC.
+// Proves the level-up terminal writes (owned-field update + perk insert/link
+// resolution) commit or roll back together via level_up_character_atomic.
+const { test, expect, afterAll } = require('bun:test');
+const { Client } = require('pg');
+const { supabaseAdmin } = require('./_base');
+const { createCharacter, levelUpCharacter } = require('./character');
+
+const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const email = `character-level-up-${suffix}@example.test`;
+let authUserId;
+let profile;
+let characterClass;
+let ACTOR;
+const db = new Client({
+  connectionString: process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+});
+
+const stats = {
+  vitality: 1, might: 1, resilience: 1, spirit: 1, arcane: 1, will: 1,
+  sensory: 1, reflex: 1, vigor: 1, skill: 1, intelligence: 1, luck: 1,
+  level: 1, completed_missions: 0, commissary_reward: 0
+};
+
+const setup = async () => {
+  if (profile) return;
+  await db.connect();
+  const { rows } = await db.query(
+    `insert into auth.users (id, aud, role, email, email_confirmed_at, created_at, updated_at, raw_app_meta_data, raw_user_meta_data)
+     values (gen_random_uuid(), 'authenticated', 'authenticated', $1, now(), now(), now(), '{}'::jsonb, '{}'::jsonb)
+     returning id`,
+    [email]
+  );
+  authUserId = rows[0].id;
+  ({ data: profile } = await supabaseAdmin.from('profiles')
+    .insert({ user_id: authUserId, name: `LevelUp ${suffix}`, is_public: true, timezone: 'UTC' })
+    .select()
+    .single());
+  ({ data: characterClass } = await supabaseAdmin.from('classes')
+    .insert({ name: `LevelUp Class ${suffix}`, rules_version: 'v1', is_public: true, gear: [], abilities: [] })
+    .select()
+    .single());
+  ACTOR = { userId: authUserId, profileId: profile.id, role: null };
+};
+
+afterAll(async () => {
+  if (profile?.id) await db.query('delete from characters where creator_id = $1', [profile.id]);
+  if (profile?.id) await db.query('delete from missions where creator_id = $1', [profile.id]);
+  if (profile?.id) await db.query('delete from profiles where id = $1', [profile.id]);
+  if (characterClass?.id) await db.query('delete from classes where id = $1', [characterClass.id]);
+  if (authUserId) await db.query('delete from auth.users where id = $1', [authUserId]);
+  await db.end();
+});
+
+const input = (name) => ({
+  ...stats,
+  name,
+  class: characterClass.name,
+  class_id: characterClass.id,
+  trait0: 'Brave',
+  gear: [{ name: 'LevelUp Gear', class_id: characterClass.id }],
+  abilities: [{ name: 'LevelUp Ability', class_id: characterClass.id }]
+});
+
+// Creates an owned character and reads back its inserted class_abilities id so
+// perks can reference a valid (FK-satisfying, allowed) class_ability_id.
+const createOwnedCharacter = async () => {
+  const name = `LevelUp Character ${suffix}-${Math.random().toString(16).slice(2)}`;
+  const { data, error } = await createCharacter(input(name), profile);
+  if (error) throw error;
+  const { data: abilities } = await supabaseAdmin
+    .from('class_abilities').select('id').eq('character_id', data.id);
+  return { id: data.id, abilityId: abilities[0].id };
+};
+
+test('level-up terminal writes commit together', async () => {
+  await setup();
+  const character = await createOwnedCharacter();
+  // level is re-derived from completed missions, so backfill two named
+  // missions (v1 reaches level 2 at 2 completed missions) to actually bump it.
+  const { data, error } = await levelUpCharacter(ACTOR, character.id, {
+    level: 2,
+    completed_missions: 2,
+    mission_names: ['Op Alpha', 'Op Bravo'],
+    ability_perks: [{ class_ability_id: character.abilityId, text: 'Perk A', ref: 'r1' }]
+  });
+  expect(error).toBeNull();
+  expect(data.level).toBe(2);
+  const { data: perks } = await supabaseAdmin.from('character_perks').select('*').eq('character_id', character.id);
+  expect(perks.length).toBe(1);
+  expect(perks[0].class_ability_id).toBe(character.abilityId);
+});
+
+test('level-up compound links resolve to same-batch positions inside the RPC', async () => {
+  await setup();
+  const character = await createOwnedCharacter();
+  const { error } = await levelUpCharacter(ACTOR, character.id, {
+    level: 2,
+    ability_perks: [
+      { class_ability_id: character.abilityId, text: 'Base perk', ref: 'r1' },
+      { class_ability_id: character.abilityId, text: 'Compounding perk', ref: 'r2', compounds_with: 'new:r1' }
+    ]
+  });
+  expect(error).toBeNull();
+  const { data: perks } = await supabaseAdmin
+    .from('character_perks').select('*').eq('character_id', character.id)
+    .order('position', { ascending: true });
+  expect(perks.length).toBe(2);
+  // The position-1 perk's link was resolved by the RPC to the position-0 row's id.
+  expect(perks[1].compounds_with).toBe(perks[0].id);
+});
+
+test('level-up rolls back the counter when a perk write fails (atomic terminal writes)', async () => {
+  await setup();
+  const character = await createOwnedCharacter();
+
+  // buildPerkRows filters submitted perks to ALLOWED ability ids, so a bogus
+  // class_ability_id never reaches the RPC — that path leaves a clean state
+  // (level bumped, 0 perks). To exercise a TRUE in-RPC rollback we drive the
+  // RPC directly with a perk row whose class_ability_id violates the
+  // character_perks -> class_abilities FK; the perk INSERT must abort the whole
+  // transaction, leaving the character's level unchanged.
+  const badPerk = [{ class_ability_id: '00000000-0000-4000-8000-000000000000', text: 'Bad perk', position: 0, compounds_with: null }];
+  const { error } = await supabaseAdmin.rpc('level_up_character_atomic', {
+    p_character_id: character.id,
+    p_creator_id: profile.id,
+    p_fields: { level: 5 },
+    p_perks: badPerk
+  });
+  expect(error).toBeTruthy();
+
+  const { data: char } = await supabaseAdmin.from('characters').select('level').eq('id', character.id).single();
+  const { data: perks } = await supabaseAdmin.from('character_perks').select('id').eq('character_id', character.id);
+  // No half-applied terminal write: the level bump rolled back with the failed
+  // perk insert, so level is still 1 and no perk row exists.
+  expect(char.level).toBe(1);
+  expect(perks.length).toBe(0);
+});

--- a/models/character.js
+++ b/models/character.js
@@ -95,7 +95,9 @@ const getPublicCharactersByCreator = async (creatorId) => {
 const getCharacter = async (id, client = supabase) => {
   const { data, error } = await client.from('characters').select('*').eq('id', id).single();
   if (error) {
-    console.error(error);
+    // PGRST116 is an expected "0 rows" not-found (mapped to 404 by util/http-error.js),
+    // so don't log it; any other error code is unexpected and still logged.
+    if (error.code !== 'PGRST116') console.error(error);
     return { data: null, error };
   }
 

--- a/models/character.js
+++ b/models/character.js
@@ -418,6 +418,9 @@ const markCharacterDeceased = (actor, id, confirmName) => characterService.markD
 const upgradeCharacterClass = (actor, id, targetClassId, client) => characterService.upgradeClass(actor, id, targetClassId, client);
 const updateCharacterStats = (actor, id, fields) => characterService.updateStats(actor, id, fields);
 const levelUpCharacter = (actor, id, body) => characterService.levelUp(actor, id, body);
+const createCharacterOffscreenMission = (actor, characterId, body) => characterService.createOffscreenMission(actor, characterId, body);
+const updateCharacterOffscreenMission = (actor, characterId, omId, body) => characterService.updateOffscreenMission(actor, characterId, omId, body);
+const deleteCharacterOffscreenMission = (actor, characterId, omId) => characterService.deleteOffscreenMission(actor, characterId, omId);
 
 module.exports = {
   getOwnCharacters,
@@ -430,6 +433,9 @@ module.exports = {
   upgradeCharacterClass,
   updateCharacterStats,
   levelUpCharacter,
+  createCharacterOffscreenMission,
+  updateCharacterOffscreenMission,
+  deleteCharacterOffscreenMission,
   findUpgradeTargetsFor,
   getCharacterRecentMissions,
   getCharacterAllMissions,

--- a/models/character.test.js
+++ b/models/character.test.js
@@ -457,6 +457,39 @@ delete require.cache[require.resolve('../services/character/repository')];
 delete require.cache[require.resolve('../services/character/repository')];
 });
 
+test('getCharacter does not log console.error when the characters read returns a PGRST116 not-found', async () => {
+  // Inline client whose primary `characters` read resolves to Supabase's
+  // "0 rows" not-found error (PGRST116). This is an EXPECTED not-found that
+  // util/http-error.js maps to a clean 404, so getCharacter must NOT dump it
+  // into the logs — but must still surface the error so callers produce 404.
+  const notFoundError = { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' };
+  const notFoundClient = {
+    from() {
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        single() { return Promise.resolve({ data: null, error: notFoundError }); }
+      };
+      return chain;
+    }
+  };
+
+  const realConsoleError = console.error;
+  const errorSpy = mock(() => {});
+  console.error = errorSpy;
+  try {
+    const { getCharacter } = require('./character');
+    const { data, error } = await getCharacter('missing-id', notFoundClient);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(data).toBeNull();
+    expect(error).toBe(notFoundError);
+    expect(error.code).toBe('PGRST116');
+  } finally {
+    console.error = realConsoleError;
+  }
+});
+
 test('serializeCharacterForAgent omits v2 fields on v1 characters', () => {
   const { serializeCharacterForAgent } = require('./character');
   const row = {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
     "test:integration": "bun scripts/run-tests.mjs integration",
     "check": "bun scripts/check.mjs",
     "setup": "bun run scripts/setup.mjs",
+    "seed:local": "bun run scripts/seed-local.mjs",
     "seed:classes": "bun run util/seed-classes.js",
     "seed:admin": "bun run util/seed-admin.js",
+    "seed:badges": "bun run scripts/seed-badges.js",
+    "fetch:badges": "bun run scripts/fetch-badge-art.js",
     "db:backup": "sh scripts/db-backup.sh"
   },
   "dependencies": {

--- a/routes/character-level-up.test.js
+++ b/routes/character-level-up.test.js
@@ -103,18 +103,40 @@ mock.module('../services/character/repository', () => ({
   getClassRulesVersion: async () => ({ data: 'v1', error: null }),
   fetchAllowedAbilityIds: async () => ({ data: classAbilities.map(a => ({ id: a.id })), error: null }),
   fetchExistingPerks: async () => ({ data: characterPerks.map(p => ({ ...p })), error: null }),
-  insertPerks: async (rows) => {
-    for (const row of rows) {
-      characterPerks.push({ id: `perk-${++perkIdSeq}`, compounds_with: null, ...row });
+  // In-memory stand-in for the level_up_character_atomic RPC: applies the
+  // owned-field update, inserts the new perk rows, then resolves each perk's
+  // compound link exactly as the SQL does — a 'position-<n>' link targets a
+  // same-ability perk by position; a bare UUID targets a same-ability existing
+  // perk by id; anything else stays null.
+  levelUpAtomic: async ({ fields, perks }) => {
+    Object.assign(characterRow, fields);
+    if (Array.isArray(perks)) {
+      for (const row of perks) {
+        characterPerks.push({
+          id: `perk-${++perkIdSeq}`,
+          character_id: CHAR_ID,
+          class_ability_id: row.class_ability_id,
+          text: row.text,
+          position: row.position,
+          compounds_with: null
+        });
+      }
+      for (const row of perks) {
+        if (row.compounds_with == null) continue;
+        const source = characterPerks.find(p => p.class_ability_id === row.class_ability_id && p.position === row.position);
+        if (!source) continue;
+        const link = String(row.compounds_with);
+        let target = null;
+        if (link.startsWith('position-')) {
+          const pos = Number(link.slice('position-'.length));
+          target = characterPerks.find(p => p.class_ability_id === row.class_ability_id && p.position === pos);
+        } else {
+          target = characterPerks.find(p => p.id === link && p.class_ability_id === row.class_ability_id);
+        }
+        if (target && target.id !== source.id) source.compounds_with = target.id;
+      }
     }
-    return { error: null };
-  },
-  updatePerkLinks: async (updates) => {
-    for (const u of updates) {
-      const perk = characterPerks.find(p => p.id === u.id);
-      if (perk) perk.compounds_with = u.compounds_with;
-    }
-    return { error: null };
+    return { data: { ...characterRow }, error: null };
   },
   // Mirrors services/character/repository.js#createBackfillMission, using
   // this file's (possibly test-overridden) mission mocks — preserves the

--- a/routes/character-level-up.test.js
+++ b/routes/character-level-up.test.js
@@ -148,7 +148,16 @@ mock.module('../services/character/repository', () => ({
   getChildRows: async () => ({ data: [], error: null }),
   insertChildRows: async () => ({ data: true, error: null }),
   updateChildRow: async () => ({ data: true, error: null }),
-  deleteChildRows: async () => ({ data: true, error: null })
+  deleteChildRows: async () => ({ data: true, error: null }),
+  // Unused by the level-up flow but required by CharacterService's adapter
+  // validation (createOffscreenMission/updateOffscreenMission/
+  // deleteOffscreenMission capabilities).
+  getOffscreenMissionRow: async () => ({ data: null, error: null }),
+  getSourceMissionForCredit: async () => ({ data: null, error: null }),
+  getConduitCredits: async () => ({ data: null, error: null }),
+  insertOffscreenMission: async () => ({ data: null, error: null }),
+  updateOffscreenMissionRow: async () => ({ data: null, error: null }),
+  deleteOffscreenMissionRow: async () => ({ data: null, error: null })
 }));
 
 mock.module('../models/offscreen-mission', () => ({

--- a/routes/character-offscreen.test.js
+++ b/routes/character-offscreen.test.js
@@ -1,0 +1,149 @@
+// routes/character-offscreen.test.js
+//
+// HTTP regression test for the offscreen-mission POST routes after they were
+// rewired to CharacterService's createOffscreenMission/updateOffscreenMission/
+// deleteOffscreenMission capabilities via models/character.js. The service
+// throws AuthorizationError for a non-owner; the route must be wrapped in
+// asyncHandler so that throw reaches Express's error pipeline as a 403
+// instead of hanging the request (Express 4 does not catch async throws on
+// its own).
+//
+// Mocking recipe mirrors routes/character-level-up.test.js and
+// routes/character-wizard.test.js: real isAuthenticated middleware + real
+// route handler against a mocked data layer.
+const { test, expect, mock, beforeAll, afterAll } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+// Capture real modules up front so afterAll can restore them — bun's
+// mock.module is process-global and would otherwise leak into other files.
+const realBase = require('../models/_base');
+const realAuth = require('../models/auth');
+const realProfile = require('../models/profile');
+const realSystemMessage = require('../util/system-message');
+const realLfg = require('../models/lfg');
+const realNavLoader = require('../util/nav-loader');
+const realOffscreen = require('../models/offscreen-mission');
+const realCharacter = require('../models/character');
+const { AuthorizationError } = require('../util/errors');
+
+const CHAR_ID = '11111111-1111-4111-8111-111111111111';
+
+mock.module('../models/_base', () => ({
+  supabase: { from: () => { throw new Error('unexpected supabase call in offscreen test'); } },
+  supabaseAdmin: { from: () => { throw new Error('unexpected supabaseAdmin call in offscreen test'); } },
+  createUserClient: () => ({}),
+  anonKey: 'test-anon-key',
+}));
+
+mock.module('../models/auth', () => ({
+  // Consumed by the real isAuthenticated middleware:
+  getUserFromToken: async (token) => (token === 'valid-jwt' ? { id: 'u1' } : false),
+}));
+mock.module('../models/profile', () => ({
+  // Non-'owner' profile id so actorFromLocals yields a stranger actor,
+  // exercising the deny path.
+  getProfile: async () => ({ id: 'p1', user_id: 'u1' }),
+}));
+
+mock.module('../models/character', () => ({
+  createCharacterOffscreenMission: async (actor) => {
+    if (actor.profileId !== 'owner') throw new AuthorizationError('nope', { reason: 'not_owner' });
+    return { data: { characterId: CHAR_ID }, error: null };
+  },
+  updateCharacterOffscreenMission: async (actor) => {
+    if (actor.profileId !== 'owner') throw new AuthorizationError('nope', { reason: 'not_owner' });
+    return { data: { characterId: CHAR_ID }, error: null };
+  },
+  deleteCharacterOffscreenMission: async (actor) => {
+    if (actor.profileId !== 'owner') throw new AuthorizationError('nope', { reason: 'not_owner' });
+    return { data: { characterId: CHAR_ID }, error: null };
+  },
+}));
+
+mock.module('../models/offscreen-mission', () => ({
+  listOffscreenMissions: async () => ({ data: [], error: null }),
+  getAvailableHostedMissionsForPicker: async () => ({ data: [], error: null }),
+}));
+
+mock.module('../util/system-message', () => ({ getSystemMessage: () => null }));
+mock.module('../models/lfg', () => ({ getPendingJoinRequestCount: async () => ({ count: 0 }) }));
+mock.module('../util/nav-loader', () => ({
+  populateNavItems: async () => {},
+  loadNavItems: (req, res, next) => next(),
+}));
+
+const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  delete require.cache[require.resolve('./characters')];
+  delete require.cache[require.resolve('../models/character')];
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use('/characters', require('./characters'));
+  ({ server, baseUrl } = await startHttpServer(app));
+});
+
+afterAll(async () => {
+  await stopHttpServer(server);
+  mock.module('../models/_base', () => realBase);
+  mock.module('../models/auth', () => realAuth);
+  mock.module('../models/profile', () => realProfile);
+  mock.module('../util/system-message', () => realSystemMessage);
+  mock.module('../models/lfg', () => realLfg);
+  mock.module('../util/nav-loader', () => realNavLoader);
+  mock.module('../models/offscreen-mission', () => realOffscreen);
+  mock.module('../models/character', () => realCharacter);
+  delete require.cache[require.resolve('./characters')];
+  delete require.cache[require.resolve('../models/character')];
+});
+
+test('POST /:id/offscreen-missions returns 403 for a non-owner (and does not hang)', async () => {
+  const res = await Promise.race([
+    fetch(`${baseUrl}/characters/${CHAR_ID}/offscreen-missions`, {
+      method: 'POST',
+      headers: {
+        'authorization': 'Bearer valid-jwt',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'n', summary: 's' }),
+    }),
+    new Promise((_, rej) => setTimeout(() => rej(new Error('request hung')), 2000)),
+  ]);
+  expect(res.status).toBe(403);
+});
+
+test('POST /:id/offscreen-missions/:omId returns 403 for a non-owner (and does not hang)', async () => {
+  const res = await Promise.race([
+    fetch(`${baseUrl}/characters/${CHAR_ID}/offscreen-missions/om1`, {
+      method: 'POST',
+      headers: {
+        'authorization': 'Bearer valid-jwt',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'n', summary: 's' }),
+    }),
+    new Promise((_, rej) => setTimeout(() => rej(new Error('request hung')), 2000)),
+  ]);
+  expect(res.status).toBe(403);
+});
+
+test('POST /:id/offscreen-missions/:omId/delete returns 403 for a non-owner (and does not hang)', async () => {
+  const res = await Promise.race([
+    fetch(`${baseUrl}/characters/${CHAR_ID}/offscreen-missions/om1/delete`, {
+      method: 'POST',
+      headers: {
+        'authorization': 'Bearer valid-jwt',
+        'content-type': 'application/json',
+      },
+    }),
+    new Promise((_, rej) => setTimeout(() => rej(new Error('request hung')), 2000)),
+  ]);
+  expect(res.status).toBe(403);
+});

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -15,6 +15,9 @@ const {
   upgradeCharacterClass,
   updateCharacterStats,
   levelUpCharacter,
+  createCharacterOffscreenMission,
+  updateCharacterOffscreenMission,
+  deleteCharacterOffscreenMission,
   findUpgradeTargetsFor
 } = require('../models/character');
 const characterRepository = require('../services/character/repository');
@@ -28,7 +31,7 @@ const { getProfileById, getProfileConduitCredits } = require('../models/profile'
 const { statList, personalityMap, commonItemList } = require('../util/enclave-consts');
 const { deriveCharacterTotals } = require('../util/character-derived');
 const { filterClassListsByIds } = require('../util/class-filter');
-const { createOffscreenMission, getOffscreenMissionById, updateOffscreenMission, removeOffscreenMission, listOffscreenMissions, getAvailableHostedMissionsForPicker } = require('../models/offscreen-mission');
+const { getOffscreenMissionById, listOffscreenMissions, getAvailableHostedMissionsForPicker } = require('../models/offscreen-mission');
 const { isAuthenticated, authOptional } = require('../util/auth');
 const { sendError, FRIENDLY_NOT_FOUND } = require('../util/http-error');
 const { renderMarkdown } = require('../util/markdown');
@@ -114,29 +117,6 @@ const filterClassDataForUser = async (user) => {
   const { advent: filteredPCCAdventV2, aspirant: filteredPCCAspirantV2 } = splitByEdition(filteredPCCv2);
 
   return { filteredAdvent, filteredAdventV1, filteredAdventV2, filteredAspirant, filteredAspirantV1, filteredAspirantV2, filteredPCC, filteredPCCAdventV1, filteredPCCAdventV2, filteredPCCAspirantV1, filteredPCCAspirantV2, filteredGear, filteredAbilities };
-};
-
-const resolveOffscreenSource = async ({ body, profileId, supabaseClient }) => {
-  if (body.source_mission_id && body.source_mission_id !== '__other__') {
-    const { data: srcMission, error: srcErr } = await getMission(body.source_mission_id, supabaseClient);
-    if (srcErr || !srcMission) return { error: 'Source mission not found.' };
-    if (srcMission.host_id !== profileId) return { error: 'Only the host of a mission can use it as a credit source.' };
-    return {
-      source_mission_id: srcMission.id,
-      source_mission_name: srcMission.name,
-      source_mission_date: typeof srcMission.date === 'string'
-        ? srcMission.date.slice(0, 10)
-        : new Date(srcMission.date).toISOString().slice(0, 10)
-    };
-  }
-  const name = (body.source_mission_name_other || '').trim();
-  const date = (body.source_mission_date_other || '').trim();
-  if (!name || !date) return { error: 'Source mission name and date are required.' };
-  return {
-    source_mission_id: null,
-    source_mission_name: name,
-    source_mission_date: date
-  };
 };
 
 router.get('/', isAuthenticated, async (req, res) => {
@@ -496,58 +476,13 @@ router.get('/:id/offscreen-missions/new', isAuthenticated, async (req, res) => {
   });
 });
 
-router.post('/:id/offscreen-missions', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/offscreen-missions', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id: characterId } = req.params;
-
-  const { data: character, error: charError } = await getCharacter(characterId, res.locals.supabase);
-  if (charError) return sendError(req, res, charError);
-  if (character.creator_id !== profile.id) return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
-
-  const src = await resolveOffscreenSource({
-    body: req.body, profileId: profile.id, supabaseClient: res.locals.supabase
-  });
-  if (src.error) return sendError(req, res, null, { status: 400, message: src.error });
-
-  if (!req.body.name || !req.body.summary) {
-    return sendError(req, res, null, { status: 400, message: 'Name and summary are required.' });
-  }
-
-  // If the user picked a hosted mission as the source, gate on the profile's balance.
-  // Free-text sources bypass the gate.
-  if (src.source_mission_id) {
-    const { data: credits } = await getProfileConduitCredits({
-      profileId: profile.id,
-      supabase: res.locals.supabase
-    });
-    if (!credits || credits.balance <= 0) {
-      return sendError(req, res, null, { status: 400, message: 'No Conduit Credits available.' });
-    }
-  }
-
-  const { error } = await createOffscreenMission({
-    characterId,
-    profileId: profile.id,
-    payload: {
-      name: req.body.name,
-      summary: req.body.summary,
-      merx_gained: req.body.merx_gained,
-      source_mission_id: src.source_mission_id,
-      source_mission_name: src.source_mission_name,
-      source_mission_date: src.source_mission_date
-    },
-    supabase: res.locals.supabase
-  });
-
-  if (error) {
-    if (error.code === '23505' || error.message === 'duplicate_source_mission') {
-      return sendError(req, res, error, { status: 400, message: 'That mission has already funded a credit.' });
-    }
-    return sendError(req, res, error);
-  }
-
-  return res.redirect(`/characters/${characterId}/${encodeURIComponent(character.name)}`);
-});
+  const { error } = await createCharacterOffscreenMission(actor, characterId, req.body);
+  if (error) return sendRouteError(req, res, error);
+  return res.redirect(`/characters/${characterId}`);
+}));
 
 router.get('/:id/offscreen-missions/:omId/edit', isAuthenticated, async (req, res) => {
   const { profile } = res.locals;
@@ -587,76 +522,21 @@ router.get('/:id/offscreen-missions/:omId/edit', isAuthenticated, async (req, re
   });
 });
 
-router.post('/:id/offscreen-missions/:omId', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/offscreen-missions/:omId', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id: characterId, omId } = req.params;
+  const { error } = await updateCharacterOffscreenMission(actor, characterId, omId, req.body);
+  if (error) return sendRouteError(req, res, error);
+  return res.redirect(`/characters/${characterId}`);
+}));
 
-  const { data: character, error: charError } = await getCharacter(characterId, res.locals.supabase);
-  if (charError) return sendError(req, res, charError);
-  if (character.creator_id !== profile.id) return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
-
-  const { data: existing, error: omError } = await getOffscreenMissionById({
-    id: omId,
-    supabase: res.locals.supabase
-  });
-  if (omError) return sendError(req, res, omError);
-  if (!existing || existing.character_id !== characterId) {
-    return sendError(req, res, null, { status: 404, message: 'Not found' });
-  }
-
-  if (!req.body.name || !req.body.summary) {
-    return sendError(req, res, null, { status: 400, message: 'Name and summary are required.' });
-  }
-
-  const src = await resolveOffscreenSource({
-    body: req.body, profileId: profile.id, supabaseClient: res.locals.supabase
-  });
-  if (src.error) return sendError(req, res, null, { status: 400, message: src.error });
-
-  const { error } = await updateOffscreenMission({
-    id: omId,
-    payload: {
-      name: req.body.name,
-      summary: req.body.summary,
-      merx_gained: req.body.merx_gained,
-      source_mission_id: src.source_mission_id,
-      source_mission_name: src.source_mission_name,
-      source_mission_date: src.source_mission_date
-    },
-    supabase: res.locals.supabase
-  });
-  if (error) {
-    if (error.code === '23505' || error.message === 'duplicate_source_mission') {
-      return sendError(req, res, error, { status: 400, message: 'That mission has already funded a credit.' });
-    }
-    return sendError(req, res, error);
-  }
-
-  return res.redirect(`/characters/${characterId}/${encodeURIComponent(character.name)}`);
-});
-
-router.post('/:id/offscreen-missions/:omId/delete', isAuthenticated, async (req, res) => {
-  const { profile } = res.locals;
+router.post('/:id/offscreen-missions/:omId/delete', isAuthenticated, asyncHandler(async (req, res) => {
+  const actor = actorFromLocals(res.locals);
   const { id: characterId, omId } = req.params;
-
-  const { data: character, error: charError } = await getCharacter(characterId, res.locals.supabase);
-  if (charError) return sendError(req, res, charError);
-  if (character.creator_id !== profile.id) return sendError(req, res, null, { status: 403, title: 'No access', message: FRIENDLY_NOT_FOUND });
-
-  const { data: existing, error: omError } = await getOffscreenMissionById({
-    id: omId,
-    supabase: res.locals.supabase
-  });
-  if (omError) return sendError(req, res, omError);
-  if (!existing || existing.character_id !== characterId) {
-    return sendError(req, res, null, { status: 404, message: 'Not found' });
-  }
-
-  const { error } = await removeOffscreenMission({ id: omId, supabase: res.locals.supabase });
-  if (error) return sendError(req, res, error);
-
-  return res.redirect(`/characters/${characterId}/${encodeURIComponent(character.name)}`);
-});
+  const { error } = await deleteCharacterOffscreenMission(actor, characterId, omId);
+  if (error) return sendRouteError(req, res, error);
+  return res.redirect(`/characters/${characterId}`);
+}));
 
 router.post('/', isAuthenticated, async (req, res) => {
   const { profile } = res.locals;

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -18,6 +18,7 @@ const {
   findUpgradeTargetsFor
 } = require('../models/character');
 const characterRepository = require('../services/character/repository');
+const { normalizeWizardPayload } = require('../services/character/input');
 const { getMission } = require('../models/mission');
 const { actorFromLocals } = require('../util/actor');
 const { asyncHandler } = require('../util/async-handler');
@@ -68,11 +69,6 @@ const collectNamed = (body, nameKey, descKey) => {
     out.push(desc ? { name, description: desc } : { name });
   }
   return out;
-};
-
-const parseInteger = (value, fallback = 0) => {
-  const n = parseInt(value, 10);
-  return Number.isFinite(n) ? n : fallback;
 };
 
 // Renders a service-returned { status, title, message }-shaped error (or a
@@ -342,51 +338,12 @@ router.post('/wizard', isAuthenticated, async (req, res) => {
     return sendError(req, res, null, { status: 400, message: 'Invalid wizard payload.' });
   }
 
-  const trimmedName = (body.name || '').toString().trim();
-  if (!trimmedName) {
-    return sendError(req, res, null, { status: 400, message: 'Character name is required.' });
-  }
-  if (trimmedName.length > 120) {
-    return sendError(req, res, null, { status: 400, message: 'Character name is too long (max 120 characters).' });
+  const { data: normalized, error: wizardError } = normalizeWizardPayload(body);
+  if (wizardError) {
+    return sendError(req, res, null, { status: 400, message: wizardError });
   }
 
-  // Whitelist creator_mode to the same set the wizard exposes in its mode
-  // selector. createCharacter will re-validate and reject anything else.
-  const allowedModes = ['advent', 'aspiring', 'aspirant'];
-  if (body.creator_mode != null && body.creator_mode !== '' && !allowedModes.includes(body.creator_mode)) {
-    return sendError(req, res, null, { status: 400, message: `Invalid mode: ${body.creator_mode}` });
-  }
-
-  // Coerce stat values to integers; the model passes them straight through
-  // to the characters row. Unknown stat keys (shouldn't happen, but the
-  // wizard is client-built) are silently dropped.
-  const knownStats = new Set(statList);
-  for (const k of Object.keys(body)) {
-    if (knownStats.has(k)) body[k] = parseInteger(body[k], 0);
-  }
-
-  // Coerce level / completed_missions / visibility booleans to defensible
-  // shapes. The form-input handlers in createCharacter also do this for
-  // is_public / hide_from_search, but doing it here keeps the DB write from
-  // seeing "on" as a string and stops an out-of-range number from
-  // contaminating the row.
-  if (body.level != null) {
-    body.level = Math.max(1, Math.min(20, parseInteger(body.level, 1)));
-  }
-  if (body.completed_missions != null) {
-    body.completed_missions = Math.max(0, parseInteger(body.completed_missions, 0));
-  }
-  // The wizard's UI has no commissary_reward field; the column is NOT NULL,
-  // so default to 0 unless auto_calculate-derived downstream overrides it.
-  body.commissary_reward = Math.max(0, parseInteger(body.commissary_reward, 0));
-  body.name = trimmedName;
-  body.is_public = body.is_public === false ? false : true;
-  body.hide_from_search = !!body.hide_from_search;
-
-  // The 12 stat ints stay on `body` as normal columns: createCharacter only
-  // pulls out the keys it owns (trait0/1/2, gear, abilities, ability_perks,
-  // common_items) before insert, so the stats pass straight through.
-  const { data, error } = await createCharacter(body, profile);
+  const { data, error } = await createCharacter(normalized, profile);
   if (error) {
     // createCharacter returns string errors for some validation paths
     // (e.g. invalid creator_mode, v2 ability-perk validation). Wrap those

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -18,7 +18,7 @@ const {
   findUpgradeTargetsFor
 } = require('../models/character');
 const characterRepository = require('../services/character/repository');
-const { normalizeWizardPayload } = require('../services/character/input');
+const { normalizeWizardPayload, collectCharacterFormArrays } = require('../services/character/input');
 const { getMission } = require('../models/mission');
 const { actorFromLocals } = require('../util/actor');
 const { asyncHandler } = require('../util/async-handler');
@@ -36,40 +36,6 @@ const { processCharacterImport } = require('../util/character-import');
 const { exportCharacter, getSupportedFormats, EXPORT_FORMATS } = require('../util/character-export');
 const { parseImageCrop } = require('../util/crop');
 
-const asArray = (v) => (Array.isArray(v) ? v : (v == null || v === '' ? [] : [v]));
-
-const collectAbilityPerks = (body) => {
-  const ids   = asArray(body.ability_perk_class_ability_id);
-  const texts = asArray(body.ability_perk_text);
-  const pos   = asArray(body.ability_perk_position);
-  const cw    = asArray(body.ability_perk_compounds_with);
-  const n = Math.max(ids.length, texts.length, pos.length, cw.length);
-  const perks = [];
-  for (let i = 0; i < n; i++) {
-    const id = ids[i]; const text = texts[i];
-    if (!id || !text) continue;
-    perks.push({
-      class_ability_id: id,
-      text: String(text),
-      position: Number(pos[i]) || i,
-      compounds_with: cw[i] || null
-    });
-  }
-  return perks;
-};
-
-const collectNamed = (body, nameKey, descKey) => {
-  const names = asArray(body[nameKey]);
-  const descs = asArray(body[descKey]);
-  const out = [];
-  for (let i = 0; i < names.length; i++) {
-    const name = (names[i] || '').toString().trim();
-    if (!name) continue;
-    const desc = (descs[i] || '').toString().trim();
-    out.push(desc ? { name, description: desc } : { name });
-  }
-  return out;
-};
 
 // Renders a service-returned { status, title, message }-shaped error (or a
 // plain Error/string) with the appropriate status — the equivalent of
@@ -698,18 +664,7 @@ router.post('/', isAuthenticated, async (req, res) => {
   if (image_crop !== undefined) {
     req.body.image_crop = image_crop;
   }
-  req.body.ability_perks = collectAbilityPerks(req.body);
-  req.body.quirks = collectNamed(req.body, 'quirk_name', 'quirk_description');
-  req.body.accessories = collectNamed(req.body, 'accessory_name', 'accessory_description');
-  // Strip the parallel arrays so they don't reach Supabase as unknown columns.
-  delete req.body.ability_perk_class_ability_id;
-  delete req.body.ability_perk_text;
-  delete req.body.ability_perk_position;
-  delete req.body.ability_perk_compounds_with;
-  delete req.body.quirk_name;
-  delete req.body.quirk_description;
-  delete req.body.accessory_name;
-  delete req.body.accessory_description;
+  req.body = collectCharacterFormArrays(req.body);
   const { data, error } = await createCharacter(req.body, profile);
   if (error) {
     return sendError(req, res, error);
@@ -1124,18 +1079,7 @@ router.put('/:id/:name?', isAuthenticated, asyncHandler(async (req, res) => {
   if (image_crop !== undefined) {
     req.body.image_crop = image_crop;
   }
-  req.body.ability_perks = collectAbilityPerks(req.body);
-  req.body.quirks = collectNamed(req.body, 'quirk_name', 'quirk_description');
-  req.body.accessories = collectNamed(req.body, 'accessory_name', 'accessory_description');
-  // Strip the parallel arrays so they don't reach Supabase as unknown columns.
-  delete req.body.ability_perk_class_ability_id;
-  delete req.body.ability_perk_text;
-  delete req.body.ability_perk_position;
-  delete req.body.ability_perk_compounds_with;
-  delete req.body.quirk_name;
-  delete req.body.quirk_description;
-  delete req.body.accessory_name;
-  delete req.body.accessory_description;
+  req.body = collectCharacterFormArrays(req.body);
   // updateCharacter throws AuthorizationError (caught by asyncHandler) when
   // the actor doesn't own the character; other failures are still returned.
   const { data, error } = await updateCharacter(id, req.body, profile);

--- a/routes/missions.js
+++ b/routes/missions.js
@@ -238,6 +238,7 @@ router.get('/similar', isAuthenticated, async (req, res) => {
 
   res.render('partials/similar-missions', {
     layout: false,
+    profile: res.locals.profile,
     missions
   });
 });

--- a/scripts/fetch-badge-art.js
+++ b/scripts/fetch-badge-art.js
@@ -1,0 +1,62 @@
+// Reconstructs the badge source-art directory (public/img/badges/) by pulling
+// each asset from the PUBLIC prod badges storage bucket. The bucket stores
+// files flat as "<slug>.png"; this maps them back to the original nested source
+// paths that seed-badges.js expects, so the normal seed path works locally
+// (and offline afterwards). Public bucket => no credentials required.
+//
+// Idempotent: skips files already present unless --force is passed.
+//
+// Usage: bun run scripts/fetch-badge-art.js [--force]
+//   Override the source with BADGE_ART_SOURCE_URL (defaults to prod public bucket).
+require('../util/env');
+const fs = require('fs');
+const path = require('path');
+const { catalog, EXTRA_UPLOADS, ART_DIR } = require('./seed-badges');
+
+const SOURCE = (
+  process.env.BADGE_ART_SOURCE_URL ||
+  'https://ndneltuukvijkvdfaqfu.supabase.co/storage/v1/object/public/badges'
+).replace(/\/$/, '');
+
+const force = process.argv.includes('--force');
+
+// slug/object-name in the bucket -> original source path under ART_DIR.
+const downloads = [
+  ...catalog.map((e) => ({ object: `${e.slug}.png`, dest: e.file })),
+  ...EXTRA_UPLOADS.map((e) => ({ object: e.storagePath, dest: e.file }))
+];
+
+async function fetchOne({ object, dest }) {
+  const destPath = path.join(ART_DIR, dest);
+  if (!force && fs.existsSync(destPath)) return 'skipped';
+
+  const res = await fetch(`${SOURCE}/${object}`);
+  if (!res.ok) {
+    throw new Error(`GET ${object} -> ${res.status} ${res.statusText}`);
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  fs.writeFileSync(destPath, buffer);
+  return 'fetched';
+}
+
+async function main() {
+  console.log(`Fetching ${downloads.length} badge assets from ${SOURCE}`);
+  let fetched = 0;
+  let skipped = 0;
+  for (const d of downloads) {
+    const result = await fetchOne(d);
+    if (result === 'fetched') {
+      fetched++;
+      console.log(`  fetched ${d.dest}`);
+    } else {
+      skipped++;
+    }
+  }
+  console.log(`\nDone: ${fetched} fetched, ${skipped} already present.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -6,6 +6,7 @@ import { spawnSync } from 'node:child_process';
 const root = new URL('..', import.meta.url).pathname;
 const integrationFiles = new Set([
   'models/character-atomic.integration.test.js',
+  'models/character-level-up.integration.test.js',
   'models/lfg-agent.test.js',
   'routes/bot-link.test.js'
 ]);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -13,6 +13,7 @@ const httpFiles = new Set([
   'routes/badges.test.js',
   'routes/bot-link-confirm.test.js',
   'routes/character-level-up.test.js',
+  'routes/character-offscreen.test.js',
   'routes/character-wizard.test.js',
   'routes/characters.test.js',
   'routes/classes-stat-spread.test.js',

--- a/scripts/seed-badges.js
+++ b/scripts/seed-badges.js
@@ -170,7 +170,11 @@ async function main() {
   console.log(`\nDone: ${catalog.length} catalog rows, ${EXTRA_UPLOADS.length} extra assets.`);
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+module.exports = { catalog, EXTRA_UPLOADS, ART_DIR, BUCKET };
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-local.mjs
+++ b/scripts/seed-local.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+// One-command local app-data seeding for Path B (local Supabase stack).
+//
+// `supabase db reset` applies migrations + supabase/seed.sql (nav_items). This
+// script fills in everything else a working local environment needs, in the
+// right dependency order, and is idempotent — each step is skipped when its
+// table is already populated, so re-running is safe and never clobbers data.
+//
+//   nav_items  -> supabase/seed.sql            (if empty)
+//   admin      -> seed:admin                   (if no admin profile)
+//   classes    -> seed:classes                 (needs admin; if empty)
+//   badges     -> fetch-badge-art + seed-badges (if empty)
+//
+// Usage: bun run seed:local [--force]
+//   --force  bypass the "must be a local Supabase URL" guard (dangerous).
+import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const force = process.argv.includes("--force");
+const LOCAL_DB = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+const log = (m) => console.log(`\x1b[36m[seed:local]\x1b[0m ${m}`);
+const ok = (m) => console.log(`\x1b[32m[seed:local] ✓\x1b[0m ${m}`);
+const skip = (m) => console.log(`\x1b[90m[seed:local] ·\x1b[0m ${m}`);
+const fail = (m) => {
+  console.error(`\x1b[31m[seed:local] ✗\x1b[0m ${m}`);
+  process.exit(1);
+};
+
+function parseEnvUrl() {
+  const envPath = join(root, ".env");
+  if (!existsSync(envPath)) return "";
+  for (const raw of readFileSync(envPath, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^SUPABASE_URL\s*=\s*(.*)$/);
+    if (m) return m[1].replace(/^["']|["']$/g, "").trim();
+  }
+  return "";
+}
+
+function assertLocal() {
+  const url = parseEnvUrl();
+  const isLocal = /127\.0\.0\.1|localhost/.test(url);
+  if (isLocal) {
+    ok(`target is local (${url})`);
+    return;
+  }
+  if (force) {
+    log(`--force: proceeding against non-local SUPABASE_URL (${url})`);
+    return;
+  }
+  fail(
+    `SUPABASE_URL is not local (${url || "unset"}).\n` +
+      "       This script seeds a dev admin and is for the local stack only.\n" +
+      "       Point .env at http://127.0.0.1:54321, or pass --force to override.",
+  );
+}
+
+function run(label, cmd, extraEnv = {}) {
+  log(`${label} …`);
+  const result = spawnSync(cmd[0], cmd.slice(1), {
+    cwd: root,
+    stdio: "inherit",
+    env: { ...process.env, ...extraEnv },
+  });
+  if (result.status !== 0) fail(`${label} failed`);
+  ok(label);
+}
+
+async function main() {
+  console.log("\x1b[1mAgent Resources — local app-data seed\x1b[0m\n");
+  assertLocal();
+
+  const { default: pg } = await import("pg");
+  const client = new pg.Client({ connectionString: LOCAL_DB });
+  try {
+    await client.connect();
+  } catch (e) {
+    fail(
+      `could not connect to the local database (${LOCAL_DB}).\n` +
+        `       Is the stack running? Try 'supabase start'. (${e.message})`,
+    );
+  }
+
+  const count = async (table) =>
+    (await client.query(`select count(*)::int as n from ${table}`)).rows[0].n;
+
+  try {
+    // nav_items — normally seeded by `supabase db reset`; backfill if empty.
+    if ((await count("nav_items")) > 0) {
+      skip("nav_items already seeded");
+    } else {
+      const sql = await readFile(join(root, "supabase", "seed.sql"), "utf8");
+      await client.query(sql);
+      ok("nav_items seeded from supabase/seed.sql");
+    }
+
+    // admin — required before classes (classes.created_by references it).
+    const adminCount = (
+      await client.query("select count(*)::int as n from profiles where role = 'admin'")
+    ).rows[0].n;
+    if (adminCount > 0) {
+      skip(`admin profile already present (${adminCount})`);
+    } else {
+      run("seeding admin (dummy@testing.com)", ["bun", "run", "seed:admin"], { CI: "1" });
+    }
+
+    // classes
+    if ((await count("classes")) > 0) {
+      skip("classes already seeded");
+    } else {
+      run("seeding classes", ["bun", "run", "seed:classes"]);
+    }
+
+    // badges — fetch source art (from public prod bucket) then seed.
+    if ((await count("badges")) > 0) {
+      skip("badges already seeded");
+    } else {
+      run("fetching badge art", ["bun", "run", "fetch:badges"]);
+      run("seeding badges", ["bun", "run", "seed:badges"]);
+    }
+
+    console.log("");
+    ok("local seeding complete");
+    for (const t of ["nav_items", "classes", "badges", "profiles"]) {
+      console.log(`      ${t.padEnd(12)} ${await count(t)} rows`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/services/character/input.js
+++ b/services/character/input.js
@@ -135,6 +135,34 @@ const normalizeStatsPayload = (body = {}) => {
   return out;
 };
 
+const normalizeWizardPayload = (rawBody) => {
+  const body = cloneInput(rawBody);
+
+  const trimmedName = (body.name || '').toString().trim();
+  if (!trimmedName) return { data: null, error: 'Character name is required.' };
+  if (trimmedName.length > 120) {
+    return { data: null, error: 'Character name is too long (max 120 characters).' };
+  }
+
+  if (body.creator_mode != null && body.creator_mode !== '' && !CREATOR_MODES.includes(body.creator_mode)) {
+    return { data: null, error: `Invalid mode: ${body.creator_mode}` };
+  }
+
+  const knownStats = new Set(statList);
+  for (const k of Object.keys(body)) {
+    if (knownStats.has(k)) body[k] = parseInteger(body[k], 0);
+  }
+
+  if (body.level != null) body.level = Math.max(1, Math.min(20, parseInteger(body.level, 1)));
+  if (body.completed_missions != null) body.completed_missions = Math.max(0, parseInteger(body.completed_missions, 0));
+  body.commissary_reward = Math.max(0, parseInteger(body.commissary_reward, 0));
+  body.name = trimmedName;
+  body.is_public = body.is_public === false ? false : true;
+  body.hide_from_search = !!body.hide_from_search;
+
+  return { data: body, error: null };
+};
+
 module.exports = {
   cloneInput,
   normalizeCharacterInput,
@@ -143,5 +171,6 @@ module.exports = {
   normalizeAbilityItems: normalizeClassItems,
   normalizeAbilityPerks,
   parseInteger,
-  normalizeStatsPayload
+  normalizeStatsPayload,
+  normalizeWizardPayload
 };

--- a/services/character/input.js
+++ b/services/character/input.js
@@ -163,6 +163,57 @@ const normalizeWizardPayload = (rawBody) => {
   return { data: body, error: null };
 };
 
+const asArray = (v) => (Array.isArray(v) ? v : (v == null || v === '' ? [] : [v]));
+
+const collectAbilityPerksFromForm = (body) => {
+  const ids = asArray(body.ability_perk_class_ability_id);
+  const texts = asArray(body.ability_perk_text);
+  const pos = asArray(body.ability_perk_position);
+  const cw = asArray(body.ability_perk_compounds_with);
+  const n = Math.max(ids.length, texts.length, pos.length, cw.length);
+  const perks = [];
+  for (let i = 0; i < n; i++) {
+    const id = ids[i];
+    const text = texts[i];
+    if (!id || !text) continue;
+    perks.push({
+      class_ability_id: id,
+      text: String(text),
+      position: Number(pos[i]) || i,
+      compounds_with: cw[i] || null
+    });
+  }
+  return perks;
+};
+
+const collectNamedFromForm = (body, nameKey, descKey) => {
+  const names = asArray(body[nameKey]);
+  const descs = asArray(body[descKey]);
+  const out = [];
+  for (let i = 0; i < names.length; i++) {
+    const name = (names[i] || '').toString().trim();
+    if (!name) continue;
+    const desc = (descs[i] || '').toString().trim();
+    out.push(desc ? { name, description: desc } : { name });
+  }
+  return out;
+};
+
+const FORM_ARRAY_KEYS = [
+  'ability_perk_class_ability_id', 'ability_perk_text', 'ability_perk_position',
+  'ability_perk_compounds_with', 'quirk_name', 'quirk_description',
+  'accessory_name', 'accessory_description'
+];
+
+const collectCharacterFormArrays = (body) => {
+  const out = { ...body };
+  out.ability_perks = collectAbilityPerksFromForm(body);
+  out.quirks = collectNamedFromForm(body, 'quirk_name', 'quirk_description');
+  out.accessories = collectNamedFromForm(body, 'accessory_name', 'accessory_description');
+  for (const key of FORM_ARRAY_KEYS) delete out[key];
+  return out;
+};
+
 module.exports = {
   cloneInput,
   normalizeCharacterInput,
@@ -172,5 +223,6 @@ module.exports = {
   normalizeAbilityPerks,
   parseInteger,
   normalizeStatsPayload,
-  normalizeWizardPayload
+  normalizeWizardPayload,
+  collectCharacterFormArrays
 };

--- a/services/character/input.test.js
+++ b/services/character/input.test.js
@@ -55,3 +55,46 @@ test('normalizes update booleans and missing list fields deterministically', () 
   });
   expect(result.data).toMatchObject({ auto_calculate: true, common_items: [], is_public: false, hide_from_search: false, image_url: null });
 });
+
+const { normalizeWizardPayload } = require('./input');
+
+test('normalizeWizardPayload rejects a missing name', () => {
+  const { data, error } = normalizeWizardPayload({ name: '   ' });
+  expect(data).toBeNull();
+  expect(error).toBe('Character name is required.');
+});
+
+test('normalizeWizardPayload rejects an over-long name', () => {
+  const { error } = normalizeWizardPayload({ name: 'x'.repeat(121) });
+  expect(error).toBe('Character name is too long (max 120 characters).');
+});
+
+test('normalizeWizardPayload rejects an unknown creator_mode', () => {
+  const { error } = normalizeWizardPayload({ name: 'Hero', creator_mode: 'bogus' });
+  expect(error).toBe('Invalid mode: bogus');
+});
+
+test('normalizeWizardPayload coerces stats, clamps level/missions, defaults reward and booleans', () => {
+  const { data, error } = normalizeWizardPayload({
+    name: '  Hero  ',
+    might: '7',
+    level: '99',
+    completed_missions: '-3',
+    is_public: false,
+    hide_from_search: true
+  });
+  expect(error).toBeNull();
+  expect(data.name).toBe('Hero');
+  expect(data.might).toBe(7);
+  expect(data.level).toBe(20);
+  expect(data.completed_missions).toBe(0);
+  expect(data.commissary_reward).toBe(0);
+  expect(data.is_public).toBe(false);
+  expect(data.hide_from_search).toBe(true);
+});
+
+test('normalizeWizardPayload defaults is_public to true when unset', () => {
+  const { data } = normalizeWizardPayload({ name: 'Hero' });
+  expect(data.is_public).toBe(true);
+  expect(data.hide_from_search).toBe(false);
+});

--- a/services/character/input.test.js
+++ b/services/character/input.test.js
@@ -98,3 +98,36 @@ test('normalizeWizardPayload defaults is_public to true when unset', () => {
   expect(data.is_public).toBe(true);
   expect(data.hide_from_search).toBe(false);
 });
+
+const { collectCharacterFormArrays } = require('./input');
+
+test('collectCharacterFormArrays assembles perks/quirks/accessories and strips raw keys', () => {
+  const out = collectCharacterFormArrays({
+    name: 'Hero',
+    ability_perk_class_ability_id: ['a1', 'a2'],
+    ability_perk_text: ['first', ''],          // blank text row is dropped
+    ability_perk_position: ['0', '1'],
+    ability_perk_compounds_with: ['', 'new:x'],
+    quirk_name: ['Brave', '  '],               // blank name dropped
+    quirk_description: ['bold', ''],
+    accessory_name: ['Ring'],
+    accessory_description: ['']
+  });
+  expect(out.name).toBe('Hero');
+  expect(out.ability_perks).toEqual([{ class_ability_id: 'a1', text: 'first', position: 0, compounds_with: null }]);
+  expect(out.quirks).toEqual([{ name: 'Brave', description: 'bold' }]);
+  expect(out.accessories).toEqual([{ name: 'Ring' }]);
+  expect(out.ability_perk_class_ability_id).toBeUndefined();
+  expect(out.quirk_name).toBeUndefined();
+  expect(out.accessory_description).toBeUndefined();
+});
+
+test('collectCharacterFormArrays tolerates single (non-array) form values', () => {
+  const out = collectCharacterFormArrays({
+    ability_perk_class_ability_id: 'a1',
+    ability_perk_text: 'solo',
+    ability_perk_position: '3',
+    ability_perk_compounds_with: ''
+  });
+  expect(out.ability_perks).toEqual([{ class_ability_id: 'a1', text: 'solo', position: 3, compounds_with: null }]);
+});

--- a/services/character/repository.js
+++ b/services/character/repository.js
@@ -2,8 +2,12 @@ const { supabase, supabaseAdmin } = require('../../models/_base');
 const {
   listOffscreenMissions: listOffscreenMissionsForCharacter,
   createOffscreenMission,
+  updateOffscreenMission,
+  removeOffscreenMission,
+  getOffscreenMissionById,
   getAvailableHostedMissionsForPicker
 } = require('../../models/offscreen-mission');
+const { getProfileConduitCredits } = require('../../models/profile');
 const { createMission, addCharacterToMission } = require('../../models/mission');
 const { SYSTEM_ACTOR } = require('../../util/actor');
 const { escapeLikePattern } = require('../../util/validate');
@@ -400,5 +404,25 @@ module.exports = {
   getAvailableHostedMissions: (profileId) => getAvailableHostedMissionsForPicker({ profileId, supabase: supabaseAdmin }),
   createOffscreenMissionRow: ({ characterId, profileId, payload }) => createOffscreenMission({
     characterId, profileId, payload, supabase: supabaseAdmin
-  })
+  }),
+
+  // Offscreen-mission capability primitives (CharacterService#create/update/
+  // deleteOffscreenMission). Distinct from createOffscreenMissionRow above
+  // (used internally by the level-up credit-spend flow) — these back the
+  // user-facing offscreen-mission CRUD capabilities.
+  getOffscreenMissionRow: (id) => getOffscreenMissionById({ id, supabase: supabaseAdmin }),
+  getSourceMissionForCredit: async (missionId) => {
+    const { data, error } = await supabaseAdmin
+      .from('missions')
+      .select('id, name, date, host_id')
+      .eq('id', missionId)
+      .maybeSingle();
+    return { data, error };
+  },
+  getConduitCredits: (profileId) => getProfileConduitCredits({ profileId, supabase: supabaseAdmin }),
+  insertOffscreenMission: ({ characterId, profileId, payload }) => createOffscreenMission({
+    characterId, profileId, payload, supabase: supabaseAdmin
+  }),
+  updateOffscreenMissionRow: ({ id, payload }) => updateOffscreenMission({ id, payload, supabase: supabaseAdmin }),
+  deleteOffscreenMissionRow: (id) => removeOffscreenMission({ id, supabase: supabaseAdmin })
 };

--- a/services/character/repository.js
+++ b/services/character/repository.js
@@ -266,6 +266,21 @@ module.exports = {
       return { data, error };
     }
   } : {}),
+  // level-up's terminal write. Unlike saveCharacterAtomic (which has a
+  // non-atomic fallback in the service and is therefore optional/guarded),
+  // levelUp has NO fallback path — the RPC is a hard dependency — so this is
+  // exported unconditionally and listed in REQUIRED_ADAPTER_METHODS. Callers
+  // always run against a real supabase client (rpc present); the only no-rpc
+  // context is fake-client unit tests that never invoke levelUp.
+  levelUpAtomic: async ({ characterId, creatorId, fields, perks }) => {
+    const { data, error } = await supabaseAdmin.rpc('level_up_character_atomic', {
+      p_character_id: characterId,
+      p_creator_id: creatorId,
+      p_fields: fields,
+      p_perks: perks
+    });
+    return { data, error };
+  },
   getChildRows: (table, characterId) => supabaseAdmin
     .from(table)
     .select('*')
@@ -347,7 +362,9 @@ module.exports = {
   },
   getClassRulesVersion,
 
-  // Perk-append primitives (level-up flow).
+  // Perk-build reads (level-up flow) — CharacterService#buildPerkRows uses
+  // these to filter to allowed abilities and compute per-ability position
+  // offsets; the terminal perk write happens inside level_up_character_atomic.
   fetchAllowedAbilityIds: async (characterId) => {
     const { data, error } = await supabaseAdmin.from('class_abilities').select('id').eq('character_id', characterId);
     return { data, error };
@@ -358,17 +375,6 @@ module.exports = {
       .select('id, class_ability_id, text, position')
       .eq('character_id', characterId);
     return { data, error };
-  },
-  insertPerks: async (rows) => {
-    const { error } = await supabaseAdmin.from('character_perks').insert(rows);
-    return { error };
-  },
-  updatePerkLinks: async (updates) => {
-    for (const u of updates) {
-      const { error } = await supabaseAdmin.from('character_perks').update({ compounds_with: u.compounds_with }).eq('id', u.id);
-      if (error) return { error };
-    }
-    return { error: null };
   },
 
   // Level-up backfill/credit-spend writes — internal, non-user-triggered

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -38,8 +38,7 @@ const REQUIRED_ADAPTER_METHODS = [
   'getClassRulesVersion',
   'fetchAllowedAbilityIds',
   'fetchExistingPerks',
-  'insertPerks',
-  'updatePerkLinks',
+  'levelUpAtomic',
   'createBackfillMission',
   'getAvailableHostedMissions',
   'createOffscreenMissionRow',
@@ -516,11 +515,17 @@ class CharacterService {
       completed_missions: derived.completed_missions,
       commissary_reward: derived.commissary_reward
     };
-    const { data, error } = await this.adapter.updateOwnedFields({ id, creatorId: character.creator_id, fields });
-    if (error) return { data: null, error };
+    const { data: perkRows, error: perkBuildError } = await this.buildPerkRows(id, Array.isArray(body.ability_perks) ? body.ability_perks : []);
+    if (perkBuildError) return { data: null, error: perkBuildError };
 
-    const { error: perksError } = await this.appendPerks(id, Array.isArray(body.ability_perks) ? body.ability_perks : []);
-    if (perksError) return { data: null, error: perksError };
+    const { data, error } = await this.adapter.levelUpAtomic({
+      characterId: id,
+      creatorId: character.creator_id,
+      fields,
+      perks: perkRows
+    });
+    if (error) return { data: null, error };
+    if (!data) return { data: null, error: { status: 404, message: 'Character update returned no rows' } };
 
     return {
       data: {
@@ -534,21 +539,26 @@ class CharacterService {
     };
   }
 
-  // Appends newly-submitted ability perks (level-up modal) to a character's
-  // existing perk set, resolving `compounds_with` links either to an existing
-  // perk (by id) or to another perk inserted in the same batch (`new:<ref>`).
-  // Moved verbatim from routes/characters.js#appendCharacterPerks.
-  async appendPerks(characterId, submittedPerks) {
+  // Builds the ordered perk-row payload for a level-up (level-up modal),
+  // WITHOUT writing — the terminal insert + link-resolution happens atomically
+  // inside level_up_character_atomic (see repository.js#levelUpAtomic). Keeps
+  // the original allowed-ability filter, per-ability position offsets, and
+  // validation from the former perk-append path, but encodes each `compounds_with`
+  // link the way the RPC's resolver expects: `position-<n>` for a target in
+  // this same batch on the SAME ability, an existing-perk UUID (same ability)
+  // to keep, or null. Returns { data: rows, error } where each row is
+  // { class_ability_id, text, position, compounds_with }.
+  async buildPerkRows(characterId, submittedPerks) {
     if (!Array.isArray(submittedPerks) || submittedPerks.length === 0) {
-      return { error: null };
+      return { data: [], error: null };
     }
 
     const { data: abilities, error: abilityError } = await this.adapter.fetchAllowedAbilityIds(characterId);
-    if (abilityError) return { error: abilityError };
+    if (abilityError) return { data: null, error: abilityError };
     const allowedAbilityIds = new Set((abilities || []).map(a => a.id));
 
     const { data: existing, error: existingError } = await this.adapter.fetchExistingPerks(characterId);
-    if (existingError) return { error: existingError };
+    if (existingError) return { data: null, error: existingError };
 
     const existingCounts = new Map();
     // id -> ability, so a new perk may only compound with an existing perk on
@@ -561,9 +571,9 @@ class CharacterService {
       return { class_ability_id: p.class_ability_id, text: p.text, position: pos };
     });
 
-    // Build insert rows. `meta` runs parallel to `rows`, carrying each new
-    // perk's client `ref` and its requested compound link so we can resolve
-    // links after the rows (and their ids) exist.
+    // Build the perk rows. `meta` runs parallel to `rows`, carrying each new
+    // perk's client `ref` and its requested compound link so we can translate
+    // links to the RPC's encoding once every batch position is assigned.
     const rows = [];
     const meta = [];
     for (const p of submittedPerks) {
@@ -574,10 +584,10 @@ class CharacterService {
       const nextPosition = (existingCounts.get(classAbilityId) ?? -1) + 1;
       existingCounts.set(classAbilityId, nextPosition);
       rows.push({
-        character_id: characterId,
         class_ability_id: classAbilityId,
         text,
-        position: nextPosition
+        position: nextPosition,
+        compounds_with: null
       });
       meta.push({
         ref: typeof p.ref === 'string' ? p.ref : null,
@@ -585,62 +595,40 @@ class CharacterService {
       });
     }
 
-    if (rows.length === 0) return { error: null };
+    if (rows.length === 0) return { data: [], error: null };
 
     const validation = validateAbilityPerks(existingForValidation.concat(rows));
     if (!validation.ok) {
-      return { error: { status: 400, message: validation.errors.join(' ') } };
+      return { data: null, error: { status: 400, message: validation.errors.join(' ') } };
     }
 
-    const { error: insertError } = await this.adapter.insertPerks(rows);
-    if (insertError) return { error: insertError };
-
-    // Re-read the rows to recover server-assigned ids. We match by
-    // (class_ability_id, position) — each new perk got a unique position
-    // above — rather than relying on insert-return ordering.
-    const { data: current, error: selError } = await this.adapter.fetchExistingPerks(characterId);
-    if (selError) return { error: selError };
-    const idByKey = new Map((current || []).map(r => [`${r.class_ability_id}:${parseInteger(r.position, 0)}`, r.id]));
-    const keyOf = (row) => `${row.class_ability_id}:${row.position}`;
-
-    // ref -> { id, class_ability_id } for perks inserted in this batch.
-    const insertedByRef = new Map();
+    // ref -> { position, class_ability_id } for perks in this batch, so a
+    // `new:<ref>` link resolves to the target's assigned position.
+    const rowByRef = new Map();
     for (let i = 0; i < rows.length; i++) {
       if (!meta[i].ref) continue;
-      insertedByRef.set(meta[i].ref, { id: idByKey.get(keyOf(rows[i])), class_ability_id: rows[i].class_ability_id });
+      rowByRef.set(meta[i].ref, { position: rows[i].position, class_ability_id: rows[i].class_ability_id });
     }
 
-    // Resolve each new perk's compound link. A link is either `new:<ref>`
-    // (another perk inserted in this batch) or an existing perk UUID. The
-    // target must be on the same ability and not the perk itself; anything
-    // else resolves to null.
-    const linkUpdates = [];
+    // Translate each new perk's compound link into the RPC's encoding: a
+    // `new:<ref>` link → `position-<n>` of the target row (only when the target
+    // is in this batch on the SAME ability); an existing-perk UUID on the same
+    // ability → keep the UUID; anything else → null.
     for (let i = 0; i < rows.length; i++) {
       const link = meta[i].compoundsWith;
       if (!link) continue;
-      const rowId = idByKey.get(keyOf(rows[i]));
-      if (!rowId) continue;
 
-      let target = null;
       if (link.startsWith('new:')) {
-        const ref = link.slice('new:'.length);
-        const cand = insertedByRef.get(ref);
-        if (cand) target = { id: cand.id, class_ability_id: cand.class_ability_id };
-      } else if (abilityByExistingPerkId.has(link)) {
-        target = { id: link, class_ability_id: abilityByExistingPerkId.get(link) };
-      }
-
-      if (target && target.id && target.id !== rowId && target.class_ability_id === rows[i].class_ability_id) {
-        linkUpdates.push({ id: rowId, compounds_with: target.id });
+        const target = rowByRef.get(link.slice('new:'.length));
+        if (target && target.class_ability_id === rows[i].class_ability_id && target.position !== rows[i].position) {
+          rows[i].compounds_with = `position-${target.position}`;
+        }
+      } else if (abilityByExistingPerkId.get(link) === rows[i].class_ability_id) {
+        rows[i].compounds_with = link;
       }
     }
 
-    if (linkUpdates.length > 0) {
-      const { error: linkError } = await this.adapter.updatePerkLinks(linkUpdates);
-      if (linkError) return { error: linkError };
-    }
-
-    return { error: null };
+    return { data: rows, error: null };
   }
 
   // --- Offscreen-mission capabilities ----------------------------------

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -43,7 +43,14 @@ const REQUIRED_ADAPTER_METHODS = [
   'createBackfillMission',
   'getAvailableHostedMissions',
   'createOffscreenMissionRow',
-  'findUpgradeTargets'
+  'findUpgradeTargets',
+  // Offscreen-mission capabilities (create/update/deleteOffscreenMission).
+  'getOffscreenMissionRow',
+  'getSourceMissionForCredit',
+  'getConduitCredits',
+  'insertOffscreenMission',
+  'updateOffscreenMissionRow',
+  'deleteOffscreenMissionRow'
 ];
 
 // Loads the full character row (admin-privileged; includes traits/gear/
@@ -634,6 +641,115 @@ class CharacterService {
     }
 
     return { error: null };
+  }
+
+  // --- Offscreen-mission capabilities ----------------------------------
+  // Resolves the credit source for a create/update payload: either an
+  // existing hosted mission (validated as actor-hosted) or a freeform
+  // name/date pair. Pure over adapter reads; returns { error } on failure.
+  async resolveOffscreenSource(actor, body) {
+    if (body.source_mission_id && body.source_mission_id !== '__other__') {
+      const { data: srcMission, error } = await this.adapter.getSourceMissionForCredit(body.source_mission_id);
+      if (error || !srcMission) return { error: 'Source mission not found.' };
+      if (srcMission.host_id !== actor.profileId) {
+        return { error: 'Only the host of a mission can use it as a credit source.' };
+      }
+      return {
+        source_mission_id: srcMission.id,
+        source_mission_name: srcMission.name,
+        source_mission_date: typeof srcMission.date === 'string'
+          ? srcMission.date.slice(0, 10)
+          : new Date(srcMission.date).toISOString().slice(0, 10)
+      };
+    }
+    const name = (body.source_mission_name_other || '').trim();
+    const date = (body.source_mission_date_other || '').trim();
+    if (!name || !date) return { error: 'Source mission name and date are required.' };
+    return { source_mission_id: null, source_mission_name: name, source_mission_date: date };
+  }
+
+  async createOffscreenMission(actor, characterId, body) {
+    await requireOwnedCharacter(this.adapter, actor, characterId);
+
+    if (!body.name || !body.summary) {
+      return { data: null, error: { status: 400, message: 'Name and summary are required.' } };
+    }
+    const src = await this.resolveOffscreenSource(actor, body);
+    if (src.error) return { data: null, error: { status: 400, message: src.error } };
+
+    if (src.source_mission_id) {
+      const { data: credits } = await this.adapter.getConduitCredits(actor.profileId);
+      if (!credits || credits.balance <= 0) {
+        return { data: null, error: { status: 400, message: 'No Conduit Credits available.' } };
+      }
+    }
+
+    const { error } = await this.adapter.insertOffscreenMission({
+      characterId,
+      profileId: actor.profileId,
+      payload: {
+        name: body.name,
+        summary: body.summary,
+        merx_gained: body.merx_gained,
+        source_mission_id: src.source_mission_id,
+        source_mission_name: src.source_mission_name,
+        source_mission_date: src.source_mission_date
+      }
+    });
+    if (error) {
+      if (error.code === '23505' || error.message === 'duplicate_source_mission') {
+        return { data: null, error: { status: 400, message: 'That mission has already funded a credit.' } };
+      }
+      return { data: null, error };
+    }
+    return { data: { characterId }, error: null };
+  }
+
+  async updateOffscreenMission(actor, characterId, omId, body) {
+    await requireOwnedCharacter(this.adapter, actor, characterId);
+
+    const { data: existing, error: omError } = await this.adapter.getOffscreenMissionRow(omId);
+    if (omError) return { data: null, error: omError };
+    if (!existing || existing.character_id !== characterId) {
+      return { data: null, error: { status: 404, message: 'Not found' } };
+    }
+    if (!body.name || !body.summary) {
+      return { data: null, error: { status: 400, message: 'Name and summary are required.' } };
+    }
+    const src = await this.resolveOffscreenSource(actor, body);
+    if (src.error) return { data: null, error: { status: 400, message: src.error } };
+
+    const { error } = await this.adapter.updateOffscreenMissionRow({
+      id: omId,
+      payload: {
+        name: body.name,
+        summary: body.summary,
+        merx_gained: body.merx_gained,
+        source_mission_id: src.source_mission_id,
+        source_mission_name: src.source_mission_name,
+        source_mission_date: src.source_mission_date
+      }
+    });
+    if (error) {
+      if (error.code === '23505' || error.message === 'duplicate_source_mission') {
+        return { data: null, error: { status: 400, message: 'That mission has already funded a credit.' } };
+      }
+      return { data: null, error };
+    }
+    return { data: { characterId }, error: null };
+  }
+
+  async deleteOffscreenMission(actor, characterId, omId) {
+    await requireOwnedCharacter(this.adapter, actor, characterId);
+
+    const { data: existing, error: omError } = await this.adapter.getOffscreenMissionRow(omId);
+    if (omError) return { data: null, error: omError };
+    if (!existing || existing.character_id !== characterId) {
+      return { data: null, error: { status: 404, message: 'Not found' } };
+    }
+    const { error } = await this.adapter.deleteOffscreenMissionRow(omId);
+    if (error) return { data: null, error };
+    return { data: { characterId }, error: null };
   }
 }
 

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -671,11 +671,12 @@ class CharacterService {
   async createOffscreenMission(actor, characterId, body) {
     await requireOwnedCharacter(this.adapter, actor, characterId);
 
+    const src = await this.resolveOffscreenSource(actor, body);
+    if (src.error) return { data: null, error: { status: 400, message: src.error } };
+
     if (!body.name || !body.summary) {
       return { data: null, error: { status: 400, message: 'Name and summary are required.' } };
     }
-    const src = await this.resolveOffscreenSource(actor, body);
-    if (src.error) return { data: null, error: { status: 400, message: src.error } };
 
     if (src.source_mission_id) {
       const { data: credits } = await this.adapter.getConduitCredits(actor.profileId);

--- a/services/character/service.test.js
+++ b/services/character/service.test.js
@@ -84,8 +84,7 @@ const makeAdapter = (calls, overrides = {}) => ({
   getClassRulesVersion: async () => ok('v1'),
   fetchAllowedAbilityIds: async () => ok([]),
   fetchExistingPerks: async () => ok([]),
-  insertPerks: async () => ({ error: null }),
-  updatePerkLinks: async () => ({ error: null }),
+  levelUpAtomic: async ({ fields }) => ok({ id: 'character-1', name: 'Owned Hero', ...fields }),
   createBackfillMission: async () => ({ error: null }),
   getAvailableHostedMissions: async () => ok([]),
   createOffscreenMissionRow: async () => ok({}),
@@ -307,6 +306,38 @@ test('CharacterService.levelUp surfaces a backfill mission error without throwin
 
   expect(result.data).toBeNull();
   expect(result.error).toBeInstanceOf(AuthorizationError);
+});
+
+test('levelUp persists via a single levelUpAtomic call (not updateOwnedFields + insertPerks)', async () => {
+  const calls = [];
+  const adapter = {
+    ...minimalRequiredAdapter(),
+    getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', class_id: 'class-1', level: 1, completed_missions: 0, commissary_reward: 0, abilities: [] }),
+    getRealMissions: async () => ok([]),
+    listOffscreenMissions: async () => ok([]),
+    getClassRulesVersion: async () => ok('v2'),
+    fetchAllowedAbilityIds: async () => ok([{ id: 'ab-1' }]),
+    fetchExistingPerks: async () => ok([]),
+    levelUpAtomic: async (args) => { calls.push(args); return ok({ id: 'character-1', name: 'Hero', level: 2, completed_missions: 0, commissary_reward: 0 }); },
+    updateOwnedFields: async () => { throw new Error('updateOwnedFields must not be called by levelUp'); },
+  };
+  const svc = new CharacterService(adapter);
+  const { data, error } = await svc.levelUp(CREATOR, 'character-1', {
+    level: 2,
+    ability_perks: [{ class_ability_id: 'ab-1', text: 'New perk', ref: 'r1' }]
+  });
+  expect(error).toBeNull();
+  expect(data.level).toBe(2);
+  expect(calls).toHaveLength(1);
+  expect(calls[0].characterId).toBe('character-1');
+  expect(calls[0].creatorId).toBe('profile-1');
+  expect(calls[0].perks[0]).toMatchObject({ class_ability_id: 'ab-1', text: 'New perk', position: 0 });
+});
+
+test('levelUp still refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService({ ...minimalRequiredAdapter(),
+    getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', abilities: [] }) });
+  await expect(svc.levelUp(STRANGER, 'character-1', {})).rejects.toBeInstanceOf(AuthorizationError);
 });
 
 // --- Offscreen-mission capabilities ----------------------------------

--- a/services/character/service.test.js
+++ b/services/character/service.test.js
@@ -336,7 +336,12 @@ test('createOffscreenMission refuses a non-owner with AuthorizationError', async
 
 test('createOffscreenMission requires name and summary', async () => {
   const svc = new CharacterService(offscreenAdapter());
-  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', { name: '', summary: '' });
+  // Supply a valid freeform source so this isolates the name/summary check —
+  // resolveOffscreenSource runs first (route parity), so a request missing
+  // both would surface the source error instead.
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: '', summary: '', source_mission_name_other: 'Freeform', source_mission_date_other: '2026-02-02'
+  });
   expect(error).toEqual({ status: 400, message: 'Name and summary are required.' });
 });
 
@@ -370,6 +375,12 @@ test('createOffscreenMission inserts on the happy path', async () => {
   });
   expect(error).toBeNull();
   expect(calls[0].characterId).toBe('character-1');
+});
+
+test('updateOffscreenMission refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  await expect(svc.updateOffscreenMission(STRANGER, 'character-1', 'om-1', { name: 'n', summary: 's' }))
+    .rejects.toBeInstanceOf(AuthorizationError);
 });
 
 test('updateOffscreenMission 404s when the row belongs to another character', async () => {

--- a/services/character/service.test.js
+++ b/services/character/service.test.js
@@ -8,6 +8,11 @@ const CREATOR = { profileId: 'profile-1', role: null };
 const STRANGER = { profileId: 'someone-else', role: null };
 const ADMIN = { profileId: 'admin-profile', role: 'admin' };
 
+// Minimal adapter satisfying every REQUIRED_ADAPTER_METHODS entry, so
+// `new CharacterService(...)` passes constructor validation. Individual
+// tests override the methods they actually exercise.
+const minimalRequiredAdapter = () => makeAdapter([]);
+
 const OWNED_CHARACTER = {
   id: 'character-1',
   creator_id: 'profile-1',
@@ -85,6 +90,13 @@ const makeAdapter = (calls, overrides = {}) => ({
   getAvailableHostedMissions: async () => ok([]),
   createOffscreenMissionRow: async () => ok({}),
   findUpgradeTargets: async () => ([{ id: 'target-class', name: 'Upgraded Class' }]),
+  // Offscreen-mission capability defaults (create/update/deleteOffscreenMission).
+  getOffscreenMissionRow: async () => ok(null),
+  getSourceMissionForCredit: async () => ok(null),
+  getConduitCredits: async () => ok(null),
+  insertOffscreenMission: async () => ({ error: null }),
+  updateOffscreenMissionRow: async () => ({ error: null }),
+  deleteOffscreenMissionRow: async () => ({ error: null }),
   ...overrides
 });
 
@@ -295,4 +307,81 @@ test('CharacterService.levelUp surfaces a backfill mission error without throwin
 
   expect(result.data).toBeNull();
   expect(result.error).toBeInstanceOf(AuthorizationError);
+});
+
+// --- Offscreen-mission capabilities ----------------------------------
+
+const offscreenAdapter = (overrides = {}) => ({
+  // Baseline first so the specific offscreen stubs below (and per-test
+  // `overrides`) take precedence — object-spread/property order means a
+  // later same-named key wins, and minimalRequiredAdapter() also defines
+  // generic versions of the six offscreen methods (for constructor
+  // validation elsewhere), so it must not be spread after them here.
+  ...minimalRequiredAdapter(),
+  getCharacter: async () => ok({ id: 'character-1', creator_id: 'profile-1', name: 'Hero', abilities: [] }),
+  getOffscreenMissionRow: async () => ok({ id: 'om-1', character_id: 'character-1' }),
+  getSourceMissionForCredit: async () => ok({ id: 'm-1', name: 'Raid', date: '2026-01-01', host_id: 'profile-1' }),
+  getConduitCredits: async () => ok({ balance: 3 }),
+  insertOffscreenMission: async () => ({ error: null }),
+  updateOffscreenMissionRow: async () => ({ error: null }),
+  deleteOffscreenMissionRow: async () => ({ error: null }),
+  ...overrides
+});
+
+test('createOffscreenMission refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  await expect(svc.createOffscreenMission(STRANGER, 'character-1', { name: 'x', summary: 'y' }))
+    .rejects.toBeInstanceOf(AuthorizationError);
+});
+
+test('createOffscreenMission requires name and summary', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', { name: '', summary: '' });
+  expect(error).toEqual({ status: 400, message: 'Name and summary are required.' });
+});
+
+test('createOffscreenMission rejects a source mission the actor does not host', async () => {
+  const svc = new CharacterService(offscreenAdapter({
+    getSourceMissionForCredit: async () => ok({ id: 'm-1', name: 'Raid', date: '2026-01-01', host_id: 'someone-else' })
+  }));
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: 'n', summary: 's', source_mission_id: 'm-1'
+  });
+  expect(error.status).toBe(400);
+});
+
+test('createOffscreenMission gates a hosted source on the credit balance', async () => {
+  const svc = new CharacterService(offscreenAdapter({
+    getConduitCredits: async () => ok({ balance: 0 })
+  }));
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: 'n', summary: 's', source_mission_id: 'm-1'
+  });
+  expect(error).toEqual({ status: 400, message: 'No Conduit Credits available.' });
+});
+
+test('createOffscreenMission inserts on the happy path', async () => {
+  const calls = [];
+  const svc = new CharacterService(offscreenAdapter({
+    insertOffscreenMission: async (args) => { calls.push(args); return { error: null }; }
+  }));
+  const { error } = await svc.createOffscreenMission(CREATOR, 'character-1', {
+    name: 'n', summary: 's', source_mission_name_other: 'Freeform', source_mission_date_other: '2026-02-02'
+  });
+  expect(error).toBeNull();
+  expect(calls[0].characterId).toBe('character-1');
+});
+
+test('updateOffscreenMission 404s when the row belongs to another character', async () => {
+  const svc = new CharacterService(offscreenAdapter({
+    getOffscreenMissionRow: async () => ok({ id: 'om-1', character_id: 'other-char' })
+  }));
+  const { error } = await svc.updateOffscreenMission(CREATOR, 'character-1', 'om-1', { name: 'n', summary: 's' });
+  expect(error.status).toBe(404);
+});
+
+test('deleteOffscreenMission refuses a non-owner with AuthorizationError', async () => {
+  const svc = new CharacterService(offscreenAdapter());
+  await expect(svc.deleteOffscreenMission(STRANGER, 'character-1', 'om-1'))
+    .rejects.toBeInstanceOf(AuthorizationError);
 });

--- a/supabase/migrations/20260728000000_level_up_character_atomic.sql
+++ b/supabase/migrations/20260728000000_level_up_character_atomic.sql
@@ -1,0 +1,101 @@
+-- Atomically apply a level-up's terminal writes: update the character's owned
+-- counters/stats, insert the newly-submitted ability perks, and resolve their
+-- compound links — all in one transaction. Service-role only; authorization
+-- stays in CharacterService. Backfill missions and offscreen-credit rows are
+-- created upstream (cross-domain) and are intentionally NOT part of this
+-- transaction — they are additive and re-derivable.
+CREATE OR REPLACE FUNCTION public.level_up_character_atomic(
+  p_character_id uuid,
+  p_creator_id uuid,
+  p_fields jsonb,
+  p_perks jsonb
+)
+RETURNS public.characters
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  saved public.characters;
+  item jsonb;
+  source_id uuid;
+  target_id uuid;
+BEGIN
+  UPDATE public.characters AS current
+  SET
+    vitality = COALESCE((p_fields->>'vitality')::int, current.vitality),
+    might = COALESCE((p_fields->>'might')::int, current.might),
+    resilience = COALESCE((p_fields->>'resilience')::int, current.resilience),
+    spirit = COALESCE((p_fields->>'spirit')::int, current.spirit),
+    arcane = COALESCE((p_fields->>'arcane')::int, current.arcane),
+    will = COALESCE((p_fields->>'will')::int, current.will),
+    sensory = COALESCE((p_fields->>'sensory')::int, current.sensory),
+    reflex = COALESCE((p_fields->>'reflex')::int, current.reflex),
+    vigor = COALESCE((p_fields->>'vigor')::int, current.vigor),
+    skill = COALESCE((p_fields->>'skill')::int, current.skill),
+    intelligence = COALESCE((p_fields->>'intelligence')::int, current.intelligence),
+    luck = COALESCE((p_fields->>'luck')::int, current.luck),
+    level = COALESCE((p_fields->>'level')::int, current.level),
+    completed_missions = COALESCE((p_fields->>'completed_missions')::int, current.completed_missions),
+    commissary_reward = COALESCE((p_fields->>'commissary_reward')::int, current.commissary_reward)
+  WHERE current.id = p_character_id AND current.creator_id = p_creator_id
+  RETURNING current.* INTO saved;
+
+  IF saved.id IS NULL THEN
+    RAISE EXCEPTION 'Character update returned no rows';
+  END IF;
+
+  IF p_perks IS NOT NULL THEN
+    -- Insert the new perk rows.
+    FOR item IN SELECT value FROM jsonb_array_elements(p_perks)
+    LOOP
+      INSERT INTO public.character_perks (character_id, class_ability_id, text, position)
+      VALUES (
+        saved.id,
+        (item->>'class_ability_id')::uuid,
+        item->>'text',
+        COALESCE((item->>'position')::integer, 0)
+      );
+    END LOOP;
+
+    -- Resolve compound links. A link is either 'position-<n>' (another perk in
+    -- this batch on the SAME ability) or an existing perk UUID on the same
+    -- ability. Anything else is left null.
+    FOR item IN SELECT value FROM jsonb_array_elements(p_perks)
+    LOOP
+      IF item->>'compounds_with' IS NULL THEN CONTINUE; END IF;
+
+      SELECT cp.id INTO source_id
+      FROM public.character_perks cp
+      WHERE cp.character_id = saved.id
+        AND cp.class_ability_id = (item->>'class_ability_id')::uuid
+        AND cp.position = COALESCE((item->>'position')::integer, 0)
+      LIMIT 1;
+      IF source_id IS NULL THEN CONTINUE; END IF;
+
+      target_id := NULL;
+      IF item->>'compounds_with' LIKE 'position-%' THEN
+        SELECT cp.id INTO target_id
+        FROM public.character_perks cp
+        WHERE cp.character_id = saved.id
+          AND cp.class_ability_id = (item->>'class_ability_id')::uuid
+          AND cp.position = substring(item->>'compounds_with' FROM 'position-(.*)')::integer
+        LIMIT 1;
+      ELSIF item->>'compounds_with' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+        SELECT cp.id INTO target_id
+        FROM public.character_perks cp
+        WHERE cp.id = (item->>'compounds_with')::uuid
+          AND cp.character_id = saved.id
+          AND cp.class_ability_id = (item->>'class_ability_id')::uuid
+        LIMIT 1;
+      END IF;
+
+      IF target_id IS NOT NULL AND target_id <> source_id THEN
+        UPDATE public.character_perks SET compounds_with = target_id WHERE id = source_id;
+      END IF;
+    END LOOP;
+  END IF;
+
+  RETURN saved;
+END;
+$$;

--- a/supabase/migrations/20260728000001_level_up_character_atomic_permissions.sql
+++ b/supabase/migrations/20260728000001_level_up_character_atomic_permissions.sql
@@ -1,0 +1,1 @@
+REVOKE ALL ON FUNCTION public.level_up_character_atomic(uuid, uuid, jsonb, jsonb) FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260728000002_level_up_character_atomic_service_role.sql
+++ b/supabase/migrations/20260728000002_level_up_character_atomic_service_role.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION public.level_up_character_atomic(uuid, uuid, jsonb, jsonb) TO service_role;

--- a/util/seed-admin.js
+++ b/util/seed-admin.js
@@ -5,6 +5,17 @@ import readline from "node:readline";
 import { stdin as input, stdout as output } from "node:process";
 
 function confirmIsDevEnv() {
+  // Non-interactive callers (CI, the setup/seed orchestrators, or a piped
+  // stdin) can't answer a prompt — auto-confirm instead of hanging.
+  const autoYes =
+    process.env.CI ||
+    process.argv.includes("--yes") ||
+    process.argv.includes("-y") ||
+    !process.stdin.isTTY;
+  if (autoYes) {
+    return Promise.resolve(true);
+  }
+
   const rl = readline.createInterface({
     input,
     output,

--- a/views/partials/similar-missions.handlebars
+++ b/views/partials/similar-missions.handlebars
@@ -9,7 +9,7 @@
         <li class="similar-mission-item">
           <div class="similar-mission-info">
             <a href="/missions/{{id}}" target="_blank" class="similar-mission-name">{{name}}</a>
-            <span class="similar-mission-date">{{formatDate date}}</span>
+            <span class="similar-mission-date">{{#if ../profile}}{{date_tz date "MMM D, YYYY" ../profile.timezone}}{{else}}{{date date "MMM D, YYYY"}}{{/if}}</span>
             {{#if creator_name}}
               <span class="similar-mission-creator">by {{creator_name}}</span>
             {{/if}}

--- a/views/partials/similar-missions.test.js
+++ b/views/partials/similar-missions.test.js
@@ -1,0 +1,41 @@
+const { test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const { date_tz } = require('../../util/handlebars');
+
+// Register the same date helpers the real app registers (see app.js), plus the
+// full handlebars-helpers set so template helpers like `eq` resolve. If the
+// template references a helper that isn't registered, rendering throws
+// "Missing helper".
+require('handlebars-helpers')({ handlebars: Handlebars });
+Handlebars.registerHelper('date_tz', date_tz);
+
+function renderPartial(context) {
+  const src = fs.readFileSync(
+    path.join(__dirname, 'similar-missions.handlebars'),
+    'utf8'
+  );
+  return Handlebars.compile(src)(context);
+}
+
+test('similar-missions renders each mission name and a human-readable date without a missing-helper error', () => {
+  const context = {
+    profile: { timezone: 'America/New_York' },
+    missions: [
+      {
+        id: 'm1',
+        name: 'Op Nightfall',
+        date: '2026-07-15T18:00:00Z',
+        creator_name: 'Alice',
+        characters: [{}, {}]
+      }
+    ]
+  };
+
+  const html = renderPartial(context);
+
+  expect(html).toContain('Op Nightfall');
+  expect(html).toContain('2026');
+  expect(html).toMatch(/Jul(y)?/);
+});


### PR DESCRIPTION
## Summary

Completes the character mutation service boundary (ar-m8ai), finishing the seam that ar-ezes (#141) began. After this change, `routes/characters.js` handlers only translate HTTP and render responses — every character mutation is a named `CharacterService` method with a tested contract and a real transaction boundary.

**Stacked on #141** (`consolidate-service-role`). Review/merge that first.

Acceptance criterion met: *"All character mutations are implemented as named use cases/services with tested contracts and transaction boundaries; route handlers only translate HTTP and render responses."*

## The four extractions

1. **Wizard validation → input layer.** `POST /wizard` no longer re-implements name/stat/level coercion; it delegates to `normalizeWizardPayload` in `services/character/input.js`.
2. **Perk/named-array reshaping → input layer.** Route-local `collectAbilityPerks`/`collectNamed` are gone; `collectCharacterFormArrays` assembles ability_perks/quirks/accessories for `POST /` and `PUT /:id`.
3. **Offscreen missions → `CharacterService`.** `create/update/deleteOffscreenMission(actor, charId, …)` methods carry authorization (`canMutateCharacter`), validation, and the conduit-credit gate; the three route handlers are now thin `asyncHandler` wrappers. Inline `creator_id !==` checks and `resolveOffscreenSource` removed from the route.
4. **Atomic level-up.** Terminal writes (owned-field counters + perk insert + perk-link update) move into a new `level_up_character_atomic` `SECURITY DEFINER` RPC that runs as one transaction. Derivation stays in JS; backfill/offscreen creation stay sequential upstream (cross-domain, re-derivable). A rollback integration test proves no partial state on mid-sequence failure.

## Constraints preserved (from ar-ezes)

- `supabaseAdmin` confined to `models/_base.js` + `services/*/repository.js`.
- Authorization denials **throw** `AuthorizationError` → 403; business-rule failures return `{ data, error }`.
- Double-guard kept: creator-only writes retain both the JS policy check and the SQL `creator_id` filter.
- Every touched handler is `asyncHandler`-wrapped (Express 4 does not catch async throws).

## Testing

- `bun run test:unit` — exit 0
- `bun run test:http` — exit 0
- `bun run test:integration` — exit 0 (incl. new level-up rollback test, 3/3)

## Docs

- Design: `docs/superpowers/specs/2026-07-28-complete-character-service-boundary-design.md`
- Plan: `docs/superpowers/plans/2026-07-28-complete-character-service-boundary.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
