### PR TITLE
Auth redirect fixes and local-dev seed corrections (ar-h6rt, ar-w9d2, ar-t2mv, ar-p8kq)

### DIFF
--- a/.tickets/ar-c5nx.md
+++ b/.tickets/ar-c5nx.md
@@ -1,0 +1,42 @@
+---
+id: ar-c5nx
+status: open
+deps: [ar-w9d2, ar-7v3k]
+links: []
+created: 2026-08-02T02:35:10Z
+type: bug
+priority: 3
+assignee: David Torres
+tags: [character-wizard, error-handling, local-dev]
+---
+# Character wizard throws a cryptic TypeError when its class pool is empty
+
+`public/js/character-wizard.js:1675` picks an initial class with a three-step fallback — saved state, then the preselected class, then a random pick:
+
+```js
+: DATA.classes[Math.floor(Math.random() * DATA.classes.length)].id);
+```
+
+With an empty `DATA.classes`, `Math.random() * 0` is `0`, `DATA.classes[0]` is `undefined`, and the wizard dies on:
+
+```
+Uncaught TypeError: can't access property "id", DATA.classes[Math.floor(...)] is undefined
+```
+
+The class pool is built by `filterClassDataForUser(user)` (`routes/characters.js:191`), which filters by unlock — so any user with zero unlocked classes gets a blank page and an error that says nothing about the actual cause.
+
+ar-w9d2 fixed the reason the pool was empty locally (starter-unlock ids could never match seeded class ids). This ticket is the defence-in-depth half: the *next* time the pool is empty for any reason, the failure should name itself instead of surfacing as an undefined property access.
+
+## Why this is not fixed already
+
+Deferred deliberately. The fix is client-side JS, and at the time ar-w9d2 was written `complete-character-service` had no way to test client JS — `jsdom` and `test/helpers/alpine-dom.js` were added by the Alpine adoption branch (ar-7v3k) and had not merged. The route path is no easier: `routes/characters.test.js` is in the `httpFiles` set and needs a live Supabase, so it is not unit-runnable.
+
+Writing the guard untested would have broken the TDD discipline; duplicating the harness would have conflicted with the ar-7v3k PR. Hence the `deps`.
+
+## Do this after ar-7v3k merges
+
+The harness arrives with it, and the guard can then be written test-first like anything else.
+
+## Acceptance Criteria
+
+An empty class pool produces a clear, actionable message naming the cause rather than a TypeError, and the wizard does not attempt to select a class it does not have. The behavior is covered by a test that fails without the guard. Consider whether the server should refuse to render the wizard at all in that state — a redirect with a message may serve the user better than an empty wizard shell.

--- a/.tickets/ar-h6rt.md
+++ b/.tickets/ar-h6rt.md
@@ -1,0 +1,72 @@
+---
+id: ar-h6rt
+status: open
+deps: []
+links: []
+created: 2026-08-02T02:35:10Z
+type: bug
+priority: 1
+assignee: David Torres
+tags: [auth, htmx, navigation, hx-boost]
+---
+# Auth redirect leaves the URL stale, trapping the user on the last protected page
+
+Reproduced on an admin account: navigate to `/nav/manage`, then click anything. Every click runs an auth check and lands back on `/nav/manage`. The user cannot leave without editing the address bar.
+
+Pre-existing — not introduced by ar-7v3k (Alpine adoption) or the seed fixes. `public/js/app.js`'s auth logic is byte-identical across all three branches; it was last touched by `15ab2f6` (security audit).
+
+## Mechanism
+
+`redirectTo()` (`public/js/app.js:955-965`) does not navigate. It performs an htmx body swap:
+
+```js
+function redirectTo(url) {
+  const headers = { 'redirect-to': url };
+  if (token && refresh) { headers['Authorization'] = …; headers['Refresh-Token'] = …; }
+  htmx.ajax('GET', url, { target: 'body', swap: 'outerHTML', headers });
+}
+```
+
+There is no `hx-push-url` and no `history.pushState`/`replaceState` anywhere near it — the only `history` call in the file is the unrelated anchor-copy helper at line 881. **So `window.location` never changes.** The body shows one page while the address bar shows another.
+
+That matters because of the surrounding design. Auth tokens live in `localStorage` and are attached only to htmx requests via `htmx:configRequest`; a plain browser navigation carries no `Authorization` header. So `isAuthenticated` (`util/auth.js:33-46`) bounces every direct load of a protected route:
+
+```
+GET /nav/manage           (no Authorization header)
+  → 302 /auth/check?r=%2Fnav%2Fmanage
+      → renders auth-check, calls App.checkSessionNow()
+          → INITIAL_SESSION fires with a session
+              → getRedirectUrl() reads ?r= → redirectTo('/nav/manage')
+                  → htmx swaps the body to /nav/manage
+```
+
+The page now *shows* `/nav/manage`, but `window.location` is still `/auth/check?r=%2Fnav%2Fmanage`.
+
+`getRedirectUrl()` (`app.js:967-978`) reads `?r=` from `window.location`. Because that URL is frozen, **every later auth-state event re-reads the same stale `?r=` and swaps the body back to the same target** (`app.js:1000-1002` for `INITIAL_SESSION`, `1029-1031` for `SIGNED_IN`). Supabase fires these on token refresh, tab focus, and client re-init, so the bounce recurs indefinitely.
+
+A second, related defect in the same function compounds it: on a non-auth page with no `?r=`, `INITIAL_SESSION` schedules `redirectTo(current)` on a **100 ms timer** (`app.js:1005-1010`), capturing the URL at event time. Under `hx-boost` the user can navigate within that window, and the timer then yanks them back to the captured page.
+
+## Why `/nav/manage` in particular
+
+Nothing about that route is special — it is simply a protected page reached from the Admin dropdown, so it is a natural place to land and then try to leave. Any `isAuthenticated` route reached by direct load can trap the same way.
+
+## Fix direction
+
+The body swap needs to be accompanied by a history update so the address bar matches what is rendered — either `history.replaceState` after the swap, or htmx's own push-url mechanism. Once the URL tracks the content, the stale `?r=` disappears and the loop cannot re-arm.
+
+Take care: this is the code path `15ab2f6` hardened against open redirects. `getRedirectUrl()` deliberately rejects protocol-relative, absolute and backslash-prefixed values. Any change must preserve that, and must not start reflecting an attacker-supplied `?r=` into `history` — writing an unvalidated value into the address bar is strictly worse than swapping a body, because it persists and can be copied or reloaded.
+
+**The client and server validators do not actually agree**, despite the comment at `app.js:970` claiming the client "mirrors the server-side isSameOriginPath check":
+
+| input | server `isSameOriginPath` (`util/auth.js:9-14`) | client `getRedirectUrl` (`app.js:973`) |
+|---|---|---|
+| `//evil.com` | rejected | rejected |
+| `/\evil.com` | **accepted** | rejected |
+
+The client is stricter. `/\` is historically normalised like `//` by some browsers, which is why the client rejects it; the server's check only tests `startsWith('//')`. Any guard added for the history write must use the **stricter** rule. Whether the server check should be tightened to match is worth deciding separately — it feeds `redirect-to` header handling at `util/auth.js:36` and `:74`.
+
+The 100 ms timer should also be reconsidered: capturing a URL and acting on it later is unsound under boosted navigation regardless of the history fix.
+
+## Acceptance Criteria
+
+After an auth-driven redirect the address bar matches the rendered page, so a reload or a copied link goes where the user actually is. Navigating away from a protected page succeeds and does not bounce back on a later auth event. The open-redirect protections on `?r=` remain intact, with a test covering the rejected forms. A boosted navigation during the post-auth window is not undone by a stale timer.

--- a/.tickets/ar-p8kq.md
+++ b/.tickets/ar-p8kq.md
@@ -1,0 +1,48 @@
+---
+id: ar-p8kq
+status: open
+deps: []
+links: [ar-w9d2, ar-t2mv]
+created: 2026-08-02T02:35:10Z
+type: bug
+priority: 2
+assignee: David Torres
+tags: [seeding, local-dev, rules-pdf, starter-unlocks]
+---
+# Starter rules-PDF unlock fails on every local profile creation
+
+`models/profile.js` grants a starter rules-PDF unlock referencing `STARTER_RULES_PDF_ID` (now in `util/starter-content.js`), a production UUID. Nothing seeds `rules_pdfs`, so on any locally-seeded install every profile creation logs:
+
+```
+Failed to grant starter rules unlock: {
+  code: "23503",
+  details: 'Key (rules_pdf_id)=(a10948ac-...) is not present in table "rules_pdfs".'
+}
+```
+
+The error is logged and swallowed, so profile creation succeeds but the user gets no rules unlock and the Library shows nothing they can open.
+
+This is the last of three symptoms of the same root cause — the local seed does not produce a usable environment. ar-w9d2 fixed the starter *class* ids; ar-t2mv fixed empty class gear/abilities; this is the rules half.
+
+## Why it was not fixed alongside those
+
+`rules_pdfs.storage_path` is `NOT NULL` and points at an object in the `rules-pdfs` bucket. The real rules PDF is not in the repo and cannot be, so seeding this row is not a pure-data change like the other two — it needs a deliberate placeholder, which is a product decision rather than a mechanical fix.
+
+## What makes this tractable
+
+- The `rules-pdfs` bucket **already exists locally** — created by `supabase/migrations/20240101000000_baseline_schema.sql:1429`, with RLS policies alongside it.
+- The upload path convention is `<rulesPdfId>/<timestamp>-<sanitized-name>.pdf` (`models/pdf.js:70-84`).
+- `models/pdf.js` validates that uploads begin with the `%PDF-` signature, so a placeholder must be a genuinely valid PDF, not an empty file.
+- `rules_pdfs` is `UNIQUE (edition, title)`, and per `util/rules-family.js` the `edition` column holds the *version* while versions of one product share a `title` — so an unlock on one version covers the whole title family.
+
+Only the **id** must match `STARTER_RULES_PDF_ID`; title and edition are free to be local-appropriate values, since nothing outside this row depends on them.
+
+## Approach
+
+Add a seed step in the established shape — `util/seed-rules.js` exposed as `bun run seed:rules`, called from `scripts/seed-local.mjs` after classes, idempotent (skip when the row already exists) like every other step there.
+
+It should upload a small, valid placeholder PDF to the `rules-pdfs` bucket and insert the row with `STARTER_RULES_PDF_ID`. The placeholder's content must make clear on sight that it is local seed data and not the real rules, so nobody mistakes it for the product.
+
+## Acceptance Criteria
+
+Profile creation against a freshly-seeded local database completes with no foreign-key error and grants a working rules unlock; the Library lists the entry and it opens. The row's id is derived from `util/starter-content.js` rather than restated, so it cannot drift from the grant. Re-running the seed is safe. The placeholder is unmistakably identifiable as such.

--- a/.tickets/ar-t2mv.md
+++ b/.tickets/ar-t2mv.md
@@ -1,0 +1,43 @@
+---
+id: ar-t2mv
+status: open
+deps: []
+links: [ar-w9d2]
+created: 2026-08-02T02:35:10Z
+type: bug
+priority: 1
+assignee: David Torres
+tags: [seeding, local-dev, classes]
+---
+# Seeded classes have no gear or abilities
+
+`util/seed-classes.js` builds each class row with `name`, `description`, `is_public`, `status`, `is_player_created`, `rules_edition`, `rules_version`, `stat_spread` and `created_by` — and never sets `gear` or `abilities`. Those columns default to `'[]'::jsonb` (`supabase/migrations/20240101000000_baseline_schema.sql:139-140`), so every seeded class lands with both empty:
+
+```
+[{"name":"Gunslinger","gear":[],"abilities":[]},
+ {"name":"Illusionist","gear":[],"abilities":[]}]
+```
+
+The data exists and is complete. `util/enclave-consts.js` exports `classGearList` (line 31) and `classAbilityList` (line 170) covering **all 17** seeded classes — 6 gear items and 3 abilities for Gunslinger, none missing for any class. The seed imports `classStatSpread` from that same module but not these two.
+
+## Consequence
+
+The character wizard's steps 3 and 4 are built entirely from this data (`routes/characters.js` maps `c.gear` into `class_gear` with base/elective badging, and `c.abilities` into `abilities_html` for the step-3 primer). With both empty, a locally-seeded install gets a wizard with no abilities to read and no gear to spend Merx on — the class-selection and gear-shop steps render empty. Class detail pages are likewise bare.
+
+Same root cause as ar-w9d2: the local seed produces classes that are not actually usable. Different symptom, and not fixed by that change — ar-w9d2 only aligned the six starter-class ids.
+
+## Required shape
+
+`gear` and `abilities` are JSONB arrays of `{ name, description }`, per the authoritative construction in `routes/classes.js:583-587` (abilities) and `:597-601` (gear):
+
+```js
+{ name: <string>, description: <string> }
+```
+
+The consts hold plain name strings, so the seed must map each to an object. An empty `description` matches what the seed already does for the class's own `description` field — the descriptive text is authored later through the UI.
+
+Note `class_gear` and `class_abilities` are **different tables**, keyed by `character_id` — they are per-character instances, not the class template. This ticket concerns only the JSONB columns on `classes`.
+
+## Acceptance Criteria
+
+A freshly-seeded class carries its full gear and ability lists in the shape the app writes and reads, so the wizard's ability primer and gear shop are populated. The seed and the const data cannot silently diverge — a class gaining gear data in `enclave-consts.js` without the seed picking it up should fail a test.

--- a/.tickets/ar-w9d2.md
+++ b/.tickets/ar-w9d2.md
@@ -1,0 +1,59 @@
+---
+id: ar-w9d2
+status: open
+deps: []
+links: []
+created: 2026-08-02T02:35:10Z
+type: bug
+priority: 1
+assignee: David Torres
+tags: [seeding, local-dev, character-wizard, starter-unlocks]
+---
+# Character wizard is unreachable on a freshly-seeded local database
+
+`models/profile.js:9-18` hardcodes **production** UUIDs for the starter content granted to every new profile:
+
+```js
+const STARTER_RULES_PDF_ID = 'a10948ac-5f78-481f-9e53-c582b59926cd'; // Enclave: Advent v1
+const STARTER_CLASS_IDS = [
+  'b6ce893b-8207-4f89-abfc-a02ae0e9b65d', // Gunslinger
+  ... // Illusionist, Librarian, Thane, Thunderbird, Wanderer
+];
+```
+
+`util/seed-classes.js` does not set ids, so Postgres generates fresh ones — a locally-seeded Gunslinger is `37335ace-…`, not `b6ce893b-…`. Nothing seeds `rules_pdfs` at all. The starter grant therefore fails with foreign-key violations on every new profile:
+
+```
+Failed to grant starter class unlocks: {
+  code: "23503",
+  details: 'Key (class_id)=(b6ce893b-...) is not present in table "classes".'
+}
+Failed to grant starter rules unlock: {
+  code: "23503",
+  details: 'Key (rules_pdf_id)=(a10948ac-...) is not present in table "rules_pdfs".'
+}
+```
+
+Those errors are logged and swallowed, so the profile is created with **zero unlocked classes**.
+
+## Downstream symptom
+
+`routes/characters.js:191` builds the wizard's class pool via `filterClassDataForUser(user)`, which filters by unlock. With no unlocks the pool is empty, and `public/js/character-wizard.js:1675` random-picks from it without a guard:
+
+```js
+: DATA.classes[Math.floor(Math.random() * DATA.classes.length)].id);
+```
+
+`Math.random() * 0` is `0`, `DATA.classes[0]` is `undefined`, and the wizard dies with an unhelpful:
+
+```
+Uncaught TypeError: can't access property "id", DATA.classes[Math.floor(...)] is undefined
+```
+
+Net effect: **the character wizard has never worked on a locally-seeded database**, and the failure presents as a cryptic TypeError rather than anything pointing at seeding. `scripts/seed-local.mjs` does not address starter unlocks either, so `bun run setup` / `seed:local` does not produce a working wizard.
+
+Not caused by the Alpine adoption branch (ar-7v3k) — `character-wizard.js` and `character-wizard.handlebars` are byte-identical across it.
+
+## Acceptance Criteria
+
+A profile created against a freshly-seeded local database receives its starter unlocks without foreign-key errors, and the character wizard loads with a usable class pool. The seed and the starter-ID constants cannot silently drift apart again — that invariant is pinned by a test. Separately, an empty class pool produces a clear, actionable message rather than a TypeError, so the next seeding gap is self-diagnosing.

--- a/docs/superpowers/plans/2026-08-03-e2e-browser-tier.md
+++ b/docs/superpowers/plans/2026-08-03-e2e-browser-tier.md
@@ -1,0 +1,2349 @@
+# End-to-End Browser Test Tier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fourth test tier that drives a real Chromium browser against the locally-booted app, converting the thirteen manual browser checks recorded on `ar-7v3k` and `ar-h6rt` into automated specs.
+
+**Architecture:** `@playwright/test` runs specs from `e2e/specs/` against a server the runner boots on port 3100, backed by the local Supabase stack. A global setup signs two accounts in through the real `/auth` form and saves their `localStorage` as Playwright `storageState`. Each spec seeds only the rows it needs through `supabaseAdmin` + `pg` under a unique prefix and deletes them afterwards, so the developer's local dev data is never touched.
+
+**Tech Stack:** `@playwright/test` (Chromium only), Node 25 (Playwright's runner), Bun 1.3.3 (the app server), Express 4, Supabase JS v2, `pg`, htmx 2.0.8, Alpine.js 3.15.12.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-e2e-browser-tier-design.md`
+**Tickets:** ar-7v3k (checks 1-12), ar-h6rt (check 13)
+
+## Global Constraints
+
+- **These are characterization tests. They are expected to PASS on first run.** This is NOT a red-green cycle. If a spec fails, **stop: you have probably found a real bug. Do not change production code to make it pass.** Record it in the findings report (Task 17) and move to the next task.
+- The one legitimate exception is a spec whose *expectation* is wrong — a misreading of intended behavior. Fix the spec, and note in the findings why it was an expectation bug rather than a product bug.
+- **Never modify anything under `public/`, `views/`, `routes/`, `models/`, `services/`, or `util/`.** This plan only adds files under `e2e/`, plus `playwright.config.js`, `package.json`, `.gitignore`, CI, and docs.
+- Prerequisites for every task: `supabase start` is running and `bun run seed:local` has been run at least once. `.env` must have `SUPABASE_URL="http://127.0.0.1:54321"` (it already does).
+- The app server for tests runs on **port 3100**, never 3000 — port 3000 belongs to the developer's `bun run dev`.
+- Seeded admin credentials are `dummy@testing.com` / `dummypassword` (`util/seed-admin.js:43-44`). Never hardcode them anywhere but `e2e/global-setup.js`.
+- Fixture rows are always named with a per-run unique prefix and always deleted in `afterAll`. Never call `supabase db reset` from a spec.
+- Existing tiers stay untouched: do not edit `scripts/run-tests.mjs` or `scripts/check.mjs`. Playwright does its own file discovery.
+- Commit prefix `test:` for spec commits, `chore:` for tooling, `docs:` for documentation — matching repo history.
+- The CI workflow lands **last** (Task 17), so a red spec never turns `main` red before the user has triaged it.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `playwright.config.js` (create) | Runner config, `webServer`, local-Supabase guard, artifact policy |
+| `e2e/global-setup.js` (create) | Provision + sign in admin and player; write `storageState` |
+| `e2e/fixtures/db.js` (create) | `pg` connection, prefix generator, profile lookup, cleanup-by-prefix |
+| `e2e/fixtures/character.js` (create) | Seed characters, abilities, perks, offscreen missions |
+| `e2e/fixtures/class.js` (create) | Seed classes |
+| `e2e/specs/*.spec.js` (create) | One file per checklist item |
+| `package.json` (modify) | `test:e2e` script, `@playwright/test` devDependency |
+| `.gitignore` (modify) | `e2e/.auth/`, `e2e/report/` |
+| `.github/workflows/e2e.yml` (create) | CI tier |
+| `README.md`, `CONTRIBUTING.md` (modify) | Document the fourth tier |
+| `docs/superpowers/reports/2026-08-03-e2e-findings.md` (create) | Findings report |
+
+---
+
+## Phase 0 — Tier infrastructure
+
+### Task 1: Playwright tier boots and runs one spec
+
+**Files:**
+- Create: `playwright.config.js`
+- Create: `e2e/specs/00-smoke.spec.js`
+- Modify: `package.json` (scripts + devDependencies)
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Produces: `baseURL` of `http://127.0.0.1:3100` available to every later spec via Playwright's `page.goto('/path')`; the `chromium` project; `bun run test:e2e`.
+
+- [ ] **Step 1: Install Playwright and its browser**
+
+```bash
+bun add -d @playwright/test
+bunx playwright install --with-deps chromium
+```
+
+- [ ] **Step 2: Create `playwright.config.js`**
+
+```js
+// Fourth test tier: real-browser coverage for behavior the unit (jsdom),
+// http (mocked-model Express), and integration (Supabase, no browser) tiers
+// structurally cannot reach — htmx swaps, Alpine's settle phase, boosted
+// navigation, and the back button.
+require('./util/env');
+const { defineConfig, devices } = require('@playwright/test');
+
+// Same guard the integration tier applies at scripts/run-tests.mjs:44-48.
+// Pointing this suite at a cloud project would seed and delete rows there.
+const supabaseUrl = process.env.SUPABASE_URL || '';
+if (!/^http:\/\/(127\.0\.0\.1|localhost):54321\/?$/.test(supabaseUrl)) {
+  throw new Error(
+    'E2E tests require local Supabase: set SUPABASE_URL=http://127.0.0.1:54321 ' +
+    'after `supabase start`, then run `bun run seed:local`.'
+  );
+}
+
+// 3100, not 3000: the developer's `bun run dev` owns 3000 and the suite must
+// be runnable without stopping it.
+const port = Number(process.env.E2E_PORT || 3100);
+const baseURL = `http://127.0.0.1:${port}`;
+
+module.exports = defineConfig({
+  testDir: './e2e/specs',
+  outputDir: './e2e/report/artifacts',
+  globalSetup: require.resolve('./e2e/global-setup'),
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
+  retries: process.env.CI ? 1 : 0,
+  forbidOnly: !!process.env.CI,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'e2e/report/html', open: 'never' }]
+  ],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
+  ],
+  webServer: {
+    command: `PORT=${port} bun run index.js`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: 'pipe',
+    stderr: 'pipe'
+  }
+});
+```
+
+- [ ] **Step 3: Add the script to `package.json`**
+
+Add to `"scripts"`, after `"test:integration"`:
+
+```json
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+```
+
+- [ ] **Step 4: Add artifact directories to `.gitignore`**
+
+Append to `.gitignore`:
+
+```
+e2e/.auth/
+e2e/report/
+```
+
+- [ ] **Step 5: Create a temporary no-op global setup**
+
+Task 2 replaces this. It exists now only so the config resolves.
+
+```js
+// e2e/global-setup.js
+module.exports = async () => {};
+```
+
+- [ ] **Step 6: Write the smoke spec**
+
+```js
+// e2e/specs/00-smoke.spec.js
+//
+// Proves the tier itself works: the server boots, Alpine and htmx load from
+// their pinned CDNs, and no x-cloak element is left visible. x-cloak surviving
+// past Alpine's start is the signature of Alpine failing to initialise, which
+// would make every other spec in this suite fail for the wrong reason.
+const { test, expect } = require('@playwright/test');
+
+test('home page boots with Alpine and htmx initialised', async ({ page }) => {
+  const consoleErrors = [];
+  page.on('console', (msg) => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Agent Resources/);
+
+  // Alpine sets window.Alpine on start; htmx sets window.htmx on load.
+  await expect.poll(() => page.evaluate(() => typeof window.Alpine)).toBe('object');
+  expect(await page.evaluate(() => typeof window.htmx)).toBe('object');
+
+  // Alpine strips x-cloak from every element it initialises.
+  const cloaked = page.locator('[x-cloak]');
+  for (let i = 0; i < await cloaked.count(); i++) {
+    await expect(cloaked.nth(i)).toBeHidden();
+  }
+
+  expect(consoleErrors).toEqual([]);
+});
+
+test('the navbar burger toggles the menu', async ({ page }) => {
+  await page.goto('/');
+  const burger = page.locator('#navbar-burger');
+  const menu = page.locator('#navbar-menu');
+
+  await expect(menu).not.toHaveClass(/is-active/);
+  await burger.click();
+  await expect(menu).toHaveClass(/is-active/);
+  await burger.click();
+  await expect(menu).not.toHaveClass(/is-active/);
+});
+```
+
+- [ ] **Step 7: Run it**
+
+Run: `bun run test:e2e`
+Expected: 2 passed. If the server fails to boot, the failure text will name the missing env var or port conflict.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add playwright.config.js e2e/ package.json bun.lock .gitignore
+git commit -m "chore: add a Playwright browser test tier (ar-7v3k)"
+```
+
+---
+
+### Task 2: Two signed-in accounts via the real auth form
+
+**Files:**
+- Modify: `e2e/global-setup.js` (replace the Task 1 stub)
+- Create: `e2e/specs/01-auth-state.spec.js`
+
+**Interfaces:**
+- Produces:
+  - `e2e/.auth/admin.json` — storageState for `dummy@testing.com` (role `admin`).
+  - `e2e/.auth/player.json` — storageState for `e2e-player@testing.com` (role `user`).
+  - Exported constants from `e2e/global-setup.js`:
+    `ADMIN_EMAIL` (`'dummy@testing.com'`), `ADMIN_PASSWORD` (`'dummypassword'`),
+    `PLAYER_EMAIL` (`'e2e-player@testing.com'`), `PLAYER_PASSWORD` (`'e2e-player-password'`),
+    `ADMIN_STATE` (absolute path to `admin.json`), `PLAYER_STATE` (absolute path to `player.json`).
+- Later specs select an identity with `test.use({ storageState: ADMIN_STATE })`.
+
+**Background the implementer needs:** auth tokens live in `localStorage` as
+`authToken` / `refreshToken` (`public/js/app.js:74-92`) and are attached to htmx
+requests by an `htmx:configRequest` handler. A plain browser navigation carries
+no `Authorization` header, which is why direct loads of protected routes bounce
+through `/auth/check?r=`. Playwright's `storageState` captures `localStorage`
+per origin, so signing in once and reusing the state works — and signing in
+through the real form (rather than injecting tokens) makes the setup itself a
+check on that contract.
+
+- [ ] **Step 1: Replace `e2e/global-setup.js`**
+
+```js
+// Signs both test identities in through the REAL /auth form and saves their
+// localStorage as Playwright storageState.
+//
+// Deliberately not injecting tokens directly: public/js/app.js:74-92 owns the
+// authToken/refreshToken contract, and that contract is refactor-adjacent. If
+// sign-in breaks, every spec should fail loudly here rather than mysteriously
+// later.
+require('../util/env');
+const path = require('node:path');
+const fs = require('node:fs');
+const { chromium } = require('@playwright/test');
+const { supabaseAdmin } = require('../models/_base');
+
+const ADMIN_EMAIL = 'dummy@testing.com';
+const ADMIN_PASSWORD = 'dummypassword';
+const PLAYER_EMAIL = 'e2e-player@testing.com';
+const PLAYER_PASSWORD = 'e2e-player-password';
+
+const authDir = path.join(__dirname, '.auth');
+const ADMIN_STATE = path.join(authDir, 'admin.json');
+const PLAYER_STATE = path.join(authDir, 'player.json');
+
+// The player account is infrastructure, not fixture data: fixed address,
+// created idempotently (exactly as util/seed-admin.js treats the admin), never
+// torn down. It exists so specs can distinguish "a character you own" from one
+// you don't. It needs the admin API rather than the direct `insert into
+// auth.users` the fixtures use, because it must be able to sign in with a
+// password.
+const ensurePlayer = async () => {
+  const { data: list, error: listError } = await supabaseAdmin.auth.admin.listUsers();
+  if (listError) throw listError;
+
+  let user = list.users.find((u) => u.email === PLAYER_EMAIL);
+  if (!user) {
+    const { data, error } = await supabaseAdmin.auth.admin.createUser({
+      email: PLAYER_EMAIL,
+      password: PLAYER_PASSWORD,
+      email_confirm: true
+    });
+    if (error) throw error;
+    user = data.user;
+  }
+
+  const { data: profile } = await supabaseAdmin
+    .from('profiles').select('id').eq('user_id', user.id).maybeSingle();
+  if (!profile) {
+    const { error } = await supabaseAdmin.from('profiles').insert({
+      user_id: user.id, name: 'E2E Player', is_public: true, timezone: 'UTC', role: 'user'
+    });
+    if (error) throw error;
+  }
+};
+
+const signIn = async (browser, baseURL, email, password, statePath) => {
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
+
+  await page.goto('/auth');
+  await page.fill('#signin-email', email);
+  await page.fill('#signin-password', password);
+  await page.click('#signin-submit');
+
+  // App.signIn writes both keys on success; waiting on them rather than on a
+  // URL avoids racing the post-sign-in redirect.
+  await page.waitForFunction(
+    () => !!localStorage.getItem('authToken') && !!localStorage.getItem('refreshToken'),
+    null,
+    { timeout: 15_000 }
+  );
+
+  await context.storageState({ path: statePath });
+  await context.close();
+};
+
+module.exports = async (config) => {
+  const baseURL = config.projects[0].use.baseURL;
+  fs.mkdirSync(authDir, { recursive: true });
+
+  await ensurePlayer();
+
+  const browser = await chromium.launch();
+  try {
+    await signIn(browser, baseURL, ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_STATE);
+    await signIn(browser, baseURL, PLAYER_EMAIL, PLAYER_PASSWORD, PLAYER_STATE);
+  } finally {
+    await browser.close();
+  }
+};
+
+module.exports.ADMIN_EMAIL = ADMIN_EMAIL;
+module.exports.ADMIN_PASSWORD = ADMIN_PASSWORD;
+module.exports.PLAYER_EMAIL = PLAYER_EMAIL;
+module.exports.PLAYER_PASSWORD = PLAYER_PASSWORD;
+module.exports.ADMIN_STATE = ADMIN_STATE;
+module.exports.PLAYER_STATE = PLAYER_STATE;
+```
+
+- [ ] **Step 2: Confirm the sign-in form's real selectors**
+
+The selectors above (`#signin-email`, `#signin-password`, `#signin-submit`) are
+the expected ids. **Verify them before running** — open
+`views/partials/signin-form.handlebars` and correct the three selectors if they
+differ. Do not guess; the file is short.
+
+```bash
+grep -n 'id=\|name=\|type="submit"' views/partials/signin-form.handlebars
+```
+
+- [ ] **Step 3: Write the spec**
+
+```js
+// e2e/specs/01-auth-state.spec.js
+//
+// Guards the two storageStates global-setup produces. If either identity stops
+// authenticating, this fails first and explains why the rest of the suite did.
+const { test, expect } = require('@playwright/test');
+const { ADMIN_STATE, PLAYER_STATE } = require('../global-setup');
+
+test.describe('admin identity', () => {
+  test.use({ storageState: ADMIN_STATE });
+
+  test('reaches a protected admin route without bouncing', async ({ page }) => {
+    await page.goto('/nav/manage');
+    await expect(page.locator('body')).toContainText(/nav/i);
+  });
+});
+
+test.describe('player identity', () => {
+  test.use({ storageState: PLAYER_STATE });
+
+  test('is signed in but is not an admin', async ({ page }) => {
+    await page.goto('/profile');
+    const token = await page.evaluate(() => localStorage.getItem('authToken'));
+    expect(token).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 4: Run it**
+
+Run: `bun run test:e2e e2e/specs/01-auth-state.spec.js`
+Expected: 2 passed.
+
+Note: `/nav/manage` is the exact route `ar-h6rt` reports as trapping users. If
+this spec passes, the `ar-h6rt` fixes on this branch are holding for the
+authenticated path; Task 16 tests the unauthenticated path that actually
+triggered the bug.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/global-setup.js e2e/specs/01-auth-state.spec.js
+git commit -m "test: sign both e2e identities in through the real auth form (ar-7v3k)"
+```
+
+---
+
+### Task 3: Fixture layer
+
+**Files:**
+- Create: `e2e/fixtures/db.js`
+- Create: `e2e/fixtures/character.js`
+- Create: `e2e/fixtures/class.js`
+- Create: `e2e/specs/02-fixtures.spec.js`
+
+**Interfaces:**
+- Produces, from `e2e/fixtures/db.js`:
+  - `connect() -> Promise<pg.Client>`
+  - `newPrefix(spec: string) -> string`
+  - `profileForEmail(db, email) -> Promise<{id, user_id, name, ...}>`
+  - `cleanupByPrefix(db, prefix) -> Promise<void>`
+- Produces, from `e2e/fixtures/class.js`:
+  - `seedClass(prefix, { name?, rulesVersion?, isPublic?, abilities?, gear? }) -> Promise<classRow>`
+- Produces, from `e2e/fixtures/character.js`:
+  - `seedCharacter(prefix, profile, classRow, overrides?) -> Promise<characterRow>`
+  - `seedPerk(characterId, classAbilityId, text, position?) -> Promise<perkRow>`
+  - `seedOffscreenMission(characterId, profileId, { sourceMissionId, name, summary }) -> Promise<row>`
+
+**Background:** the canonical pattern is
+`models/character-atomic.integration.test.js:22-48` — direct
+`insert into auth.users` via `pg` for auth rows, `supabaseAdmin` for
+application tables. This layer differs in one way: the browser signs in as an
+*already-seeded* account, so fixtures attach rows to that account's existing
+profile rather than creating a throwaway one.
+
+Real table names (verified against the local stack): `characters`, `classes`,
+`class_abilities`, `class_gear`, `traits`, `character_perks`,
+`class_unlock_codes`, `offscreen_missions`, `lfg_posts`, `pages`.
+
+- [ ] **Step 1: Create `e2e/fixtures/db.js`**
+
+```js
+require('../../util/env');
+const { Client } = require('pg');
+
+const connectionString = process.env.SUPABASE_DB_URL
+  || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+const connect = async () => {
+  const db = new Client({ connectionString });
+  await db.connect();
+  return db;
+};
+
+// Every fixture row's name starts with this, so cleanup is a single LIKE and
+// two concurrent runs can never collide.
+const newPrefix = (spec) =>
+  `e2e-${spec}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+const profileForEmail = async (db, email) => {
+  const { rows } = await db.query(
+    `select p.* from profiles p join auth.users u on u.id = p.user_id where u.email = $1`,
+    [email]
+  );
+  if (!rows[0]) {
+    throw new Error(`No profile for ${email}. Run \`bun run seed:local\` and re-run the suite.`);
+  }
+  return rows[0];
+};
+
+// Children are deleted explicitly rather than relying on ON DELETE CASCADE,
+// so this is correct whether or not the FKs cascade.
+const cleanupByPrefix = async (db, prefix) => {
+  const like = `${prefix}%`;
+
+  const { rows: characters } = await db.query(
+    'select id from characters where name like $1', [like]
+  );
+  const characterIds = characters.map((r) => r.id);
+  if (characterIds.length) {
+    for (const table of ['character_perks', 'class_abilities', 'class_gear', 'traits', 'offscreen_missions']) {
+      await db.query(`delete from ${table} where character_id = any($1::uuid[])`, [characterIds]);
+    }
+    await db.query('delete from characters where id = any($1::uuid[])', [characterIds]);
+  }
+
+  const { rows: classes } = await db.query('select id from classes where name like $1', [like]);
+  const classIds = classes.map((r) => r.id);
+  if (classIds.length) {
+    await db.query('delete from class_unlock_codes where class_id = any($1::uuid[])', [classIds]);
+    await db.query('delete from classes where id = any($1::uuid[])', [classIds]);
+  }
+
+  await db.query('delete from lfg_posts where title like $1', [like]);
+  await db.query('delete from pages where title like $1', [like]);
+};
+
+module.exports = { connect, newPrefix, profileForEmail, cleanupByPrefix };
+```
+
+- [ ] **Step 2: Create `e2e/fixtures/class.js`**
+
+```js
+require('../../util/env');
+const { supabaseAdmin } = require('../../models/_base');
+
+const seedClass = async (prefix, {
+  name = `${prefix}-class`,
+  rulesVersion = 'v1',
+  isPublic = true,
+  abilities = [{ name: 'E2E Ability', description: 'Fixture ability' }],
+  gear = []
+} = {}) => {
+  const { data, error } = await supabaseAdmin
+    .from('classes')
+    .insert({ name, rules_version: rulesVersion, is_public: isPublic, gear, abilities })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+};
+
+module.exports = { seedClass };
+```
+
+- [ ] **Step 3: Create `e2e/fixtures/character.js`**
+
+```js
+require('../../util/env');
+const { supabaseAdmin } = require('../../models/_base');
+const { createCharacter } = require('../../models/character');
+
+// The 15 numeric fields createCharacter requires, copied from
+// models/character-atomic.integration.test.js:16-19.
+const BASE_STATS = {
+  vitality: 1, might: 1, resilience: 1, spirit: 1, arcane: 1, will: 1,
+  sensory: 1, reflex: 1, vigor: 1, skill: 1, intelligence: 1, luck: 1,
+  level: 1, completed_missions: 0, commissary_reward: 0
+};
+
+// Goes through the real model seam rather than raw inserts so fixtures cannot
+// drift from what the app itself writes.
+const seedCharacter = async (prefix, profile, classRow, overrides = {}) => {
+  const input = {
+    ...BASE_STATS,
+    name: `${prefix}-character`,
+    class: classRow.name,
+    class_id: classRow.id,
+    trait0: 'Brave',
+    gear: [],
+    abilities: [{ name: 'E2E Ability', class_id: classRow.id }],
+    ...overrides
+  };
+  const { data, error } = await createCharacter(input, profile);
+  if (error) throw error;
+  return data;
+};
+
+// character_perks.class_ability_id references class_abilities.id — the row
+// createCharacter wrote for this character, not the class's ability template.
+const abilityIdFor = async (characterId) => {
+  const { data, error } = await supabaseAdmin
+    .from('class_abilities').select('id').eq('character_id', characterId).limit(1).single();
+  if (error) throw error;
+  return data.id;
+};
+
+const seedPerk = async (characterId, classAbilityId, text, position = 1) => {
+  const { data, error } = await supabaseAdmin
+    .from('character_perks')
+    .insert({ character_id: characterId, class_ability_id: classAbilityId, text, position })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+};
+
+const seedOffscreenMission = async (characterId, profileId, {
+  sourceMissionId = null,
+  name,
+  summary = 'Fixture offscreen mission',
+  sourceMissionName = 'Fixture Source',
+  sourceMissionDate = '2026-01-01'
+}) => {
+  const { data, error } = await supabaseAdmin
+    .from('offscreen_missions')
+    .insert({
+      character_id: characterId,
+      name,
+      summary,
+      source_mission_id: sourceMissionId,
+      source_mission_name: sourceMissionName,
+      source_mission_date: sourceMissionDate,
+      created_by: profileId
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+};
+
+module.exports = { BASE_STATS, seedCharacter, seedPerk, seedOffscreenMission, abilityIdFor };
+```
+
+- [ ] **Step 4: Write the spec that proves seed-and-cleanup round-trips**
+
+```js
+// e2e/specs/02-fixtures.spec.js
+//
+// Not a product test: it guards the fixture layer every later spec depends on.
+// A silent cleanup failure would slowly fill the developer's local database
+// with e2e- rows, so the deletion half is asserted explicitly.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter } = require('../fixtures/character');
+const { ADMIN_EMAIL } = require('../global-setup');
+
+test('fixtures seed under a prefix and clean up completely', async () => {
+  const db = await connect();
+  const prefix = newPrefix('fixtures');
+  try {
+    const profile = await profileForEmail(db, ADMIN_EMAIL);
+    const classRow = await seedClass(prefix);
+    const character = await seedCharacter(prefix, profile, classRow);
+
+    expect(character.id).toBeTruthy();
+    expect(character.name).toBe(`${prefix}-character`);
+
+    await cleanupByPrefix(db, prefix);
+
+    const { rows: leftoverCharacters } = await db.query(
+      'select id from characters where name like $1', [`${prefix}%`]
+    );
+    const { rows: leftoverClasses } = await db.query(
+      'select id from classes where name like $1', [`${prefix}%`]
+    );
+    expect(leftoverCharacters).toHaveLength(0);
+    expect(leftoverClasses).toHaveLength(0);
+  } finally {
+    await cleanupByPrefix(db, prefix);
+    await db.end();
+  }
+});
+```
+
+- [ ] **Step 5: Run it**
+
+Run: `bun run test:e2e e2e/specs/02-fixtures.spec.js`
+Expected: 1 passed.
+
+If `createCharacter` rejects the input, read its validation in
+`services/character/input.js` and add the missing required fields to
+`BASE_STATS` or the `input` object — this is fixture code, not product code,
+so correcting it here is in scope.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/fixtures e2e/specs/02-fixtures.spec.js
+git commit -m "test: add e2e fixture layer with prefix-scoped cleanup (ar-7v3k)"
+```
+
+---
+
+## Phase 1 — Silent-data-loss risks
+
+These three run first because they are the checks where a regression destroys
+user data rather than merely looking wrong.
+
+### Task 4: Perk textarea round-trip (ar-7v3k check 4)
+
+**Files:**
+- Create: `e2e/specs/03-perk-textarea.spec.js`
+
+**Interfaces:**
+- Consumes: `connect`, `newPrefix`, `profileForEmail`, `cleanupByPrefix` (Task 3); `seedClass` (Task 3); `seedCharacter`, `seedPerk`, `abilityIdFor` (Task 3); `ADMIN_EMAIL`, `ADMIN_STATE` (Task 2).
+
+**Background:** the refactor changed the perk field from `<input type="text">`
+to `<textarea>`, keeping `name="ability_perk_text[]"`
+(`views/partials/character-ability-perk.handlebars:7`). The server reads
+`body.ability_perk_text` at `services/character/input.js:170`, and Express's
+`urlencoded({ extended: true })` collapses the `[]` suffix into an array. The
+wiring looks correct on inspection — this spec proves it end to end, including
+the newline case the `<textarea>` change exists to allow. The live word count
+is `x-text` on `.word-count` bound to a sibling `x-data="{ text: ... }"`
+(`character-ability-perk.handlebars:6-10`).
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/03-perk-textarea.spec.js
+//
+// ar-7v3k check 4. The perk field became a <textarea> during the Alpine
+// adoption; a disturbed name="ability_perk_text[]" would drop perk text with
+// no error surfaced to the user. This asserts the value actually lands in the
+// database, not merely that the form looks right.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter, seedPerk, abilityIdFor } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('perk');
+let db;
+let character;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  const classRow = await seedClass(prefix);
+  character = await seedCharacter(prefix, profile, classRow);
+  await seedPerk(character.id, await abilityIdFor(character.id), 'original perk text');
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test('the perk field is a textarea carrying the array field name', async ({ page }) => {
+  await page.goto(`/characters/${character.id}/edit`);
+  const field = page.locator('textarea[name="ability_perk_text[]"]').first();
+  await expect(field).toBeVisible();
+  await expect(field).toHaveValue('original perk text');
+});
+
+test('the live word count tracks typing and shows 0 for whitespace', async ({ page }) => {
+  await page.goto(`/characters/${character.id}/edit`);
+  const field = page.locator('textarea[name="ability_perk_text[]"]').first();
+  const count = page.locator('.word-count').first();
+
+  await field.fill('one two three');
+  await expect(count).toHaveText('3');
+
+  await field.fill('   ');
+  await expect(count).toHaveText('0');
+});
+
+test('saving persists perk text, including newlines', async ({ page }) => {
+  const multiline = 'first line\nsecond line';
+
+  await page.goto(`/characters/${character.id}/edit`);
+  await page.locator('textarea[name="ability_perk_text[]"]').first().fill(multiline);
+  await page.locator('form#characterForm button[type="submit"]').first().click();
+
+  await page.waitForURL(/\/characters\//);
+
+  const { rows } = await db.query(
+    'select text from character_perks where character_id = $1', [character.id]
+  );
+  expect(rows).toHaveLength(1);
+  expect(rows[0].text).toBe(multiline);
+});
+```
+
+- [ ] **Step 2: Confirm the edit-form and submit-button selectors**
+
+`form#characterForm button[type="submit"]` is the expected shape. Verify and
+correct before running:
+
+```bash
+grep -n '<form\|type="submit"' views/character-form.handlebars | head -20
+```
+
+Also confirm the edit route is `/characters/:id/edit`:
+
+```bash
+grep -n "router.get('/:id/edit'\|/edit'" routes/characters.js | head
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/03-perk-textarea.spec.js`
+Expected: 3 passed.
+
+**If the save test fails, that is the silent-data-loss defect ar-7v3k warned
+about. Stop. Do not touch `views/partials/character-ability-perk.handlebars` or
+`services/character/input.js`.** Record it for Task 17 with the trace path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/03-perk-textarea.spec.js
+git commit -m "test: cover the perk textarea round-trip in a browser (ar-7v3k)"
+```
+
+---
+
+### Task 5: Stats editor cycle and ownership gate (ar-7v3k check 3)
+
+**Files:**
+- Create: `e2e/specs/04-stats-editor.spec.js`
+
+**Interfaces:**
+- Consumes: the Task 3 fixtures; `ADMIN_EMAIL`, `ADMIN_STATE`, `PLAYER_EMAIL`, `PLAYER_STATE` (Task 2).
+
+**Real selectors** (from `views/character.handlebars:191-227` and
+`views/partials/character-stats-editor.handlebars`):
+
+| Element | Selector |
+| --- | --- |
+| Component root | `#statsBox` (`x-data="characterStats(...)"`) |
+| Edit button | `#statsUnlockBtn` (`x-show="!editing"`) |
+| Read-only grid | `#statsReadOnly` (`x-show="!editing"`) |
+| Editor | `#statsEditor` (`x-show="editing"`, `x-cloak`) |
+| Live total | `#statsTotalSum` (`x-text="total"`) |
+| Cancel | `#statsCancelBtn` (`@click="cancel()"`) |
+| Save | `#statsSaveBtn` (`:disabled="saving"`) |
+| Error | `#statsEditorError` (`x-show="error"`) |
+| A stat input | `input[name="might"]` (`x-model.number="stats.might"`) |
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/04-stats-editor.spec.js
+//
+// ar-7v3k check 3. public/js/character-stats.js (108 lines) was deleted and
+// replaced by the Alpine `characterStats` component; this is the whole of its
+// replacement behaviour, plus the ownership gate that hides Edit entirely.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE, PLAYER_STATE } = require('../global-setup');
+
+const prefix = newPrefix('stats');
+let db;
+let character;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  const classRow = await seedClass(prefix);
+  character = await seedCharacter(prefix, profile, classRow);
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test.describe('as the owner', () => {
+  test.use({ storageState: ADMIN_STATE });
+
+  test('the stats box renders with the editor hidden', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await expect(page.locator('#statsBox')).toBeVisible();
+    await expect(page.locator('#statsReadOnly')).toBeVisible();
+    await expect(page.locator('#statsEditor')).toBeHidden();
+    await expect(page.locator('#statsUnlockBtn')).toBeVisible();
+  });
+
+  test('Edit reveals the editor and focuses the first input', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+
+    await expect(page.locator('#statsEditor')).toBeVisible();
+    await expect(page.locator('#statsReadOnly')).toBeHidden();
+
+    // The old imperative code focused the first input on reveal; the Alpine
+    // edit() must still do it or keyboard users land nowhere.
+    const focusedName = await page.evaluate(() => document.activeElement?.getAttribute('name'));
+    expect(focusedName).toBeTruthy();
+  });
+
+  test('the live total tracks edits', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+
+    const before = Number(await page.locator('#statsTotalSum').innerText());
+    await page.locator('input[name="might"]').fill('7');
+    await expect
+      .poll(async () => Number(await page.locator('#statsTotalSum').innerText()))
+      .toBe(before - 1 + 7); // seeded value is 1
+  });
+
+  test('Cancel restores the original values and hides the editor', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+    await page.locator('input[name="might"]').fill('9');
+    await page.locator('#statsCancelBtn').click();
+
+    await expect(page.locator('#statsEditor')).toBeHidden();
+    await page.locator('#statsUnlockBtn').click();
+    await expect(page.locator('input[name="might"]')).toHaveValue('1');
+  });
+
+  test('Save persists to the database', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+    await page.locator('input[name="might"]').fill('5');
+    await page.locator('#statsSaveBtn').click();
+
+    await expect(page.locator('#statsEditor')).toBeHidden();
+    await expect.poll(async () => {
+      const { rows } = await db.query('select might from characters where id = $1', [character.id]);
+      return rows[0].might;
+    }).toBe(5);
+  });
+});
+
+test.describe('as a non-owner', () => {
+  test.use({ storageState: PLAYER_STATE });
+
+  test('sees no Edit button', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await expect(page.locator('#statsUnlockBtn')).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun run test:e2e e2e/specs/04-stats-editor.spec.js`
+Expected: 6 passed.
+
+The non-owner test depends on the seeded character being visible to another
+account. If the page 404s or redirects for the player, the character is private
+— add `is_public: true` to the `seedCharacter` overrides in `beforeAll`. That is
+a fixture correction, not a product change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/04-stats-editor.spec.js
+git commit -m "test: cover the Alpine stats editor end to end (ar-7v3k)"
+```
+
+---
+
+### Task 6: Level-up modal, full cycle (ar-7v3k check 1)
+
+**Files:**
+- Create: `e2e/specs/05-level-up-modal.spec.js`
+
+**Background:** `public/js/character-level-up.js` (317 lines) was left untouched
+and now opens its modal through a one-line bridge —
+`window.dispatchEvent(new CustomEvent('open-modal', { detail: 'levelUp' }))`
+at `character-level-up.js:238`. The modal shell is the Alpine `modal`
+component (`public/js/alpine-components.js:155-177`), which sets
+`document.body.classList.add('modal-open')` on open and removes it on close,
+and scopes `close(which)` by name so a broadcast for a different modal is
+ignored. This is the only path that writes character data through a converted
+modal.
+
+Known ids: trigger `#levelUpBtn` (`views/character.handlebars:154`), modal
+`#levelUpModal`, total `#levelUpTotal`, missing-missions container
+`#levelUpMissingMissions`, conduit credit `#levelUpConduitCredit`, save
+`#levelUpSaveBtn`, error `#levelUpError`.
+
+- [ ] **Step 1: Read the level-up partial for the remaining selectors**
+
+```bash
+grep -n 'id=\|name=\|@click\|x-' views/partials/character-level-up.handlebars
+```
+
+Note the stat-input names and the four close controls (modal background, header
+`.delete`, footer Cancel, Escape). Use what you find; do not invent ids.
+
+- [ ] **Step 2: Write the spec**
+
+```js
+// e2e/specs/05-level-up-modal.spec.js
+//
+// ar-7v3k check 1. character-level-up.js was NOT converted — it now opens the
+// Alpine modal through a single dispatchEvent bridge. This is the only path
+// writing character data through a converted modal, so both the bridge and all
+// four close paths are covered.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('levelup');
+let db;
+let character;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  const classRow = await seedClass(prefix);
+  // completed_missions high enough that the level-up gate lets the modal open.
+  character = await seedCharacter(prefix, profile, classRow, { completed_missions: 10 });
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test('the dispatchEvent bridge opens the Alpine modal and locks the body', async ({ page }) => {
+  await page.goto(`/characters/${character.id}`);
+  await page.locator('#levelUpBtn').click();
+
+  await expect(page.locator('#levelUpModal')).toHaveClass(/is-active/);
+  await expect(page.locator('body')).toHaveClass(/modal-open/);
+});
+
+for (const [name, close] of [
+  ['background click', async (page) => page.locator('#levelUpModal .modal-background').click()],
+  ['header delete button', async (page) => page.locator('#levelUpModal .delete').first().click()],
+  ['footer cancel', async (page) => page.locator('#levelUpModal .modal-card-foot .button', { hasText: /cancel/i }).click()],
+  ['escape key', async (page) => page.keyboard.press('Escape')]
+]) {
+  test(`closes via ${name} and releases the body lock`, async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#levelUpBtn').click();
+    await expect(page.locator('#levelUpModal')).toHaveClass(/is-active/);
+
+    await close(page);
+
+    await expect(page.locator('#levelUpModal')).not.toHaveClass(/is-active/);
+    await expect(page.locator('body')).not.toHaveClass(/modal-open/);
+  });
+}
+
+test('completing a level-up persists the new level', async ({ page }) => {
+  const before = character.level;
+
+  await page.goto(`/characters/${character.id}`);
+  await page.locator('#levelUpBtn').click();
+  await expect(page.locator('#levelUpModal')).toHaveClass(/is-active/);
+
+  // Spend the level-up's stat points. The modal gates Save until the running
+  // total matches what the level grants, so read the target off the DOM rather
+  // than hardcoding a rules number.
+  await page.locator('#levelUpModal input[type="number"]').first().fill('2');
+  await page.locator('#levelUpSaveBtn').click();
+
+  await expect(page.locator('#levelUpError')).toBeHidden();
+  await expect.poll(async () => {
+    const { rows } = await db.query('select level from characters where id = $1', [character.id]);
+    return rows[0].level;
+  }, { timeout: 15_000 }).toBe(before + 1);
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/05-level-up-modal.spec.js`
+Expected: 6 passed.
+
+This is the spec most likely to need selector corrections from Step 1, and the
+most likely to reveal a real defect. If the *close* tests fail, the Alpine modal
+conversion is at fault — record and stop. If only the *save* test fails because
+the level-up rules gate is unsatisfied, that is a fixture problem: adjust
+`completed_missions` or the stat allocation and re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/05-level-up-modal.spec.js
+git commit -m "test: cover the level-up modal bridge and all four close paths (ar-7v3k)"
+```
+
+---
+
+## Phase 2 — Modal semantics
+
+### Task 7: Deceased modal (ar-7v3k check 5)
+
+**Files:**
+- Create: `e2e/specs/06-deceased-modal.spec.js`
+
+**Real markup** (`views/character-form.handlebars:407-450`): trigger is
+`@click="$dispatch('open-modal', 'deceased')"` on a `.button.is-dark`; the modal
+is `#deceased-modal` with `x-data="modal('deceased')"`; the confirm input is
+`input[name="confirmName"]` with `x-model="typed"`; the submit is
+`#deceased-submit` with `:disabled="typed !== required"`. Opening now sets
+`body.modal-open` for the first time, so the scroll lock is new behavior worth
+asserting. The modal only renders for a saved, not-yet-deceased character
+(`{{#unless isNew}}{{#unless character.is_deceased}}`).
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/06-deceased-modal.spec.js
+//
+// ar-7v3k check 5. Uses a character whose name contains an apostrophe, because
+// the required-name comparison is injected as {{json character.name}} into an
+// Alpine expression — a quoting bug there would break the confirm gate for
+// exactly those characters and no others.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('deceased');
+const NAME = `${prefix}-O'Brien`;
+let db;
+let character;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  const classRow = await seedClass(prefix);
+  character = await seedCharacter(prefix, profile, classRow, { name: NAME });
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test('opening locks background scroll; the confirm gate honours an apostrophe', async ({ page }) => {
+  await page.goto(`/characters/${character.id}/edit`);
+  await page.locator('button', { hasText: /deceased/i }).first().click();
+
+  const modal = page.locator('#deceased-modal');
+  await expect(modal).toHaveClass(/is-active/);
+  await expect(page.locator('body')).toHaveClass(/modal-open/);
+  await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+
+  const submit = page.locator('#deceased-submit');
+  await expect(submit).toBeDisabled();
+
+  await page.locator('#deceased-modal input[name="confirmName"]').fill('wrong name');
+  await expect(submit).toBeDisabled();
+
+  await page.locator('#deceased-modal input[name="confirmName"]').fill(NAME);
+  await expect(submit).toBeEnabled();
+});
+
+test('confirming marks the character deceased', async ({ page }) => {
+  await page.goto(`/characters/${character.id}/edit`);
+  await page.locator('button', { hasText: /deceased/i }).first().click();
+  await page.locator('#deceased-modal input[name="confirmName"]').fill(NAME);
+  await page.locator('#deceased-submit').click();
+
+  await expect.poll(async () => {
+    const { rows } = await db.query('select is_deceased from characters where id = $1', [character.id]);
+    return rows[0].is_deceased;
+  }, { timeout: 15_000 }).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun run test:e2e e2e/specs/06-deceased-modal.spec.js`
+Expected: 2 passed.
+
+The `overflow: hidden` assertion depends on a `.modal-open` rule in
+`public/css/styles.css`. If it fails but `body` does carry `modal-open`, check
+whether the rule exists — a missing rule means the scroll lock is cosmetic only,
+which is a genuine finding. Record it; do not add the CSS.
+
+Run the two tests in order (`--workers=1` for this file) — the second
+permanently marks the character deceased, which removes the modal from the page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/06-deceased-modal.spec.js
+git commit -m "test: cover the deceased modal scroll lock and confirm gate (ar-7v3k)"
+```
+
+---
+
+### Task 8: Unlock-code modal clears on reopen (ar-7v3k check 6)
+
+**Files:**
+- Create: `e2e/specs/07-unlock-code-modal.spec.js`
+
+**Real markup** (`views/class-view.handlebars:262-311`): `#unlockCodeModal` with
+`x-data="clearingModal('unlockCode')"`; trigger is a `.button.is-info` with
+`@click="$dispatch('open-modal', 'unlockCode')"` at line 32; the result target is
+`#codeResult-{{class.id}}` carrying `x-ref="result"`; all four close controls
+call `closeAndClear()`. The `clearingModal` component
+(`alpine-components.js:195-203`) blanks `$refs.result.innerHTML` only when the
+call actually transitioned the modal from open to closed.
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/07-unlock-code-modal.spec.js
+//
+// ar-7v3k check 6. clearingModal must blank the generated code on EVERY close
+// path — a stale code shown on reopen looks like a freshly issued one, and the
+// user would hand out a code that is already spent.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('unlock');
+let db;
+let classRow;
+
+test.beforeAll(async () => {
+  db = await connect();
+  await profileForEmail(db, ADMIN_EMAIL);
+  classRow = await seedClass(prefix);
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+const openAndGenerate = async (page) => {
+  await page.locator('button', { hasText: /generate unlock code/i }).click();
+  await expect(page.locator('#unlockCodeModal')).toHaveClass(/is-active/);
+  await page.locator('#unlockCodeModal button[hx-post], #unlockCodeModal button[type="submit"]').first().click();
+  await expect(page.locator(`#codeResult-${classRow.id}`)).not.toBeEmpty();
+};
+
+for (const [name, close] of [
+  ['background click', async (page) => page.locator('#unlockCodeModal .modal-background').click()],
+  ['header delete button', async (page) => page.locator('#unlockCodeModal .delete').first().click()],
+  ['footer close', async (page) => page.locator('#unlockCodeModal .modal-card-foot .button', { hasText: /close/i }).click()],
+  ['escape key', async (page) => page.keyboard.press('Escape')]
+]) {
+  test(`closing via ${name} clears the code before reopen`, async ({ page }) => {
+    await page.goto(`/classes/${classRow.id}`);
+    await openAndGenerate(page);
+
+    await close(page);
+    await expect(page.locator('#unlockCodeModal')).not.toHaveClass(/is-active/);
+    await expect(page.locator('body')).not.toHaveClass(/modal-open/);
+
+    await page.locator('button', { hasText: /generate unlock code/i }).click();
+    await expect(page.locator('#unlockCodeModal')).toHaveClass(/is-active/);
+    await expect(page.locator(`#codeResult-${classRow.id}`)).toBeEmpty();
+  });
+}
+```
+
+- [ ] **Step 2: Confirm the generate button's selector**
+
+```bash
+sed -n 280,310p views/class-view.handlebars
+```
+
+Replace the `openAndGenerate` inner selector with the real one.
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/07-unlock-code-modal.spec.js`
+Expected: 4 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/07-unlock-code-modal.spec.js
+git commit -m "test: cover unlock-code modal clearing on all four close paths (ar-7v3k)"
+```
+
+---
+
+### Task 9: Per-row duplicate modal on My Classes (ar-7v3k check 9)
+
+**Files:**
+- Create: `e2e/specs/08-my-classes-duplicate.spec.js`
+
+**Real markup** (`views/my-classes.handlebars:90-156`): each row is
+`#row-{{this.id}}`; its trigger dispatches `open-modal` with
+`'duplicate-{{this.id}}'`; the modal is `#duplicateModal-{{this.id}}` with
+`x-data="modal('duplicate-{{this.id}}')"`. The whole point of the name-scoping
+in `modalBase` (`alpine-components.js:158-159`) is that one row's trigger must
+not open every row's modal, so the spec needs **at least two** classes.
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/08-my-classes-duplicate.spec.js
+//
+// ar-7v3k check 9. modalBase.open(which) returns early unless `which` matches
+// the instance's name; with several rows on the page, an unscoped
+// implementation would open all of them at once. Needs two classes to detect
+// that at all.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('myclasses');
+let db;
+let first;
+let second;
+
+test.beforeAll(async () => {
+  db = await connect();
+  await profileForEmail(db, ADMIN_EMAIL);
+  first = await seedClass(prefix, { name: `${prefix}-alpha` });
+  second = await seedClass(prefix, { name: `${prefix}-beta` });
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test("one row's Duplicate opens only that row's modal", async ({ page }) => {
+  await page.goto('/classes/my');
+
+  const firstModal = page.locator(`#duplicateModal-${first.id}`);
+  const secondModal = page.locator(`#duplicateModal-${second.id}`);
+
+  await expect(firstModal).not.toHaveClass(/is-active/);
+  await expect(secondModal).not.toHaveClass(/is-active/);
+
+  await page.locator(`#row-${first.id} button`, { hasText: /duplicate/i }).click();
+
+  await expect(firstModal).toHaveClass(/is-active/);
+  await expect(secondModal).not.toHaveClass(/is-active/);
+});
+
+test('the duplicate modal submits and creates a copy', async ({ page }) => {
+  await page.goto('/classes/my');
+  await page.locator(`#row-${first.id} button`, { hasText: /duplicate/i }).click();
+
+  const modal = page.locator(`#duplicateModal-${first.id}`);
+  await expect(modal).toHaveClass(/is-active/);
+  await modal.locator('button[type="submit"]').click();
+
+  await expect.poll(async () => {
+    const { rows } = await db.query('select id from classes where name like $1', [`${prefix}%`]);
+    return rows.length;
+  }, { timeout: 15_000 }).toBeGreaterThan(2);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun run test:e2e e2e/specs/08-my-classes-duplicate.spec.js`
+Expected: 2 passed.
+
+The duplicate form requires `new_version` (`my-classes.handlebars:147` marks the
+select `required`). If submission does nothing, select a version first with
+`await modal.locator(`#dup-version-${first.id}`).selectOption({ index: 1 })`
+before clicking submit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/08-my-classes-duplicate.spec.js
+git commit -m "test: cover per-row duplicate modal scoping on My Classes (ar-7v3k)"
+```
+
+---
+
+## Phase 3 — htmx and Alpine interaction
+
+This phase covers what the ticket calls structurally unreachable: jsdom has no
+htmx, so the swap-then-settle race and history snapshots cannot be simulated.
+
+### Task 10: Boosted navigation leaves the navbar closed (ar-7v3k check 2)
+
+**Files:**
+- Create: `e2e/specs/09-boosted-nav-settle.spec.js`
+
+**Background — this is the single most important spec in the suite.** It is the
+entire justification for `defaultSettleDelay: 0` in
+`views/partials/head.handlebars:4`. The hazard: htmx's settle phase restores
+`class` and `style` attributes it captured *before* Alpine wrote to them, so a
+menu Alpine closed can be re-opened by the settle. The navbar is
+`x-data="{ open: false }"` with `:class="open && 'is-active'"` on both
+`#navbar-burger` and `#navbar-menu` (`views/partials/nav.handlebars:1-14`).
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/09-boosted-nav-settle.spec.js
+//
+// ar-7v3k check 2 — the whole reason defaultSettleDelay: 0 exists.
+//
+// htmx's settle phase can restore class/style attributes captured before
+// Alpine wrote to them. With a non-zero settle delay, a navbar menu that
+// Alpine re-initialises closed after a boosted swap gets its is-active class
+// restored by the settle, and the menu arrives OPEN on the new page. jsdom has
+// no htmx, so this race is unreachable from every other tier.
+const { test, expect } = require('@playwright/test');
+const { ADMIN_STATE } = require('../global-setup');
+
+test.use({
+  storageState: ADMIN_STATE,
+  viewport: { width: 500, height: 900 } // narrow enough that the burger shows
+});
+
+test('htmx-config pins the settle delay to zero', async ({ page }) => {
+  await page.goto('/');
+  const config = await page.locator('meta[name="htmx-config"]').getAttribute('content');
+  expect(JSON.parse(config).defaultSettleDelay).toBe(0);
+});
+
+test('the navbar menu arrives closed after a boosted navigation', async ({ page }) => {
+  await page.goto('/');
+
+  const burger = page.locator('#navbar-burger');
+  const menu = page.locator('#navbar-menu');
+
+  await burger.click();
+  await expect(menu).toHaveClass(/is-active/);
+
+  // A boosted link swaps <body> rather than doing a full page load.
+  const link = page.locator('#navbar-menu a[href]:not([href^="http"])').first();
+  const href = await link.getAttribute('href');
+  await link.click();
+
+  await page.waitForURL((url) => url.pathname === href);
+
+  // The assertion the settle race would break.
+  await expect(page.locator('#navbar-menu')).not.toHaveClass(/is-active/);
+  await expect(page.locator('#navbar-burger')).not.toHaveClass(/is-active/);
+});
+
+test('a hidden x-show element stays hidden across a boosted body swap', async ({ page }) => {
+  // ar-7v3k records this as the one part of acceptance criterion 2 with no
+  // test: x-show combined with a real boosted swap.
+  await page.goto('/');
+  const link = page.locator('#navbar-menu a[href]:not([href^="http"])').first();
+  await link.click();
+  await page.waitForLoadState('networkidle');
+
+  const cloaked = page.locator('[x-cloak]');
+  for (let i = 0; i < await cloaked.count(); i++) {
+    await expect(cloaked.nth(i)).toBeHidden();
+  }
+});
+```
+
+- [ ] **Step 2: Confirm `hx-boost` is actually on the navbar links**
+
+```bash
+grep -n 'hx-boost' views/layouts/main.handlebars views/partials/nav.handlebars
+```
+
+If boosting is set on a wrapper rather than the nav, adjust the link selector so
+the click really performs a body swap rather than a full navigation. A full page
+load would make this spec pass vacuously — verify by asserting no `load` event
+fires, or by checking `window.htmx` object identity is preserved across the
+click:
+
+```js
+await page.evaluate(() => { window.__preNav = true; });
+await link.click();
+await page.waitForURL((url) => url.pathname === href);
+expect(await page.evaluate(() => window.__preNav)).toBe(true); // survives a swap, not a reload
+```
+
+Add that identity check to the boosted-navigation test.
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/09-boosted-nav-settle.spec.js`
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/09-boosted-nav-settle.spec.js
+git commit -m "test: prove defaultSettleDelay 0 keeps the navbar closed after boosted nav (ar-7v3k)"
+```
+
+---
+
+### Task 11: Back button after a boosted navigation (ar-7v3k check 12)
+
+**Files:**
+- Create: `e2e/specs/10-back-button-snapshot.spec.js`
+
+**Background:** htmx caches a DOM snapshot for history restoration. That snapshot
+is taken *after* Alpine stripped `x-cloak` and wrote `:class` bindings, so a
+restored page can come back with Alpine's writes baked into the markup but no
+live Alpine state behind them — leaving a menu visually open that nothing can
+close.
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/10-back-button-snapshot.spec.js
+//
+// ar-7v3k check 12. htmx snapshots the DOM for history restore AFTER Alpine has
+// stripped x-cloak and written :class. A restored snapshot can therefore carry
+// Alpine's output as literal markup with no component behind it — a menu stuck
+// open that no click can close.
+const { test, expect } = require('@playwright/test');
+const { ADMIN_STATE } = require('../global-setup');
+
+test.use({
+  storageState: ADMIN_STATE,
+  viewport: { width: 500, height: 900 }
+});
+
+test('going back after a boosted navigation restores a closed, live navbar', async ({ page }) => {
+  await page.goto('/');
+
+  await page.locator('#navbar-burger').click();
+  await expect(page.locator('#navbar-menu')).toHaveClass(/is-active/);
+
+  const link = page.locator('#navbar-menu a[href]:not([href^="http"])').first();
+  const href = await link.getAttribute('href');
+  await link.click();
+  await page.waitForURL((url) => url.pathname === href);
+
+  await page.goBack();
+  await page.waitForURL((url) => url.pathname === '/');
+
+  // Restored closed...
+  await expect(page.locator('#navbar-menu')).not.toHaveClass(/is-active/);
+
+  // ...and still live: the component must respond, not just look right.
+  await page.locator('#navbar-burger').click();
+  await expect(page.locator('#navbar-menu')).toHaveClass(/is-active/);
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun run test:e2e e2e/specs/10-back-button-snapshot.spec.js`
+Expected: 1 passed.
+
+A failure on the final assertion (menu restored closed but the burger no longer
+works) means Alpine did not re-initialise the restored snapshot. Record it —
+this is exactly the class of defect the check exists to find.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/10-back-button-snapshot.spec.js
+git commit -m "test: cover Alpine liveness after htmx history restore (ar-7v3k)"
+```
+
+---
+
+### Task 12: Export dropdowns on character and class pages (ar-7v3k check 11)
+
+**Files:**
+- Create: `e2e/specs/11-export-dropdowns.spec.js`
+
+**Real markup** — identical shape in both templates
+(`views/character.handlebars:161-171`, `views/class-view.handlebars:34-46`):
+`#export-dropdown` with `x-data="{ open: false }"`, `@click.outside="open = false"`,
+a toggle button with `@click="open = !open"` and `:aria-expanded="open"`, and
+`#export-menu`. These replaced the two global dropdown handlers deleted from
+`public/js/app.js`.
+
+- [ ] **Step 1: Confirm the Escape binding**
+
+```bash
+sed -n 160,172p views/character.handlebars
+```
+
+Line 163 (elided in the grep used to write this plan) carries the remaining
+directives. If there is no `@keydown.escape` binding, **drop the Escape test and
+record the gap as a finding** — ar-7v3k check 11 lists Escape-close as required
+behavior, so its absence is a genuine regression from the deleted global handler.
+
+- [ ] **Step 2: Write the spec**
+
+```js
+// e2e/specs/11-export-dropdowns.spec.js
+//
+// ar-7v3k check 11. Both global dropdown handlers were deleted from app.js and
+// replaced with per-dropdown Alpine state. Outside-click and Escape used to be
+// document-level behaviour; they are now per-component and easy to lose.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('export');
+let db;
+let character;
+let classRow;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  classRow = await seedClass(prefix);
+  character = await seedCharacter(prefix, profile, classRow);
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+// character/classRow are assigned in beforeAll, so the URL has to be resolved
+// inside each test rather than when the loop body is built.
+const PAGES = ['character page', 'class page'];
+const urlFor = (label) =>
+  label === 'character page' ? `/characters/${character.id}` : `/classes/${classRow.id}`;
+
+for (const label of PAGES) {
+  test(`${label}: dropdown opens, second click closes, outside click closes`, async ({ page }) => {
+    await page.goto(urlFor(label));
+
+    const toggle = page.locator('#export-dropdown button[aria-haspopup="true"]');
+    const dropdown = page.locator('#export-dropdown');
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(dropdown).toHaveClass(/is-active/);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await page.locator('body').click({ position: { x: 5, y: 5 } });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test(`${label}: Escape closes the dropdown`, async ({ page }) => {
+    await page.goto(urlFor(label));
+
+    const toggle = page.locator('#export-dropdown button[aria-haspopup="true"]');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await page.keyboard.press('Escape');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test(`${label}: both export links resolve`, async ({ page }) => {
+    await page.goto(urlFor(label));
+    await page.locator('#export-dropdown button[aria-haspopup="true"]').click();
+
+    const links = page.locator('#export-menu a[href]');
+    const count = await links.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    for (let i = 0; i < count; i++) {
+      const href = await links.nth(i).getAttribute('href');
+      const response = await page.request.get(href);
+      expect(response.status()).toBe(200);
+    }
+  });
+}
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/11-export-dropdowns.spec.js`
+Expected: 6 passed (3 per page).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/11-export-dropdowns.spec.js
+git commit -m "test: cover Alpine export dropdowns on character and class pages (ar-7v3k)"
+```
+
+---
+
+## Phase 4 — Remaining forms
+
+### Task 13: Offscreen mission with a linked source (ar-7v3k check 7)
+
+**Files:**
+- Create: `e2e/specs/12-offscreen-mission.spec.js`
+
+**Background — this covers a deliberate, human-approved behavior change.** The
+"other" fields previously carried `style="display: ;"` — invalid CSS that falls
+back to visible — so they showed whenever an offscreen mission existed, even
+when the select had a real mission chosen. Now
+`views/partials/offscreen-mission-form.handlebars:55` uses
+`x-show="sourceId === '__other__'"` with `x-cloak`, so with a linked source they
+start **hidden** while the select still shows the linked mission as selected.
+
+Real markup: form root `x-data="{ sourceId: '' }"`
+(`offscreen-mission-form.handlebars:1`); the "other" block is `#om-source-other`;
+its inputs are `#om-source-name` (`name="source_mission_name_other"`) and
+`#om-source-date` (`name="source_mission_date_other"`); the sentinel option
+value is `__other__` (line 41).
+
+- [ ] **Step 1: Read the form to find the select's name and how `sourceId` initialises**
+
+```bash
+sed -n 1,60p views/partials/offscreen-mission-form.handlebars
+```
+
+The `x-data` shown above initialises `sourceId` to `''`. **If it is literally
+`{ sourceId: '' }` with no server-rendered initial value, that is a defect for
+the edit case** — a linked mission would leave `sourceId` empty rather than
+matching the selected option. Check whether the edit template
+(`views/offscreen-mission-edit.handlebars`) passes `currentSourceId`
+(`routes/characters.js:506` sets it) into the partial. Record what you find
+before writing the spec; the spec below asserts correct behavior either way.
+
+- [ ] **Step 2: Write the spec**
+
+```js
+// e2e/specs/12-offscreen-mission.spec.js
+//
+// ar-7v3k check 7 — a deliberate behaviour change. The "other" source fields
+// used to carry style="display: ;" (invalid CSS, falls back to visible) and so
+// appeared even when a real mission was linked. They must now start hidden
+// while the select still shows the linked mission as selected.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter, seedOffscreenMission } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('offscreen');
+let db;
+let character;
+let offscreen;
+let hasLinkedSource = false;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  const classRow = await seedClass(prefix);
+  character = await seedCharacter(prefix, profile, classRow);
+
+  // A linked source mission, if one exists to link to. Without any mission in
+  // the database the "linked" case is untestable — record that as a skip
+  // rather than silently testing the unlinked path instead.
+  const { rows: missions } = await db.query('select id from missions limit 1');
+  hasLinkedSource = !!missions[0];
+  offscreen = await seedOffscreenMission(character.id, profile.id, {
+    name: `${prefix}-offscreen`,
+    sourceMissionId: missions[0]?.id || null
+  });
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test('editing a linked offscreen mission starts with the other fields hidden', async ({ page }) => {
+  test.skip(!hasLinkedSource, 'no mission in the database to link as an offscreen source');
+  await page.goto(`/characters/${character.id}/offscreen-missions/${offscreen.id}/edit`);
+
+  await expect(page.locator('#om-source-other')).toBeHidden();
+
+  // The select must still show the linked mission, not fall back to blank.
+  const select = page.locator('select').first();
+  await expect(select).not.toHaveValue('__other__');
+  await expect(select).not.toHaveValue('');
+});
+
+test('choosing "Other" reveals the other fields', async ({ page }) => {
+  await page.goto(`/characters/${character.id}/offscreen-missions/${offscreen.id}/edit`);
+
+  await page.locator('select').first().selectOption('__other__');
+  await expect(page.locator('#om-source-other')).toBeVisible();
+  await expect(page.locator('#om-source-name')).toBeVisible();
+  await expect(page.locator('#om-source-date')).toBeVisible();
+});
+
+test('a new offscreen mission starts with the other fields hidden', async ({ page }) => {
+  await page.goto(`/characters/${character.id}/offscreen-missions/new`);
+  await expect(page.locator('#om-source-other')).toBeHidden();
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/12-offscreen-mission.spec.js`
+Expected: 3 passed, or a skip if the local database has no missions.
+
+If the first test fails because the select is blank, that confirms the Step 1
+suspicion: `sourceId` never receives the server's `currentSourceId`. **Record it,
+do not fix the template.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/12-offscreen-mission.spec.js
+git commit -m "test: cover offscreen mission linked-source field visibility (ar-7v3k)"
+```
+
+---
+
+### Task 14: Page editor slug stability (ar-7v3k check 8)
+
+**Files:**
+- Create: `e2e/specs/13-page-slug.spec.js`
+
+**Real markup** (`views/page-form.handlebars:15-29`): the form is `#page-form`
+with `x-data="pageSlug({{json page.title}}, {{json page.slug}})"`; `#title` has
+`x-model="title" @input="onTitle()"`; `#slug` has `x-model="slug" @input="auto = false"`.
+The `pageSlug` component is at `public/js/alpine-components.js:52`. Two
+behaviors matter: an existing page's slug must not move when the title is
+untouched, and the auto-fill must re-arm when the slug field is cleared
+(commit `e626499`).
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/13-page-slug.spec.js
+//
+// ar-7v3k check 8. The slug auto-fill replaced a deleted inline script. On an
+// EXISTING page the slug is part of the public URL, so an auto-fill that
+// re-fires on load or on an unrelated edit silently breaks every inbound link.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, cleanupByPrefix } = require('../fixtures/db');
+const { supabaseAdmin } = require('../../models/_base');
+const { ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('page');
+const ORIGINAL_SLUG = `${prefix}-original-slug`;
+let db;
+let pageRow;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const { data, error } = await supabaseAdmin.from('pages').insert({
+    title: `${prefix}-title`,
+    slug: ORIGINAL_SLUG,
+    content: 'Fixture content',
+    access_level: 'public',
+    is_published: true
+  }).select().single();
+  if (error) throw error;
+  pageRow = data;
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test('an existing page loads with title and slug populated', async ({ page }) => {
+  await page.goto(`/pages/${pageRow.id}/edit`);
+  await expect(page.locator('#title')).toHaveValue(`${prefix}-title`);
+  await expect(page.locator('#slug')).toHaveValue(ORIGINAL_SLUG);
+});
+
+test('saving without touching the slug leaves the URL unchanged', async ({ page }) => {
+  await page.goto(`/pages/${pageRow.id}/edit`);
+  await page.locator('#page-form button[type="submit"]').first().click();
+  await page.waitForLoadState('networkidle');
+
+  const { rows } = await db.query('select slug from pages where id = $1', [pageRow.id]);
+  expect(rows[0].slug).toBe(ORIGINAL_SLUG);
+});
+
+test('editing the title of an existing page does not move its slug', async ({ page }) => {
+  await page.goto(`/pages/${pageRow.id}/edit`);
+  await page.locator('#title').fill(`${prefix}-a-completely-different-title`);
+  await expect(page.locator('#slug')).toHaveValue(ORIGINAL_SLUG);
+});
+
+test('clearing the slug re-arms auto-fill from the title', async ({ page }) => {
+  await page.goto(`/pages/${pageRow.id}/edit`);
+  await page.locator('#slug').fill('');
+  await page.locator('#title').fill('Re Armed Title');
+  await expect(page.locator('#slug')).toHaveValue('re-armed-title');
+});
+
+test('slugify preserves underscores', async ({ page }) => {
+  // Deliberate, human-approved: foo_bar stays foo_bar rather than folding to
+  // foo-bar, matching the deleted script (ar-7v3k "Deliberate behavior changes").
+  await page.goto('/pages/new');
+  await page.locator('#title').fill('foo_bar baz');
+  await expect(page.locator('#slug')).toHaveValue('foo_bar-baz');
+});
+```
+
+- [ ] **Step 2: Confirm the page edit and new routes**
+
+```bash
+grep -n "router.get(" routes/pages.js | head
+```
+
+Correct `/pages/:id/edit` and `/pages/new` if they differ.
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/13-page-slug.spec.js`
+Expected: 5 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/13-page-slug.spec.js
+git commit -m "test: cover page slug auto-fill and stability on existing pages (ar-7v3k)"
+```
+
+---
+
+### Task 15: LFG form controls (ar-7v3k check 10)
+
+**Files:**
+- Create: `e2e/specs/14-lfg-controls.spec.js`
+
+**Real markup:**
+- `views/partials/lfg-form.handlebars:2` — `x-data="{ hosting: <bool> }"`, seeded
+  from whether the viewer is the post's host; the checkbox at line 29 is
+  `input[type="checkbox"][name="host_id"]` with `x-model="hosting"`; the
+  character picker is `#character-select` with `x-show="!hosting"` and `x-cloak`.
+- `views/partials/lfg-join-form.handlebars:1` — `x-data="{ joinType: 'player' }"`;
+  radios `#join-player-opt` (`value="player"`) and a `value="conduit"` radio,
+  both `x-model="joinType"`; `#character-select` is `x-show="joinType === 'player'"`.
+
+Note both partials use the id `#character-select`, so scope every locator to its
+form.
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/14-lfg-controls.spec.js
+//
+// ar-7v3k check 10. Both LFG forms gained Alpine-driven conditional sections.
+// The create-form case has to start on a post where the viewer IS the host,
+// because `hosting` initialises from the server-rendered value — the bug this
+// would catch is an initialiser that ignores it and defaults to false.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { supabaseAdmin } = require('../../models/_base');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+test.use({ storageState: ADMIN_STATE });
+
+const prefix = newPrefix('lfg');
+let db;
+let hostedPost;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+
+  const { data, error } = await supabaseAdmin.from('lfg_posts').insert({
+    title: `${prefix}-hosted-post`,
+    description: 'Fixture LFG post',
+    date: '2027-01-01T18:00:00Z',
+    creator_id: profile.id,
+    host_id: profile.id,          // the viewer IS the host
+    max_characters: 4,
+    is_public: true
+  }).select().single();
+  if (error) throw error;
+  hostedPost = data;
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+test('the create form starts hosting, hiding the character picker', async ({ page }) => {
+  await page.goto(`/lfg/${hostedPost.id}/edit`);
+
+  const form = page.locator('form:has(input[name="host_id"])');
+  const hosting = form.locator('input[type="checkbox"][name="host_id"]');
+  const picker = form.locator('#character-select');
+
+  await expect(hosting).toBeChecked();
+  await expect(picker).toBeHidden();
+
+  await hosting.uncheck();
+  await expect(picker).toBeVisible();
+
+  await hosting.check();
+  await expect(picker).toBeHidden();
+});
+
+test('the join form radios toggle the character picker', async ({ page }) => {
+  await page.goto(`/lfg/${hostedPost.id}`);
+
+  const form = page.locator('form:has(#join-player-opt)');
+  test.skip(await form.count() === 0, 'no join form on this post for the current viewer');
+
+  const picker = form.locator('#character-select');
+  await expect(picker).toBeVisible();
+
+  const conduit = form.locator('input[type="radio"][value="conduit"]');
+  test.skip(await conduit.isDisabled(), 'conduit option disabled because the post has a host');
+
+  await conduit.check();
+  await expect(picker).toBeHidden();
+
+  await form.locator('#join-player-opt').check();
+  await expect(picker).toBeVisible();
+});
+
+test('join requests still lazy-load on demand', async ({ page }) => {
+  await page.goto(`/lfg/${hostedPost.id}`);
+
+  const toggle = page.locator('[hx-get*="join-requests"]').first();
+  test.skip(await toggle.count() === 0, 'no join-requests toggle rendered');
+
+  await toggle.click();
+  await expect(page.locator('#join-requests, [id*="join-request"]').first()).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Confirm the LFG routes**
+
+```bash
+grep -n "router.get(" routes/lfg.js | head -15
+```
+
+Correct `/lfg/:id` and `/lfg/:id/edit` if they differ.
+
+- [ ] **Step 3: Run it**
+
+Run: `bun run test:e2e e2e/specs/14-lfg-controls.spec.js`
+Expected: 3 passed, or skips where the fixture post does not present that form.
+
+Skips are acceptable here and must be listed in the findings report as
+**uncovered**, not as passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/14-lfg-controls.spec.js
+git commit -m "test: cover LFG create and join form conditional sections (ar-7v3k)"
+```
+
+---
+
+## Phase 5 — Auth redirect
+
+### Task 16: Auth redirect no longer traps the user (ar-h6rt)
+
+**Files:**
+- Create: `e2e/specs/15-auth-redirect.spec.js`
+
+**Background:** `redirectTo()` (`public/js/app.js:955-965`) performs an htmx body
+swap without touching `window.location`, so the address bar kept showing
+`/auth/check?r=%2Fnav%2Fmanage` while the body showed `/nav/manage`.
+`getRedirectUrl()` then re-read the same stale `?r=` on every later auth event
+and swapped the body back — an unescapable loop. The fixes on this branch
+(`af2b098`, `43c6120`, `a324968`, `b072d4a`) sync the address bar and stop the
+deferred timer from undoing a boosted navigation.
+
+The open-redirect guards must survive: `getRedirectUrl` rejects
+protocol-relative (`//evil.com`), absolute, and backslash-prefixed
+(`/\evil.com`) values. The client is **stricter** than the server, which only
+tests `startsWith('//')` — the stricter rule is the one that must hold.
+
+These tests start **unauthenticated**, then sign in through the form, because
+that is the flow that produced the bug.
+
+- [ ] **Step 1: Write the spec**
+
+```js
+// e2e/specs/15-auth-redirect.spec.js
+//
+// ar-h6rt. Starts with NO storageState: the trap only appears on a direct load
+// of a protected route, which carries no Authorization header and so bounces
+// through /auth/check?r=.
+const { test, expect } = require('@playwright/test');
+const { ADMIN_EMAIL, ADMIN_PASSWORD } = require('../global-setup');
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const signInThroughForm = async (page) => {
+  await page.fill('#signin-email', ADMIN_EMAIL);
+  await page.fill('#signin-password', ADMIN_PASSWORD);
+  await page.click('#signin-submit');
+};
+
+test('after an auth redirect the address bar matches the rendered page', async ({ page }) => {
+  await page.goto('/nav/manage');
+
+  // Bounced to the auth check with the intended destination in ?r=.
+  await page.waitForURL(/\/auth/);
+  await signInThroughForm(page);
+
+  // The fix: the URL must catch up with the body swap.
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 15_000 })
+    .toBe('/nav/manage');
+  await expect.poll(() => new URL(page.url()).search).toBe('');
+});
+
+test('a reload after the redirect lands on the same page', async ({ page }) => {
+  await page.goto('/nav/manage');
+  await page.waitForURL(/\/auth/);
+  await signInThroughForm(page);
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 15_000 }).toBe('/nav/manage');
+
+  await page.reload();
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 15_000 }).toBe('/nav/manage');
+});
+
+test('navigating away from the protected page is not bounced back', async ({ page }) => {
+  await page.goto('/nav/manage');
+  await page.waitForURL(/\/auth/);
+  await signInThroughForm(page);
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 15_000 }).toBe('/nav/manage');
+
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/$/);
+
+  // The original bug re-armed on later auth events (token refresh, focus).
+  // Give the deferred handlers a window to misfire, then confirm we stayed put.
+  await page.waitForTimeout(3000);
+  expect(new URL(page.url()).pathname).toBe('/');
+});
+
+test('a boosted navigation is not undone by the deferred timer', async ({ page }) => {
+  await page.goto('/auth');
+  await signInThroughForm(page);
+  await page.waitForFunction(() => !!localStorage.getItem('authToken'), null, { timeout: 15_000 });
+
+  await page.goto('/');
+  const link = page.locator('a[href]:not([href^="http"]):not([href^="#"])').first();
+  const href = await link.getAttribute('href');
+  await link.click();
+  await page.waitForURL((url) => url.pathname === href);
+
+  // The 100 ms timer captured a URL at event time; it must not yank us back.
+  await page.waitForTimeout(2000);
+  expect(new URL(page.url()).pathname).toBe(href);
+});
+
+for (const hostile of ['//evil.com', '/\\evil.com', 'https://evil.com', '///evil.com']) {
+  test(`rejects a hostile ?r= value: ${hostile}`, async ({ page, baseURL }) => {
+    await page.goto(`/auth/check?r=${encodeURIComponent(hostile)}`);
+    await signInThroughForm(page);
+    await page.waitForTimeout(2000);
+
+    // Never navigated off-origin, and never wrote the hostile value into the
+    // address bar — which would persist and be copyable, strictly worse than
+    // the body swap it replaced.
+    expect(new URL(page.url()).origin).toBe(new URL(baseURL).origin);
+    expect(page.url()).not.toContain('evil.com');
+  });
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun run test:e2e e2e/specs/15-auth-redirect.spec.js --workers=1`
+Expected: 8 passed.
+
+Run this file with `--workers=1`: several tests sign in from a clean state and
+share the app's Supabase client behavior around token refresh.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/15-auth-redirect.spec.js
+git commit -m "test: cover the auth redirect address-bar sync and open-redirect guards (ar-h6rt)"
+```
+
+---
+
+## Phase 6 — CI, documentation, findings
+
+### Task 17: Wire CI, document the tier, and publish the findings report
+
+**Files:**
+- Create: `.github/workflows/e2e.yml`
+- Create: `docs/superpowers/reports/2026-08-03-e2e-findings.md`
+- Modify: `README.md`
+- Modify: `CONTRIBUTING.md`
+
+**Interfaces:**
+- Consumes: the pass/fail verdict recorded during Tasks 4-16.
+
+- [ ] **Step 1: Run the whole suite and capture the verdict**
+
+```bash
+bun run test:e2e 2>&1 | tee /tmp/e2e-full-run.txt
+```
+
+Record, for every spec: passed / failed / skipped. Do not proceed with a guess —
+this run is the report's evidence.
+
+- [ ] **Step 2: Write the findings report**
+
+Create `docs/superpowers/reports/2026-08-03-e2e-findings.md` with this exact
+structure, filling in real results:
+
+```markdown
+# E2E Browser Tier — Findings
+
+**Run date:** <date>
+**Branch:** <branch>
+**Command:** `bun run test:e2e`
+**Result:** <N passed, N failed, N skipped>
+
+## Summary
+
+| ar-7v3k check | Spec | Verdict |
+| --- | --- | --- |
+| 1 Level-up modal | `05-level-up-modal.spec.js` | |
+| 2 Boosted nav settle | `09-boosted-nav-settle.spec.js` | |
+| 3 Stats editor | `04-stats-editor.spec.js` | |
+| 4 Perk textarea | `03-perk-textarea.spec.js` | |
+| 5 Deceased modal | `06-deceased-modal.spec.js` | |
+| 6 Unlock-code modal | `07-unlock-code-modal.spec.js` | |
+| 7 Offscreen mission | `12-offscreen-mission.spec.js` | |
+| 8 Page editor slug | `13-page-slug.spec.js` | |
+| 9 My Classes duplicate | `08-my-classes-duplicate.spec.js` | |
+| 10 LFG controls | `14-lfg-controls.spec.js` | |
+| 11 Export dropdowns | `11-export-dropdowns.spec.js` | |
+| 12 Back button | `10-back-button-snapshot.spec.js` | |
+| ar-h6rt auth redirect | `15-auth-redirect.spec.js` | |
+
+## Failures
+
+For each failure:
+
+### <spec name> — <one-line description>
+
+- **What the spec asserted:**
+- **What happened:**
+- **Trace:** `e2e/report/artifacts/<dir>/trace.zip` (open with `bunx playwright show-trace <path>`)
+- **Diagnosis:** (file:line of the suspected cause — no fix applied)
+- **Severity:** data loss / broken behavior / cosmetic
+
+## Skipped and uncovered
+
+List every `test.skip` that fired and why. A skip is **not** a pass.
+
+## Expectation bugs corrected
+
+Any spec whose expectation was wrong rather than the product, with reasoning.
+```
+
+- [ ] **Step 3: Create the CI workflow**
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E browser tests
+
+on:
+  pull_request:
+    paths:
+      - 'public/**'
+      - 'views/**'
+      - 'routes/**'
+      - 'models/**'
+      - 'services/**'
+      - 'util/**'
+      - 'supabase/**'
+      - 'scripts/**'
+      - 'e2e/**'
+      - 'playwright.config.js'
+      - 'package.json'
+      - 'bun.lock'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: supabase/setup-cli@v1
+      - run: bun install --frozen-lockfile
+      - run: supabase start
+      - run: supabase db reset
+      - name: Seed local app data
+        run: |
+          eval "$(supabase status -o env)"
+          SUPABASE_URL="$API_URL" \
+          SUPABASE_PUBLISHABLE_KEY="$ANON_KEY" \
+          SUPABASE_SECRET_KEY="$SERVICE_ROLE_KEY" \
+          SUPABASE_DB_URL="$DB_URL" \
+          bun run seed:local
+      - run: bunx playwright install --with-deps chromium
+      - name: Run E2E suite
+        run: |
+          eval "$(supabase status -o env)"
+          SUPABASE_URL="$API_URL" \
+          SUPABASE_PUBLISHABLE_KEY="$ANON_KEY" \
+          SUPABASE_SECRET_KEY="$SERVICE_ROLE_KEY" \
+          SUPABASE_DB_URL="$DB_URL" \
+          bun run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            e2e/report/html
+            e2e/report/artifacts
+          retention-days: 7
+```
+
+Note: this workflow deliberately has **no `push: branches: [main]` trigger**
+while failing specs remain. Add it only after the findings are triaged.
+
+- [ ] **Step 4: Document the tier in `README.md`**
+
+Add a "Testing" subsection listing all four tiers:
+
+```markdown
+### Testing
+
+| Command | Tier | Requires |
+| --- | --- | --- |
+| `bun run test` | Unit (jsdom, no DB) | nothing |
+| `bun run test:http` | HTTP (Express + mocked models) | nothing |
+| `bun run test:integration` | Integration (real Supabase) | `supabase start` |
+| `bun run test:e2e` | End-to-end (Chromium) | `supabase start` + `bun run seed:local` |
+
+The E2E tier boots its own server on port 3100, so it runs alongside
+`bun run dev`. It seeds and deletes its own rows under an `e2e-` prefix and
+never resets your database.
+
+Open the report for a failed run with:
+
+```sh
+bunx playwright show-report e2e/report/html
+```
+```
+
+- [ ] **Step 5: Document the conventions in `CONTRIBUTING.md`**
+
+Add: new E2E specs go in `e2e/specs/`, seed through `e2e/fixtures/` under a
+prefix from `newPrefix()`, clean up in `afterAll`, and pick an identity with
+`test.use({ storageState: ADMIN_STATE })` or `PLAYER_STATE`. Unlike the other
+tiers, there is no file to register — Playwright discovers `e2e/specs/*.spec.js`
+automatically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/e2e.yml docs/superpowers/reports README.md CONTRIBUTING.md
+git commit -m "docs: document the e2e tier and record its first-run findings (ar-7v3k, ar-h6rt)"
+```
+
+- [ ] **Step 7: Report to the user — do not merge**
+
+Present the findings table and stop. The triage decision is the user's:
+fix the defects, mark specs `test.fixme()` with ticket references, or accept
+them. Only after that decision should `push: branches: [main]` be added to the
+workflow and `ar-7v3k`'s "BLOCKING: manual browser verification" section be
+replaced with a reference to this suite.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** all thirteen checks in the design's spec inventory have a
+task (4-16); the infrastructure sections map to Tasks 1-3; CI, documentation,
+reporting, and the `.gitignore` entries map to Tasks 1 and 17.
+
+**Known selector risk:** the sign-in form (Task 2), level-up partial (Task 6),
+character-form submit (Task 4), unlock-code generate button (Task 8), and the
+export dropdown's Escape binding (Task 12) each carry an explicit verification
+step because their exact ids were not read while writing this plan. Every other
+selector in this plan was read from the template and is quoted with its
+file and line.
+
+**Deliberate deviation from red-green-refactor:** these are characterization
+tests, expected green on first run. The TDD cycle does not apply, and the
+"do not fix production code" rule in Global Constraints is what replaces it.

--- a/docs/superpowers/specs/2026-08-03-e2e-browser-tier-design.md
+++ b/docs/superpowers/specs/2026-08-03-e2e-browser-tier-design.md
@@ -1,0 +1,228 @@
+# End-to-End Browser Test Tier — Design
+
+**Date:** 2026-08-03
+**Tickets:** ar-7v3k (Alpine adoption), ar-h6rt (auth redirect loop)
+**Status:** Approved, awaiting implementation plan
+
+## Problem
+
+The Alpine.js adoption (`ar-7v3k`, 44 commits) rewrote roughly 90 line-level
+sites of client-side view state. Its own ticket records the gap:
+
+> **Nothing on this branch has executed in a browser.** Every task ran headless,
+> and jsdom has no htmx — so the swap-then-settle race that
+> `defaultSettleDelay: 0` exists to neutralise is structurally unreachable from
+> the test suite.
+
+The ticket then lists twelve manual checks that gate the merge. Two of them
+guard silent data loss: the perk field changed from `<input>` to `<textarea>`,
+and a disturbed `name="ability_perk_text[]"` would drop perk text with no error.
+
+The repository has three test tiers — `test:unit` (jsdom, no DB), `test:http`
+(bare Express with mocked models), `test:integration` (local Supabase) — and 715
+passing tests across 84 files. None of them run a browser, so none of them can
+observe htmx swaps, Alpine's settle behavior, boosted navigation, or the back
+button.
+
+The `ar-h6rt` auth-redirect defect has the same shape: `redirectTo()` swaps the
+body without touching `window.location`, and only a real browser can confirm the
+address bar now tracks the rendered page.
+
+## Goal
+
+Add a fourth test tier that drives a real browser against the running app, and
+use it to convert the ar-7v3k manual checklist into automated coverage. The tier
+outlives this verification pass: every future client-side refactor inherits it.
+
+## Non-goals
+
+- Fixing any defect the suite uncovers. This pass **reports**, it does not
+  repair. See "Failure policy".
+- Alpine Phase 4 conversions (mission-form repeater, conduit picker,
+  `character-form-version.js`, `character-new-selector` restore-draft,
+  `app.js` clipboard/search timers). Not started; own spec/plan cycle.
+- The Discord bot, the `/api/agent` surface, cross-browser matrix, visual
+  regression.
+- Breadth-first per-route coverage. The http and integration tiers already
+  cover most server-side paths; duplicating them in a browser buys little.
+
+## Architecture
+
+A fourth tier, peer to the existing three, with its own runner.
+
+```
+playwright.config.js        repo root
+e2e/
+  global-setup.js           sign-in + storageState provisioning
+  fixtures/                 per-spec seeders over supabaseAdmin + pg
+  specs/                    one file per ar-7v3k checklist item
+  .auth/                    storageState JSON (gitignored)
+  report/                   HTML report + traces (gitignored)
+```
+
+`bun run test:e2e` → `playwright test`. Existing tiers,
+`scripts/run-tests.mjs`, and `bun run check` are untouched; Playwright does its
+own file discovery, so the `httpFiles` / `integrationFiles` sets in
+`scripts/run-tests.mjs` do not change.
+
+**Runner: `@playwright/test`, not `bun:test` + `playwright-core`.** The tier's
+output is a findings report, and Playwright's runner supplies trace-on-failure,
+screenshots, video, retries, and the trace viewer. Driving `playwright-core`
+from `bun:test` would keep one runner across all four tiers but discard exactly
+the artifacts that make a browser failure diagnosable.
+
+**Browser: Chromium only.** The refactor is behavioral, not
+rendering-sensitive. Adding browsers multiplies runtime for no signal here.
+
+**Server:** the config's `webServer` boots `bun run index.js` on **port 3100**,
+so it never collides with a `bun run dev` on 3000. It refuses to start unless
+`SUPABASE_URL` matches `http://127.0.0.1:54321`, mirroring the guard the
+integration tier applies at `scripts/run-tests.mjs:44-48`.
+
+**Prerequisite:** `supabase start` and `bun run seed:local` must have run. The
+suite fails fast with that instruction rather than producing confusing empty-DB
+failures.
+
+## Authentication
+
+Auth tokens live in `localStorage` as `authToken` / `refreshToken`
+(`public/js/app.js:74-92`) and are attached to htmx requests via
+`htmx:configRequest`. A plain browser navigation carries no `Authorization`
+header, which is the whole reason protected routes bounce through
+`/auth/check?r=`.
+
+`e2e/global-setup.js` therefore:
+
+1. Signs in **through the real `/auth` form** as the seeded admin
+   (`dummy@testing.com` / `dummypassword`, from `util/seed-admin.js:43-44`) and
+   saves `storageState` to `e2e/.auth/admin.json`.
+2. Provisions a second, non-admin user at a fixed address
+   (`e2e-player@testing.com`) via `supabaseAdmin.auth.admin.createUser`, signs
+   it in the same way, and saves `e2e/.auth/player.json`.
+
+The player account is **infrastructure, not fixture data**: it has a stable
+email, is created idempotently (skipped if already present, exactly as
+`util/seed-admin.js` treats the admin), and is never torn down. It needs the
+admin API rather than the direct `insert into auth.users` the fixtures use,
+because it must be able to sign in with a password — the fixtures' auth rows
+only ever need to own records, never to authenticate.
+
+Signing in through the form rather than injecting tokens is deliberate: the
+localStorage contract in `app.js:74-92` is itself refactor-adjacent, so the
+setup doubles as a check. If sign-in breaks, every spec fails loudly at setup.
+
+The non-admin user exists for checklist item 3 — "a character you do **not** own
+shows no Edit button" — which cannot be expressed with a single account.
+
+The `ar-h6rt` specs deliberately ignore both storage states and start
+**unauthenticated**, because the defect lives in the `/auth/check?r=` flow
+itself.
+
+## Fixtures
+
+`e2e/fixtures/` exports per-spec seeders built on `supabaseAdmin` and a `pg`
+`Client`, following the conventions already established in
+`models/character-atomic.integration.test.js`: direct `insert into auth.users`
+for auth rows, `supabaseAdmin` for application tables, connection string from
+`process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'`.
+
+Each spec seeds only the rows it needs in `beforeAll`, under a per-run unique
+prefix (`e2e-<spec>-<timestamp>-<random>`, as
+`character-atomic.integration.test.js:7` does), and deletes by that prefix in
+`afterAll`.
+
+**No `supabase db reset`.** The developer's local dev data is never touched, and
+specs stay parallel-safe because no two runs share a prefix.
+
+Fixture shapes required by the checklist: a character owned by the admin; a
+character owned by the player (for the non-owner check); a character whose name
+contains an apostrophe; a character with abilities and perk text; a class with
+unlock codes; a class the admin owns several copies of (My Classes duplicate); a
+mission plus an offscreen mission with a linked source mission; an LFG post
+where the admin is host, and one where they are not; a CMS page with an existing
+slug.
+
+## Spec inventory
+
+One spec file per ar-7v3k checklist item, so the ticket can be struck through
+item by item.
+
+| # | Spec | What only a browser proves |
+| --- | --- | --- |
+| 1 | Level-up modal, full cycle + all four close paths | The only path writing character data through a converted modal; `character-level-up.js` (317 lines) hangs off a one-line event bridge |
+| 2 | Boosted navigation → navbar menu arrives closed | The entire justification for `defaultSettleDelay: 0` |
+| 3 | Stats editor cycle; non-owner sees no Edit button | Reveal focuses the first input, live total tracks, Cancel restores, Save persists |
+| 4 | Perk textarea round-trip | That `ability_perk_text[]` still persists — silent data loss otherwise |
+| 5 | Deceased modal | `body.modal-open` prevents background scroll; exact-name gate with an apostrophe |
+| 6 | Unlock-code modal | All four close paths; prior code gone on reopen |
+| 7 | Offscreen mission edit with a linked source | "Other" fields start hidden while the select still shows the linked mission |
+| 8 | Page editor on an existing page | Title and slug populate; saving without touching the slug does not change the URL |
+| 9 | My Classes duplicate | One row's Duplicate opens only that row's modal, and submits |
+| 10 | LFG controls | Create-form checkbox, join-form radios, calendar panel, per-participant Details, lazy-loaded join requests |
+| 11 | Export dropdowns (character + class) | Second-click close, outside-click close, Escape close, both export links download |
+| 12 | Back button after boosted navigation | htmx restores a snapshot taken after Alpine stripped `x-cloak` and wrote `:class` |
+| 13 | **ar-h6rt** auth redirect | Address bar matches rendered page; navigating away does not bounce; `//evil.com` and `/\evil.com` still rejected; a boosted navigation is not undone by the 100 ms timer |
+
+Spec 13 is not on the ar-7v3k list — it covers the acceptance criteria of the
+`ar-h6rt` fixes on the current branch, which have the same
+untestable-without-a-browser character.
+
+## Failure policy
+
+These are new tests against code that has never run in a browser. Some are
+expected to fail, and a failure is the deliverable, not a problem to code
+around.
+
+When a spec fails: **stop, do not modify production code.** Record the failure,
+its trace, and a diagnosis. This mirrors the convention already written into
+`docs/superpowers/plans/2026-08-01-test-gap-remediation.md`:
+
+> If a test fails, stop: you have likely found a real bug. Do not change
+> production code to make it pass; report it.
+
+The one legitimate exception is a spec whose *expectation* is wrong — a
+misreading of intended behavior. That gets fixed in the spec, with a note in the
+findings explaining why it was an expectation bug and not a product bug.
+
+The pass ends with a findings table: check, verdict, trace path, diagnosis. The
+user triages which failures are real before any fix is attempted.
+
+## Artifacts and reporting
+
+Trace, screenshot, and video retained on failure only (`retain-on-failure`), to
+keep passing runs cheap. HTML report to `e2e/report/`. Both `e2e/.auth/` and
+`e2e/report/` are added to `.gitignore`.
+
+## CI
+
+New `.github/workflows/e2e.yml`, mirroring the structure of
+`.github/workflows/integration.yml`:
+
+```
+supabase start
+supabase db reset
+bun run seed:local
+bunx playwright install --with-deps chromium
+bun run test:e2e
+```
+
+Path filters match `integration.yml` plus `public/**`, `views/**`, and `e2e/**`,
+since this tier is sensitive to client-side and template changes that the
+integration tier ignores. The HTML report uploads as an artifact on failure.
+
+## Documentation
+
+`README.md` and `CONTRIBUTING.md` gain the fourth tier: what it covers, its
+`supabase start` + `seed:local` prerequisites, and how to open a trace.
+
+## Success criteria
+
+- `bun run test:e2e` runs Chromium against a locally-booted app and executes all
+  thirteen specs.
+- Every item on the ar-7v3k "BLOCKING: manual browser verification" list has a
+  corresponding automated spec, so the section can be replaced by a suite
+  reference.
+- A findings report enumerates every failure with a replayable trace.
+- The existing three tiers and `bun run check` are unchanged and still green.
+- A clean checkout with `supabase start` + `bun run seed:local` can run the tier
+  with no further manual setup.

--- a/models/profile.js
+++ b/models/profile.js
@@ -3,19 +3,12 @@ const { escapeLikePattern } = require('../util/validate');
 const { SYSTEM_ACTOR } = require('../util/actor');
 const { ProfileService } = require('../services/profile/service');
 const profileRepository = require('../services/profile/repository');
+const { STARTER_RULES_PDF_ID, STARTER_CLASS_UNLOCKS } = require('../util/starter-content');
 
 const PROFILE_NOT_FOUND_ERROR = 'PGRST116';
 
 // Starter content IDs - Advent v1 rules and base 6 classes
-const STARTER_RULES_PDF_ID = 'a10948ac-5f78-481f-9e53-c582b59926cd'; // Enclave: Advent v1
-const STARTER_CLASS_IDS = [
-  'b6ce893b-8207-4f89-abfc-a02ae0e9b65d', // Gunslinger
-  '018fcdba-39cf-4cc8-8f4d-92e2023719cf', // Illusionist
-  'f0de4397-5e71-4ed6-a16a-26dc72c46801', // Librarian
-  'aa0f9690-37a6-4784-9119-1b2117f798a7', // Thane
-  'a605940b-f27f-45d8-af76-abda848b3e12', // Thunderbird
-  'ebd55f52-9768-400a-94d6-392cd07e2b24', // Wanderer
-];
+const STARTER_CLASS_IDS = Object.values(STARTER_CLASS_UNLOCKS);
 const STARTER_UNLOCK_DAYS = 30;
 
 const profileService = new ProfileService(profileRepository);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "setup": "bun run scripts/setup.mjs",
     "seed:local": "bun run scripts/seed-local.mjs",
     "seed:classes": "bun run util/seed-classes.js",
+    "seed:rules": "bun run util/seed-rules-pdfs.js",
     "seed:admin": "bun run util/seed-admin.js",
     "seed:badges": "bun run scripts/seed-badges.js",
     "fetch:badges": "bun run scripts/fetch-badge-art.js",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -928,6 +928,15 @@ const App = (function (document, supabase, htmx) {
     start();
   }
 
+  // Only honor same-origin, in-app paths ("/foo"). Reject protocol-relative
+  // ("//evil.com"), absolute ("https://evil.com"), and backslash-prefixed
+  // values so a crafted ?r= cannot redirect the user off-site. Stricter than
+  // the server-side isSameOriginPath check (which loosely accepts
+  // "/\evil.com") -- do not relax this to match it.
+  function _isSafeInAppPath(url) {
+    return !!url && url[0] === '/' && url[1] !== '/' && url[1] !== '\\';
+  }
+
   function redirectTo(url) {
     const token = _getAuthToken();
     const refresh = _getRefreshToken();
@@ -936,6 +945,16 @@ const App = (function (document, supabase, htmx) {
       headers['Authorization'] = `Bearer ${token}`;
       headers['Refresh-Token'] = refresh;
     }
+    // Update the address bar synchronously, before the swap settles, so it
+    // never diverges from what's rendered. Use replaceState (never
+    // pushState) so Back can't land on /auth/check and re-trigger the
+    // bounce. This must not be deferred into the ajax completion callback:
+    // if the swap fails, an already-updated URL means a reload retries the
+    // intended target, whereas deferring the write would leave the user
+    // stuck at /auth/check -- exactly the trap being fixed.
+    if (_isSafeInAppPath(url)) {
+      history.replaceState(null, '', url);
+    }
     // Use swap: 'outerHTML' to ensure proper body replacement
     htmx.ajax('GET', url, { target: 'body', swap: 'outerHTML', headers });
   }
@@ -943,11 +962,7 @@ const App = (function (document, supabase, htmx) {
   function getRedirectUrl() {
     const url = new URL(window.location.href);
     const r = url.searchParams.get('r');
-    // Only honor same-origin, in-app paths ("/foo"). Reject protocol-relative
-    // ("//evil.com"), absolute ("https://evil.com"), and backslash-prefixed
-    // values so a crafted ?r= cannot redirect the user off-site. Mirrors the
-    // server-side isSameOriginPath check.
-    if (!r || r[0] !== '/' || r[1] === '/' || r[1] === '\\') {
+    if (!_isSafeInAppPath(r)) {
       return null;
     }
     return r;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -996,6 +996,14 @@ const App = (function (document, supabase, htmx) {
           const current = window.location.pathname + window.location.search;
           // Use a small delay to ensure any editors are initialized first, then redirect
           setTimeout(() => {
+            // A boosted navigation can move the user to a different page
+            // during this delay without a real page load, leaving this timer
+            // pending. Re-read the location and bail if it no longer matches
+            // what we captured, so we don't drag the user back to a page
+            // they already left. Do not simplify this to an unconditional
+            // redirectTo(current).
+            const now = window.location.pathname + window.location.search;
+            if (now !== current) return;
             redirectTo(current);
           }, 100);
         }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -664,7 +664,11 @@ const App = (function (document, supabase, htmx) {
 
   // Handle form submissions - sync editors before submit
   const _setupFormSync = () => {
-    document.body.addEventListener('submit', function(event) {
+    // Bound to `document`, not `document.body`: redirectTo() replaces the
+    // <body> element on every authed page load (outerHTML swap), which
+    // destroys any listener bound directly to that node. `document` itself
+    // is never replaced, so listeners survive.
+    document.addEventListener('submit', function(event) {
       const form = event.target;
       if (form && form.tagName === 'FORM') {
         _syncToastUIEditorsToTextareas(form);
@@ -672,7 +676,7 @@ const App = (function (document, supabase, htmx) {
     }, true); // Use capture phase to run before HTMX
 
     // Also sync before HTMX requests
-    document.body.addEventListener('htmx:configRequest', function(event) {
+    document.addEventListener('htmx:configRequest', function(event) {
       const form = event.detail.elt;
       if (form && form.tagName === 'FORM') {
         _syncToastUIEditorsToTextareas(form);
@@ -701,7 +705,11 @@ const App = (function (document, supabase, htmx) {
       supabaseClient.auth.onAuthStateChange(_handleAuthStateChange);
 
       // add auth token to htmx requests
-      document.body.addEventListener("htmx:configRequest", function (event) {
+      // Bound to `document`, not `document.body`: redirectTo() replaces the
+      // <body> element on every authed page load (outerHTML swap), which
+      // destroys any listener bound directly to that node. `document` itself
+      // is never replaced, so listeners survive.
+      document.addEventListener("htmx:configRequest", function (event) {
         const authToken = _getAuthToken();
         const refreshToken = _getRefreshToken();
         if (authToken && refreshToken) {
@@ -711,7 +719,7 @@ const App = (function (document, supabase, htmx) {
       });
 
       // handle htmx errors
-      document.body.addEventListener("htmx:responseError", function (event) {
+      document.addEventListener("htmx:responseError", function (event) {
         _displayError(_extractErrorMessage(event.detail.xhr.response));
       });
 
@@ -723,7 +731,7 @@ const App = (function (document, supabase, htmx) {
       });
 
       // Add handler for htmx:afterSettle
-      document.body.addEventListener('htmx:afterSettle', function(event) {
+      document.addEventListener('htmx:afterSettle', function(event) {
         const xhr = event.detail && event.detail.xhr;
         if (!xhr) return;
         const authOptional = xhr.getResponseHeader('X-Auth-Optional') === 'true';
@@ -840,7 +848,11 @@ const App = (function (document, supabase, htmx) {
         form.dataset.navFormInit = 'true';
       };
 
-      document.body.addEventListener('htmx:afterSwap', function(evt) {
+      // Bound to `document`, not `document.body`: redirectTo() replaces the
+      // <body> element on every authed page load (outerHTML swap), which
+      // destroys any listener bound directly to that node. `document` itself
+      // is never replaced, so listeners survive.
+      document.addEventListener('htmx:afterSwap', function(evt) {
         // Handle character search results visibility
         const targetEl = evt.detail && evt.detail.target;
         if (targetEl && targetEl.id === 'characterSearchResults') {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -702,7 +702,25 @@ const App = (function (document, supabase, htmx) {
       })();
       // initialize supabase client
       supabaseClient = supabase.createClient(supabaseUrl, supabaseKey);
-      supabaseClient.auth.onAuthStateChange(_handleAuthStateChange);
+      // This subscription handles only the LIVE auth events. supabase-js
+      // also emits INITIAL_SESSION to every subscriber once it finishes
+      // initializing (onAuthStateChange fires an async IIFE ->
+      // _emitInitialSession -> callback('INITIAL_SESSION', session)), and
+      // start() below already dispatches that event itself from an explicit
+      // getSession(). Handling it in both places ran the whole INITIAL_SESSION
+      // branch twice per page load -- two _syncDiscordToProfile() round-trips
+      // and two redirectTo() body swaps of the entire page.
+      //
+      // start() owns INITIAL_SESSION rather than this subscription because
+      // its session comes from a getSession() we await directly, so the
+      // event is dispatched exactly once with a known session, independent
+      // of when supabase's own emit happens to win the lock. Do not drop
+      // the guard and rely on the emit instead: that couples the whole
+      // authed-page bootstrap to supabase-js internals.
+      supabaseClient.auth.onAuthStateChange((event, session) => {
+        if (event === 'INITIAL_SESSION') return;
+        return _handleAuthStateChange(event, session);
+      });
 
       // add auth token to htmx requests
       // Bound to `document`, not `document.body`: redirectTo() replaces the

--- a/routes/nav-manage-navbar.test.js
+++ b/routes/nav-manage-navbar.test.js
@@ -1,0 +1,157 @@
+// routes/nav-manage-navbar.test.js
+//
+// ar-h6rt: GET /nav/manage rendered its admin table data under the key
+// `navItems` -- the same key `util/nav-loader.js` puts the *decorated*
+// navbar items into `res.locals` under, and the same key
+// `views/partials/nav.handlebars` iterates. Express render-locals win over
+// res.locals, so the layout's navbar silently switched to the admin rows.
+//
+// Those rows come from getAllNavItems(), which returns raw `nav_items`
+// records; only getNavItems() computes `href` (models/nav.js:59-65). The
+// navbar template reads `navItem.href`, so every link on that one page
+// rendered `href=""`.
+//
+// The user-visible failure is a navigation trap, not just dead links:
+//   1. htmx only boosts anchors with a truthy raw href (its `ut()` guard),
+//      so an empty href is left as a plain browser navigation.
+//   2. `href=""` resolves to the *current* URL, so the browser navigates
+//      back to /nav/manage.
+//   3. A real navigation carries no Authorization header (tokens live in
+//      localStorage), so util/auth.js 302s to /auth/check?r=/nav/manage,
+//      which then redirects back to /nav/manage.
+// Net effect: clicking "Characters" bounces through an auth check and
+// lands on /nav/manage again, with no way out via the navbar.
+//
+// These tests pin the contract at the route boundary: whatever key the
+// admin table uses, the render context must not clobber the navbar data
+// the layout already has.
+const { test, expect, mock, beforeAll, afterAll } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY
+  || process.env.SUPABASE_ANON_KEY
+  || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY
+  || process.env.SUPABASE_SERVICE_ROLE_KEY
+  || 'test-secret-key';
+
+const realAuth = require('../models/auth');
+const realProfile = require('../models/profile');
+const realNav = require('../models/nav');
+const realPages = require('../models/pages');
+
+// Raw rows exactly as getAllNavItems() returns them: no `href`, only `url`.
+const RAW_ROWS = [
+  { id: 'n1', label: 'Characters', type: 'link', url: '/characters', parent_id: null, position: 0, pages: null },
+  { id: 'n2', label: 'Admin', type: 'dropdown', url: null, parent_id: null, position: 1, pages: null },
+  { id: 'n3', label: 'Manage Navigation', type: 'link', url: '/nav/manage', parent_id: 'n2', position: 0, pages: null }
+];
+
+// What util/nav-loader.js actually puts on res.locals: decorated, with href.
+const DECORATED_NAV = [
+  { id: 'n1', label: 'Characters', type: 'link', url: '/characters', href: '/characters', children: [] },
+  { id: 'n2', label: 'Admin', type: 'dropdown', href: '#', children: [
+    { id: 'n3', label: 'Manage Navigation', type: 'link', url: '/nav/manage', href: '/nav/manage', children: [] }
+  ] }
+];
+
+mock.module('../models/auth', () => ({
+  getUserFromToken: async (token) => (token === 'valid-jwt' ? { id: 'u1' } : false),
+}));
+mock.module('../models/profile', () => ({
+  getProfile: async () => ({ id: 'p-admin', user_id: 'u1', role: 'admin' })
+}));
+mock.module('../models/nav', () => ({
+  // The real util/nav-loader calls this to fill res.locals.navItems, which
+  // is what the layout's navbar reads. Keep it wired so the test exercises
+  // the production path rather than hand-seeding res.locals.
+  getNavItems: async () => ({ data: DECORATED_NAV, error: null }),
+  getAllNavItems: async () => ({ data: RAW_ROWS, error: null }),
+  getNavItem: async () => ({ data: null, error: null }),
+  createNavItem: async () => ({ data: null, error: null }),
+  updateNavItem: async () => ({ data: null, error: null }),
+  deleteNavItem: async () => ({ data: null, error: null }),
+  reorderNavItems: async () => ({ data: null, error: null }),
+  getDropdownParents: async () => ({ data: [], error: null })
+}));
+mock.module('../models/pages', () => ({ getPages: async () => ({ data: [], error: null }) }));
+
+const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  delete require.cache[require.resolve('./nav')];
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+
+  // Stand in for the Handlebars view engine: capture what the route hands
+  // to res.render. res.locals.navItems is left to the real
+  // util/nav-loader, which isAuthenticated invokes.
+  app.use((req, res, next) => {
+    res.render = (view, ctx) => res.json({
+      view,
+      ctx: ctx || {},
+      // Express render-locals shadow res.locals, so this is the array the
+      // navbar partial will actually iterate.
+      navbarSees: (ctx && 'navItems' in ctx) ? ctx.navItems : res.locals.navItems
+    });
+    next();
+  });
+
+  app.use('/nav', require('./nav'));
+  ({ server, baseUrl } = await startHttpServer(app));
+});
+
+afterAll(async () => {
+  await stopHttpServer(server);
+  mock.module('../models/auth', () => realAuth);
+  mock.module('../models/profile', () => realProfile);
+  mock.module('../models/nav', () => realNav);
+  mock.module('../models/pages', () => realPages);
+  delete require.cache[require.resolve('./nav')];
+});
+
+const getManage = async () => {
+  const res = await fetch(`${baseUrl}/nav/manage`, {
+    headers: { Authorization: 'Bearer valid-jwt' }
+  });
+  expect(res.status).toBe(200);
+  return res.json();
+};
+
+const flatten = (items) => (items || []).flatMap(
+  (item) => [item, ...flatten(item.children)]
+);
+
+test('every navbar link on /nav/manage renders a usable href', async () => {
+  const { navbarSees } = await getManage();
+
+  const links = flatten(navbarSees).filter((item) => item.type !== 'dropdown');
+  expect(links.length).toBeGreaterThan(0);
+
+  // An empty href is the trap: htmx refuses to boost it and the browser
+  // resolves it back to the current URL.
+  for (const link of links) {
+    expect(link.href).toBeTruthy();
+  }
+});
+
+test('/nav/manage does not replace the navbar data with its admin rows', async () => {
+  const { navbarSees } = await getManage();
+  expect(navbarSees).toEqual(DECORATED_NAV);
+});
+
+test('the admin table still receives the hierarchy it needs', async () => {
+  const { ctx } = await getManage();
+
+  // Key name is the fix's choice; the data contract is what matters.
+  const table = ctx.items || ctx.navItems;
+  expect(table).toBeDefined();
+  expect(table.map((item) => item.id)).toEqual(['n1', 'n2']);
+
+  const admin = table.find((item) => item.id === 'n2');
+  expect(admin.children.map((child) => child.id)).toEqual(['n3']);
+});

--- a/routes/nav.js
+++ b/routes/nav.js
@@ -66,7 +66,13 @@ router.get('/manage', isAuthenticated, requireAdmin, async (req, res) => {
     return res.render('nav-manage', {
         profile,
         title: 'Manage Navigation',
-        navItems: rootItems,
+        // Deliberately NOT `navItems`: util/nav-loader puts the decorated
+        // navbar items on res.locals under that name, and render-locals
+        // shadow res.locals. Reusing the key swapped the layout's navbar
+        // for these raw getAllNavItems() rows, which carry `url` but no
+        // computed `href` -- rendering every navbar link as href="" and
+        // trapping the user on this page. See ar-h6rt.
+        items: rootItems,
         activeNav: null,
         breadcrumbs: [
             { label: 'Manage Navigation', href: '/nav/manage' }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -18,7 +18,8 @@ const httpFiles = new Set([
   'routes/character-wizard.test.js',
   'routes/characters.test.js',
   'routes/classes-stat-spread.test.js',
-  'routes/missions.test.js'
+  'routes/missions.test.js',
+  'routes/nav-manage-navbar.test.js'
 ]);
 const mode = process.argv[2] || 'unit';
 

--- a/scripts/seed-local.mjs
+++ b/scripts/seed-local.mjs
@@ -9,6 +9,7 @@
 //   nav_items  -> supabase/seed.sql            (if empty)
 //   admin      -> seed:admin                   (if no admin profile)
 //   classes    -> seed:classes                 (needs admin; if empty)
+//   rules_pdfs -> seed:rules                    (needs admin; if empty)
 //   badges     -> fetch-badge-art + seed-badges (if empty)
 //
 // Usage: bun run seed:local [--force]
@@ -119,6 +120,14 @@ async function main() {
       run("seeding classes", ["bun", "run", "seed:classes"]);
     }
 
+    // rules PDFs — needs admin (created_by); the starter rules-PDF unlock
+    // grant references this row's id, so it must exist before profiles do.
+    if ((await count("rules_pdfs")) > 0) {
+      skip("rules_pdfs already seeded");
+    } else {
+      run("seeding rules PDFs", ["bun", "run", "seed:rules"]);
+    }
+
     // badges — fetch source art (from public prod bucket) then seed.
     if ((await count("badges")) > 0) {
       skip("badges already seeded");
@@ -129,7 +138,7 @@ async function main() {
 
     console.log("");
     ok("local seeding complete");
-    for (const t of ["nav_items", "classes", "badges", "profiles"]) {
+    for (const t of ["nav_items", "classes", "rules_pdfs", "badges", "profiles"]) {
       console.log(`      ${t.padEnd(12)} ${await count(t)} rows`);
     }
   } finally {

--- a/test/auth-initial-session-dispatch.test.js
+++ b/test/auth-initial-session-dispatch.test.js
@@ -1,0 +1,113 @@
+// test/auth-initial-session-dispatch.test.js
+//
+// ar-h6rt (third defect): app.js dispatched INITIAL_SESSION twice per page
+// load.
+//
+//   1. init() subscribes: supabaseClient.auth.onAuthStateChange(
+//      _handleAuthStateChange). supabase-js emits INITIAL_SESSION to every
+//      subscriber on its own -- onAuthStateChange() fires an async IIFE
+//      that awaits initializePromise, takes the lock, then calls
+//      _emitInitialSession(id), which invokes the callback with
+//      ('INITIAL_SESSION', session). See
+//      node_modules/@supabase/auth-js/dist/main/GoTrueClient.js:1233-1253.
+//   2. init() ALSO calls _handleAuthStateChange('INITIAL_SESSION', session)
+//      directly, from its own await getSession().
+//
+// The INITIAL_SESSION branch is not idempotent -- its only guard protects
+// token writing, not the redirect -- so both dispatches ran the full path:
+// two _syncDiscordToProfile() round-trips and two redirectTo() body swaps
+// of the whole page. A production HAR of one /auth/check bounce shows
+// exactly that: two GET /auth/v1/user, two POST /profile/discord/sync, and
+// two htmx GET /nav/manage ~200ms apart.
+//
+// test/auth-redirect-history.test.js could not catch this: its supabase
+// stub uses `onAuthStateChange: () => {}`, which never emits, so only the
+// manual dispatch ever ran. The stub below emits the way the real client
+// does, which is the whole point of this file.
+const { test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const APP_JS_PATH = path.join(__dirname, '..', 'public', 'js', 'app.js');
+const APP_SOURCE = fs.readFileSync(APP_JS_PATH, 'utf8');
+
+// Same loading strategy as auth-redirect-history.test.js (see the long note
+// at the top of that file for why `new Function` rather than vm/require):
+// app.js is a browser-global IIFE with no exports.
+async function loadAppWithEmittingAuthStub(url) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url });
+  const { window } = dom;
+
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.localStorage = window.localStorage;
+  globalThis.history = window.history;
+
+  if (window.document.readyState === 'loading') {
+    await new Promise((resolve) => window.document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+  }
+
+  const session = { access_token: 'tok-1', refresh_token: 'refresh-1' };
+  const getUserCalls = [];
+
+  const supabaseStub = {
+    createClient: () => ({
+      auth: {
+        // Faithful to supabase-js: registering a listener schedules an
+        // asynchronous INITIAL_SESSION emit to that listener.
+        onAuthStateChange: (callback) => {
+          (async () => { await callback('INITIAL_SESSION', session); })();
+          return { data: { subscription: { unsubscribe: () => {} } } };
+        },
+        getUser: async () => {
+          getUserCalls.push(Date.now());
+          // No Discord identity: _syncDiscordToProfile bails on the `error`
+          // branch before touching fetch().
+          return { data: null, error: 'no-user' };
+        },
+        getSession: async () => ({ data: { session } })
+      }
+    })
+  };
+
+  const ajaxCalls = [];
+  const htmxStub = { ajax: (...args) => { ajaxCalls.push(args); } };
+
+  window.history.replaceState = () => {};
+  window.history.pushState = () => {};
+
+  const loadModule = new Function('document', 'supabase', 'htmx', `${APP_SOURCE}\nreturn App;`);
+  const App = loadModule(window.document, supabaseStub, htmxStub);
+
+  App.init('https://test.invalid', 'test-publishable-key');
+
+  // Let BOTH dispatch paths finish. The subscription emit and the manual
+  // getSession() dispatch are independent async chains, so this waits well
+  // past either of them settling rather than racing the first one.
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  return { ajaxCalls, getUserCalls };
+}
+
+test('INITIAL_SESSION triggers exactly one redirect body swap', async () => {
+  const { ajaxCalls } = await loadAppWithEmittingAuthStub(
+    'http://localhost/auth/check?r=%2Fnav%2Fmanage'
+  );
+
+  // Still redirects to the right place...
+  expect(ajaxCalls.length).toBeGreaterThan(0);
+  expect(ajaxCalls[0][1]).toBe('/nav/manage');
+
+  // ...but only once. A second swap re-renders the whole page and destroys
+  // any state the first swap established.
+  expect(ajaxCalls.length).toBe(1);
+});
+
+test('INITIAL_SESSION runs the Discord profile sync exactly once', async () => {
+  const { getUserCalls } = await loadAppWithEmittingAuthStub(
+    'http://localhost/auth/check?r=%2Fnav%2Fmanage'
+  );
+
+  expect(getUserCalls.length).toBe(1);
+});

--- a/test/auth-redirect-history.test.js
+++ b/test/auth-redirect-history.test.js
@@ -272,3 +272,89 @@ test('staying on the same page through the deferred-refresh window still trigger
   expect(ajaxCalls.length).toBe(1);
   expect(ajaxCalls[0][1]).toBe('/nav/manage');
 });
+
+// ar-h6rt (third and root defect): redirectTo() calls
+// `htmx.ajax('GET', url, { target: 'body', swap: 'outerHTML', headers })`.
+// A real htmx `outerHTML` swap on `target: 'body'` replaces the <body>
+// element itself, not its contents. App.init binds most of its listeners --
+// including the one at ~line 704 that adds the Authorization/Refresh-Token
+// headers to every htmx request -- to `document.body`, so replacing that
+// element destroys them. Every htmx request issued after the first
+// auth-driven redirect goes out unauthenticated.
+//
+// Reuses loadAppAndTriggerInitialSession's setup, but replaces the htmxStub
+// so `ajax()` performs the real DOM consequence of that swap: it detaches
+// the current <body> and puts a brand new, listener-free <body> element in
+// its place (a fresh node cannot carry over addEventListener registrations
+// made against the old one -- that is the whole mechanism of the bug).
+async function loadAppAndTriggerInitialSessionThenSwapBody(url) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url });
+  const { window } = dom;
+
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.localStorage = window.localStorage;
+  globalThis.history = window.history;
+
+  if (window.document.readyState === 'loading') {
+    await new Promise((resolve) => window.document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+  }
+
+  const session = { access_token: 'tok-1', refresh_token: 'refresh-1' };
+  const supabaseStub = {
+    createClient: () => ({
+      auth: {
+        onAuthStateChange: () => {},
+        getUser: async () => ({ data: null, error: 'no-user' }),
+        getSession: async () => ({ data: { session } })
+      }
+    })
+  };
+
+  const bodyBeforeSwap = window.document.body;
+  let resolveAjaxCalled;
+  const ajaxCalled = new Promise((resolve) => { resolveAjaxCalled = resolve; });
+  const htmxStub = {
+    ajax: (...args) => {
+      // The real DOM consequence of `swap: 'outerHTML'` on `target: 'body'`:
+      // the current <body> element is detached and a brand new one takes
+      // its place, taking every listener bound to the old node with it.
+      const freshBody = window.document.createElement('body');
+      window.document.body.replaceWith(freshBody);
+      resolveAjaxCalled();
+    }
+  };
+
+  const loadModule = new Function('document', 'supabase', 'htmx', `${APP_SOURCE}\nreturn App;`);
+  const App = loadModule(window.document, supabaseStub, htmxStub);
+
+  App.init('https://test.invalid', 'test-publishable-key');
+  await ajaxCalled;
+
+  return { window, bodyBeforeSwap };
+}
+
+test('the Authorization header still gets added to htmx requests after redirectTo swaps the body', async () => {
+  const { window, bodyBeforeSwap } = await loadAppAndTriggerInitialSessionThenSwapBody(
+    'http://localhost/auth/check?r=%2Fnav%2Fmanage'
+  );
+
+  // Guard against a vacuous test: the swap must have actually replaced the
+  // body element, not merely been invoked. If this assertion ever fails, the
+  // test below is no longer exercising anything real.
+  expect(window.document.body).not.toBe(bodyBeforeSwap);
+
+  const headers = {};
+  // bubbles: true is deliberate, not incidental: htmx's own triggerEvent
+  // helper constructs every htmx:* event with bubbles: true, so a
+  // document-level listener in the (default) bubble phase always sees it in
+  // production. Dropping this back to the CustomEvent default of
+  // bubbles: false would silently stop exercising the real bug and could
+  // reintroduce a capture-phase-vs-bubble-phase mismatch between this and
+  // the other htmx:configRequest listener.
+  const configRequestEvent = new window.CustomEvent('htmx:configRequest', { detail: { headers }, bubbles: true });
+  window.document.body.dispatchEvent(configRequestEvent);
+
+  expect(headers['Authorization']).toBe('Bearer tok-1');
+  expect(headers['Refresh-Token']).toBe('refresh-1');
+});

--- a/test/auth-redirect-history.test.js
+++ b/test/auth-redirect-history.test.js
@@ -153,3 +153,122 @@ test('an unsafe window.location.pathname reaching redirectTo via the no-?r= time
   // something off-site.
   expect(historyCalls.replaceState.length).toBe(0);
 });
+
+// ar-h6rt (second defect): the no-?r= "refresh current page" branch (app.js
+// ~995-1000) captures `current` from window.location at event time, then
+// schedules `redirectTo(current)` on a 100ms setTimeout. Under hx-boost a
+// user can navigate to a different in-app page inside that 100ms window --
+// a boosted navigation is a client-side body swap that updates the URL
+// without a page load, so both the JS realm and the pending timer survive
+// it. The timer then fires and calls redirectTo() with the STALE url it
+// captured before the navigation, bouncing the user back to the page they
+// just left.
+//
+// Loads a fresh app.js/jsdom pair identically to
+// loadAppAndTriggerInitialSession above, but additionally intercepts the
+// global `setTimeout` app.js's timer branch calls (it is not passed in as a
+// parameter the way document/supabase/htmx are, so it resolves against
+// whatever `globalThis.setTimeout` is at call time). Capturing the
+// scheduled callback -- instead of waiting out the real 100ms -- lets each
+// test decide deterministically whether a simulated boosted navigation
+// happens before or after the deferred refresh runs, with no dependency on
+// wall-clock timing and no race between the navigation and the timer.
+async function loadAppAndTriggerInitialSessionWithTimerControl(url) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url });
+  const { window } = dom;
+
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.localStorage = window.localStorage;
+  globalThis.history = window.history;
+
+  if (window.document.readyState === 'loading') {
+    await new Promise((resolve) => window.document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+  }
+
+  const session = { access_token: 'tok-1', refresh_token: 'refresh-1' };
+  const supabaseStub = {
+    createClient: () => ({
+      auth: {
+        onAuthStateChange: () => {},
+        getUser: async () => ({ data: null, error: 'no-user' }),
+        getSession: async () => ({ data: { session } })
+      }
+    })
+  };
+
+  const ajaxCalls = [];
+  const htmxStub = { ajax: (...args) => { ajaxCalls.push(args); } };
+
+  // Several unrelated things also schedule setTimeout during this path:
+  // jsdom's own localStorage backing-store flush runs on a 0ms timer (fired
+  // by _setTokens()'s two setItem() calls), and app.js's start() schedules a
+  // 100ms ToastUI-editor-init timer (initializeUIComponents(), after
+  // _handleAuthStateChange() returns). The no-?r= branch's deferred refresh
+  // is the first 100ms timer scheduled, so filter to 100ms delays and take
+  // the first of those.
+  const realSetTimeout = globalThis.setTimeout;
+  const capturedTimers = [];
+  globalThis.setTimeout = (fn, ms) => {
+    capturedTimers.push({ fn, ms });
+    return 0;
+  };
+
+  const loadModule = new Function('document', 'supabase', 'htmx', `${APP_SOURCE}\nreturn App;`);
+  const App = loadModule(window.document, supabaseStub, htmxStub);
+
+  App.init('https://test.invalid', 'test-publishable-key');
+
+  // Let the async chain leading up to the setTimeout call settle
+  // (getSession(), _handleAuthStateChange's own awaits, _syncDiscordToProfile)
+  // without waiting on real timers: queue behind the pending microtasks with
+  // a real setTimeout(_, 0) macrotask.
+  await new Promise((resolve) => realSetTimeout(resolve, 0));
+
+  globalThis.setTimeout = realSetTimeout;
+
+  const deferredRefreshTimer = capturedTimers.find((entry) => entry.ms === 100);
+  const capturedTimerFn = deferredRefreshTimer && deferredRefreshTimer.fn;
+  if (typeof capturedTimerFn !== 'function') {
+    throw new Error('expected the no-?r= INITIAL_SESSION branch to schedule a deferred refresh via setTimeout');
+  }
+
+  return {
+    ajaxCalls,
+    window,
+    fireDeferredRefresh: () => capturedTimerFn()
+  };
+}
+
+test('a boosted navigation away from the page before the deferred refresh fires is not undone by a stale redirect', async () => {
+  const { ajaxCalls, window, fireDeferredRefresh } = await loadAppAndTriggerInitialSessionWithTimerControl(
+    'http://localhost/nav/manage'
+  );
+
+  // Simulate an hx-boost navigation completing inside the 100ms window: it
+  // updates window.location without a page load, the same way
+  // history.replaceState/pushState do under hx-boost.
+  window.history.replaceState(null, '', '/characters');
+
+  fireDeferredRefresh();
+
+  // The deferred refresh must not act on the stale '/nav/manage' it
+  // captured when the timer was scheduled -- the user already left that
+  // page, and dragging them back to it is exactly the reported bug.
+  const staleRedirects = ajaxCalls.filter((args) => args[1] === '/nav/manage');
+  expect(staleRedirects.length).toBe(0);
+});
+
+test('staying on the same page through the deferred-refresh window still triggers the authed re-render', async () => {
+  const { ajaxCalls, fireDeferredRefresh } = await loadAppAndTriggerInitialSessionWithTimerControl(
+    'http://localhost/nav/manage'
+  );
+
+  // No navigation happens this time -- the mechanism's whole purpose is to
+  // re-fetch the still-current page with auth headers so the server can
+  // render the authed view, and that must keep working.
+  fireDeferredRefresh();
+
+  expect(ajaxCalls.length).toBe(1);
+  expect(ajaxCalls[0][1]).toBe('/nav/manage');
+});

--- a/test/auth-redirect-history.test.js
+++ b/test/auth-redirect-history.test.js
@@ -1,0 +1,155 @@
+// ar-h6rt: redirectTo() (public/js/app.js) performs an htmx body swap but
+// never updates `history`, so after an auth-driven redirect the address bar
+// stays on `/auth/check?r=...` while the body shows the real target. Because
+// getRedirectUrl() re-reads that stale `?r=` on every later auth event
+// (token refresh, tab focus), the user gets bounced back to the same page
+// forever. See .tickets/ar-h6rt.md for the full trace.
+//
+// This is an EXECUTION test, not a source-text assertion. app.js is a
+// classic <script> IIFE — `const App = (function (document, supabase,
+// htmx) {...})(document, supabase, htmx);` — with no module.exports and no
+// export of `App` (by design: it's wired up purely through browser
+// globals, and adding a test-only export is explicitly out of bounds here).
+// `vm.runInContext` was tried first and rejected: Bun's `vm` module cannot
+// run scripts against jsdom's contextified window (`TypeError: Proxy is
+// not allowed in the global prototype chain`), a Bun-specific limitation.
+// Instead we load the real file contents with `new Function('document',
+// 'supabase', 'htmx', source + '; return App;')`. This gives every free
+// identifier in app.js the same resolution semantics a <script> tag would:
+// `document`/`supabase`/`htmx` are the function's named parameters (so we
+// can hand it stubs), everything else (`window`, `localStorage`, `history`,
+// `setTimeout`, ...) resolves against real globals, which we point at a
+// fresh jsdom window per test. This reaches the redirect logic only
+// through the real auth-event path (App.init() -> start() -> a stubbed
+// supabase.auth.getSession() -> _handleAuthStateChange('INITIAL_SESSION',
+// session) -> redirectTo()), never by exporting redirectTo itself.
+const { test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const APP_JS_PATH = path.join(__dirname, '..', 'public', 'js', 'app.js');
+const APP_SOURCE = fs.readFileSync(APP_JS_PATH, 'utf8');
+
+// Loads a fresh copy of app.js against a fresh jsdom window at `url`, with
+// stub `supabase`/`htmx` globals, then drives it through
+// App.init(...) -> INITIAL_SESSION with a fake already-authenticated
+// session -- the same path `/auth/check?r=...` takes in production
+// (util/auth.js's redirect there is what puts `?r=` on the URL in the
+// first place). Resolves once `htmx.ajax` (the body-swap call inside
+// redirectTo) has been invoked, which is the last observable effect of
+// today's implementation.
+async function loadAppAndTriggerInitialSession(url) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url });
+  const { window } = dom;
+
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.localStorage = window.localStorage;
+  globalThis.history = window.history;
+
+  if (window.document.readyState === 'loading') {
+    await new Promise((resolve) => window.document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+  }
+
+  const session = { access_token: 'tok-1', refresh_token: 'refresh-1' };
+  const supabaseStub = {
+    createClient: () => ({
+      auth: {
+        onAuthStateChange: () => {},
+        // No Discord identity: _syncDiscordToProfile must bail on the
+        // `error` branch before ever touching fetch().
+        getUser: async () => ({ data: null, error: 'no-user' }),
+        getSession: async () => ({ data: { session } })
+      }
+    })
+  };
+
+  const ajaxCalls = [];
+  let resolveAjaxCalled;
+  const ajaxCalled = new Promise((resolve) => { resolveAjaxCalled = resolve; });
+  const htmxStub = { ajax: (...args) => { ajaxCalls.push(args); resolveAjaxCalled(); } };
+
+  const historyCalls = { replaceState: [], pushState: [] };
+  window.history.replaceState = (...args) => historyCalls.replaceState.push(args);
+  window.history.pushState = (...args) => historyCalls.pushState.push(args);
+
+  const loadModule = new Function('document', 'supabase', 'htmx', `${APP_SOURCE}\nreturn App;`);
+  const App = loadModule(window.document, supabaseStub, htmxStub);
+
+  App.init('https://test.invalid', 'test-publishable-key');
+  await ajaxCalled;
+
+  return { ajaxCalls, historyCalls };
+}
+
+test('an auth-driven redirect to a valid in-app path writes a matching, replaceState history entry', async () => {
+  const { ajaxCalls, historyCalls } = await loadAppAndTriggerInitialSession(
+    'http://localhost/auth/check?r=%2Fnav%2Fmanage'
+  );
+
+  // Sanity check on the pre-existing (already-correct) part of the
+  // behavior: the body swap targets the redirect param.
+  expect(ajaxCalls[0][1]).toBe('/nav/manage');
+
+  // The missing behavior: the address bar must be updated to match what
+  // was actually rendered, via replaceState (not pushState, so Back does
+  // not land the user on /auth/check and re-trigger the bounce).
+  expect(historyCalls.pushState.length).toBe(0);
+  expect(historyCalls.replaceState.length).toBe(1);
+  expect(historyCalls.replaceState[0][2]).toBe('/nav/manage');
+});
+
+test.each([
+  ['//evil.com'],
+  ['/\\evil.com'],
+  ['https://evil.com'],
+  ['not-a-path']
+])('an unsafe ?r=%s is never written to history verbatim', async (unsafe) => {
+  const url = `http://localhost/auth/check?r=${encodeURIComponent(unsafe)}`;
+  const { ajaxCalls, historyCalls } = await loadAppAndTriggerInitialSession(url);
+
+  // getRedirectUrl() already rejects all of these, so redirectTo falls back
+  // to '/' -- that part already passes today. The point of this test is
+  // that the history write must use that same sanitized fallback, not some
+  // independent read of the raw query string.
+  expect(ajaxCalls[0][1]).toBe('/');
+
+  expect(historyCalls.replaceState.length).toBe(1);
+  expect(historyCalls.replaceState[0][2]).toBe('/');
+  for (const call of historyCalls.replaceState) {
+    expect(call[2]).not.toBe(unsafe);
+  }
+});
+
+// The four "unsafe ?r=" tests above only exercise getRedirectUrl()'s own
+// filter: an unsafe `?r=` is rejected there, so redirectTo() only ever
+// receives the already-sanitized fallback '/' -- the hostile string never
+// reaches the guard inside redirectTo itself. Disabling that guard (e.g.
+// `if (true) { history.replaceState(...) }`) leaves all five tests above
+// green, because none of them route an unsafe value into redirectTo
+// directly.
+//
+// There is a second, currently-reachable route that does: the no-`?r=`
+// "refresh current page" branch (app.js's INITIAL_SESSION handling, ~line
+// 996-1000) builds `current` from `window.location.pathname + search` and
+// passes THAT straight to redirectTo(url), on a 100ms timer. A pathname can
+// legitimately start with "//" -- e.g. `http://app.com//evil.com` parses to
+// pathname "//evil.com" -- so this is a real, reachable path to a
+// protocol-relative value reaching redirectTo, with no upstream filter.
+// This is exactly the scenario `15ab2f6` hardened against, and exactly what
+// redirectTo's own guard exists to stop even if every upstream filter were
+// ever bypassed or a future call site added one that doesn't filter.
+test('an unsafe window.location.pathname reaching redirectTo via the no-?r= timer branch is never written to history, but the swap still happens', async () => {
+  const { ajaxCalls, historyCalls } = await loadAppAndTriggerInitialSession('http://localhost//evil.com');
+
+  // Reached the timer branch, not a getRedirectUrl-filtered one: the swap
+  // target is the raw unsafe pathname itself, confirming this test takes a
+  // different route through the code than the four above.
+  expect(ajaxCalls[0][1]).toBe('//evil.com');
+
+  // Skipping the URL update must not silently break navigation -- the user
+  // still gets the page, just without the address bar being rewritten to
+  // something off-site.
+  expect(historyCalls.replaceState.length).toBe(0);
+});

--- a/util/seed-classes.js
+++ b/util/seed-classes.js
@@ -3,6 +3,7 @@ const { createClient } = require('@supabase/supabase-js');
 const ClassModel = require('../models/class');
 const { SYSTEM_ACTOR } = require('./actor');
 const { adventClassList, aspirantPreviewClassList, playerCreatedClassList, classStatSpread } = require('./enclave-consts');
+const { STARTER_CLASS_UNLOCKS } = require('./starter-content');
 
 // Initialize Supabase client
 const supabase = createClient(
@@ -10,42 +11,6 @@ const supabase = createClient(
     process.env.SUPABASE_SECRET_KEY
 );
 
-// build a list of classes from the consts
-const hardcodedClasses = [
-    ...adventClassList.map(cls => ({
-        name: cls,
-        description: '',
-        is_public: true,
-        status: 'release',
-        is_player_created: false,
-        rules_edition: 'advent',
-        rules_version: 'v1',
-        stat_spread: classStatSpread[cls] || {},
-        created_by: null
-    })),
-    ...aspirantPreviewClassList.map(cls => ({
-        name: cls,
-        description: '',
-        is_public: true,
-        status: 'release',
-        is_player_created: false,
-        rules_edition: 'advent',
-        rules_version: 'v1',
-        stat_spread: classStatSpread[cls] || {},
-        created_by: null
-    })),
-    ...playerCreatedClassList.map(cls => ({
-        name: cls,
-        description: '',
-        is_public: true,
-        status: 'release',
-        is_player_created: true,
-        rules_edition: 'advent',
-        rules_version: 'v1',
-        stat_spread: classStatSpread[cls] || {},
-        created_by: null
-    }))
-];
 
 
 async function seedClasses() {
@@ -64,7 +29,7 @@ async function seedClasses() {
         }
 
         // Set created_by to admin user ID
-        const classesWithAdmin = hardcodedClasses.map(cls => ({
+        const classesWithAdmin = buildHardcodedClasses().map(cls => ({
             ...cls,
             created_by: adminUser.user_id
         }));
@@ -86,5 +51,36 @@ async function seedClasses() {
     }
 }
 
-// Run the seed function
-seedClasses(); 
+// Building the row list must be import-safe (no network, no side effects) so
+// it can be unit tested.
+const buildRow = (cls, is_player_created) => {
+    const row = {
+        name: cls,
+        description: '',
+        is_public: true,
+        status: 'release',
+        is_player_created,
+        rules_edition: 'advent',
+        rules_version: 'v1',
+        stat_spread: classStatSpread[cls] || {},
+        created_by: null
+    };
+    if (Object.prototype.hasOwnProperty.call(STARTER_CLASS_UNLOCKS, cls)) {
+        row.id = STARTER_CLASS_UNLOCKS[cls];
+    }
+    return row;
+};
+
+const buildHardcodedClasses = () => [
+    ...adventClassList.map(cls => buildRow(cls, false)),
+    ...aspirantPreviewClassList.map(cls => buildRow(cls, false)),
+    ...playerCreatedClassList.map(cls => buildRow(cls, true)),
+];
+
+module.exports = { buildHardcodedClasses };
+
+// Run the seed function — only when invoked directly (`bun run seed:classes`),
+// never as a side effect of require().
+if (require.main === module) {
+  seedClasses();
+} 

--- a/util/seed-classes.js
+++ b/util/seed-classes.js
@@ -2,7 +2,7 @@ require('./env');
 const { createClient } = require('@supabase/supabase-js');
 const ClassModel = require('../models/class');
 const { SYSTEM_ACTOR } = require('./actor');
-const { adventClassList, aspirantPreviewClassList, playerCreatedClassList, classStatSpread } = require('./enclave-consts');
+const { adventClassList, aspirantPreviewClassList, playerCreatedClassList, classStatSpread, classGearList, classAbilityList } = require('./enclave-consts');
 const { STARTER_CLASS_UNLOCKS } = require('./starter-content');
 
 // Initialize Supabase client
@@ -63,6 +63,8 @@ const buildRow = (cls, is_player_created) => {
         rules_edition: 'advent',
         rules_version: 'v1',
         stat_spread: classStatSpread[cls] || {},
+        gear: (classGearList[cls] || []).map(name => ({ name, description: '' })),
+        abilities: (classAbilityList[cls] || []).map(name => ({ name, description: '' })),
         created_by: null
     };
     if (Object.prototype.hasOwnProperty.call(STARTER_CLASS_UNLOCKS, cls)) {

--- a/util/seed-classes.test.js
+++ b/util/seed-classes.test.js
@@ -1,6 +1,7 @@
 const { test, expect } = require('bun:test');
 const { buildHardcodedClasses } = require('./seed-classes');
 const { STARTER_CLASS_UNLOCKS } = require('./starter-content');
+const { classGearList, classAbilityList } = require('./enclave-consts');
 
 // The starter-unlock grant (models/profile.js) and the seed's class rows
 // must never drift apart, or every new profile gets a foreign-key violation
@@ -31,4 +32,32 @@ test('the seed assigns each starter class exactly the id its starter-unlock cons
   const nonStarterRow = rows.find(row => row.name === 'Berserker');
   expect(nonStarterRow).toBeDefined();
   expect(nonStarterRow.id).toBeUndefined();
+});
+
+// The wizard's ability primer (step 3) and gear shop (step 4) are built from
+// each class's gear/abilities arrays. If the seed builds rows without them,
+// those columns default to '[]'::jsonb and a locally-seeded install gets
+// empty steps. The expected names are derived from enclave-consts, never
+// pasted, so a class gaining gear/abilities there without the seed picking
+// it up fails this test.
+test('every seeded class row carries its full gear and abilities, shaped as {name, description}', () => {
+  const rows = buildHardcodedClasses();
+  const rowsByName = Object.fromEntries(rows.map(row => [row.name, row]));
+
+  // Representative class: exact shape and order, derived from the consts.
+  const expectedGear = classGearList.Gunslinger.map(name => ({ name, description: '' }));
+  const expectedAbilities = classAbilityList.Gunslinger.map(name => ({ name, description: '' }));
+  expect(rowsByName.Gunslinger.gear).toEqual(expectedGear);
+  expect(rowsByName.Gunslinger.abilities).toEqual(expectedAbilities);
+
+  // Coverage: every class the seed builds has non-empty gear and abilities,
+  // matching the consts exactly.
+  for (const row of rows) {
+    const gearNames = classGearList[row.name];
+    const abilityNames = classAbilityList[row.name];
+    expect(gearNames && gearNames.length > 0).toBe(true);
+    expect(abilityNames && abilityNames.length > 0).toBe(true);
+    expect(row.gear).toEqual(gearNames.map(name => ({ name, description: '' })));
+    expect(row.abilities).toEqual(abilityNames.map(name => ({ name, description: '' })));
+  }
 });

--- a/util/seed-classes.test.js
+++ b/util/seed-classes.test.js
@@ -1,0 +1,34 @@
+const { test, expect } = require('bun:test');
+const { buildHardcodedClasses } = require('./seed-classes');
+const { STARTER_CLASS_UNLOCKS } = require('./starter-content');
+
+// The starter-unlock grant (models/profile.js) and the seed's class rows
+// must never drift apart, or every new profile gets a foreign-key violation
+// and zero unlocked classes. Names are stable, known concepts; only the ids
+// are fragile, so the ids are derived from the modules under test rather
+// than pasted here.
+const STARTER_CLASS_NAMES = ['Gunslinger', 'Illusionist', 'Librarian', 'Thane', 'Thunderbird', 'Wanderer'];
+
+test('the seed assigns each starter class exactly the id its starter-unlock constant grants, leaving other classes id-less', () => {
+  expect(Object.keys(STARTER_CLASS_UNLOCKS).sort()).toEqual([...STARTER_CLASS_NAMES].sort());
+
+  const rows = buildHardcodedClasses();
+  const rowsByName = Object.fromEntries(rows.map(row => [row.name, row]));
+
+  for (const name of STARTER_CLASS_NAMES) {
+    expect(rowsByName[name]).toBeDefined();
+    expect(rowsByName[name].id).toBe(STARTER_CLASS_UNLOCKS[name]);
+  }
+
+  // Same invariant, checked as a set comparison rather than restating the
+  // ids a third time: the ids the starter-unlock logic grants must be
+  // exactly the ids the seed assigned to those six named rows.
+  const idsGrantedByStarterUnlock = Object.values(STARTER_CLASS_UNLOCKS).sort();
+  const idsAssignedBySeed = STARTER_CLASS_NAMES.map(name => rowsByName[name] && rowsByName[name].id).sort();
+  expect(idsAssignedBySeed).toEqual(idsGrantedByStarterUnlock);
+
+  // Non-starter classes are unaffected — Postgres is free to generate their ids.
+  const nonStarterRow = rows.find(row => row.name === 'Berserker');
+  expect(nonStarterRow).toBeDefined();
+  expect(nonStarterRow.id).toBeUndefined();
+});

--- a/util/seed-rules-pdfs.js
+++ b/util/seed-rules-pdfs.js
@@ -1,0 +1,112 @@
+require('./env');
+const { createClient } = require('@supabase/supabase-js');
+const RulesModel = require('../models/rules');
+const { RULES_PDF_BUCKET } = require('../models/pdf');
+const pdfRepository = require('../services/pdf/repository');
+const { STARTER_RULES_PDF_ID } = require('./starter-content');
+
+// Initialize Supabase client
+const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SECRET_KEY
+);
+
+// A genuinely valid minimal PDF (starts with the %PDF- signature required by
+// models/pdf.js) whose visible page text makes clear on sight that this is
+// local seed data, not the real rulebook.
+const buildPlaceholderPdfBuffer = () => {
+    const header = '%PDF-1.4\n';
+    const stream =
+        'BT /F1 16 Tf 72 700 Td (Placeholder - local development seed data.) Tj ET\n' +
+        'BT /F1 12 Tf 72 676 Td (This is not the Enclave rulebook.) Tj ET\n';
+
+    const obj1 = '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n';
+    const obj2 = '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n';
+    const obj3 = '3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>\nendobj\n';
+    const obj4 = '4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n';
+    const obj5 = `5 0 obj\n<< /Length ${stream.length} >>\nstream\n${stream}endstream\nendobj\n`;
+
+    let offset = header.length;
+    const objects = [obj1, obj2, obj3, obj4, obj5].map((str) => {
+        const entry = { offset, str };
+        offset += str.length;
+        return entry;
+    });
+
+    const xrefOffset = offset;
+    let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+    for (const o of objects) {
+        xref += `${String(o.offset).padStart(10, '0')} 00000 n \n`;
+    }
+    const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+
+    const body = header + objects.map((o) => o.str).join('') + xref + trailer;
+    return Buffer.from(body, 'latin1');
+};
+
+// Building the row list must be import-safe (no network, no side effects) so
+// it can be unit tested.
+const buildHardcodedRulesPdfs = () => [
+    {
+        id: STARTER_RULES_PDF_ID,
+        title: 'Enclave: Advent',
+        edition: 'v1',
+        storage_path: `${STARTER_RULES_PDF_ID}/local-seed-placeholder.pdf`,
+        is_active: true
+    }
+];
+
+async function seedRulesPdfs() {
+    try {
+        // Get system admin user ID
+        const { data: adminUser, error: adminError } = await supabase
+            .from('profiles')
+            .select('id')
+            .eq('role', 'admin')
+            .single();
+
+        if (adminError) {
+            throw new Error('Failed to find admin user: ' + adminError.message);
+        }
+
+        for (const row of buildHardcodedRulesPdfs()) {
+            const { data: existing } = await supabase
+                .from('rules_pdfs')
+                .select('id')
+                .eq('id', row.id)
+                .maybeSingle();
+
+            if (existing) {
+                console.log(`Rules PDF already seeded, skipping: ${row.title} (${row.id})`);
+                continue;
+            }
+
+            const { error: uploadError } = await pdfRepository.uploadObject(
+                RULES_PDF_BUCKET,
+                row.storage_path,
+                buildPlaceholderPdfBuffer(),
+                { contentType: 'application/pdf', upsert: true }
+            );
+
+            if (uploadError) {
+                throw new Error('Failed to upload placeholder rules PDF: ' + uploadError.message);
+            }
+
+            await RulesModel.createRulesPdf({ ...row, created_by: adminUser.id });
+            console.log(`Successfully seeded rules PDF: ${row.title}`);
+        }
+
+        console.log('Rules PDF seeding completed');
+    } catch (error) {
+        console.error('Error during rules PDF seeding:', error);
+        process.exit(1);
+    }
+}
+
+module.exports = { buildHardcodedRulesPdfs };
+
+// Run the seed function — only when invoked directly (`bun run seed:rules`),
+// never as a side effect of require().
+if (require.main === module) {
+  seedRulesPdfs();
+}

--- a/util/seed-rules-pdfs.test.js
+++ b/util/seed-rules-pdfs.test.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('bun:test');
+const { buildHardcodedRulesPdfs } = require('./seed-rules-pdfs');
+const { STARTER_RULES_PDF_ID } = require('./starter-content');
+
+// models/profile.js grants every new profile a rules-PDF unlock referencing
+// STARTER_RULES_PDF_ID (util/starter-content.js). Locally, nothing seeds
+// rules_pdfs, so that grant is a foreign-key violation waiting to happen.
+// The seed's row id must be derived from the same constant the grant uses —
+// never restated — or the two can drift apart again.
+test('the seed builds the starter rules PDF row under the exact id the starter-unlock grant references', () => {
+  const rows = buildHardcodedRulesPdfs();
+  const row = rows.find(r => r.id === STARTER_RULES_PDF_ID);
+
+  expect(row).toBeDefined();
+
+  // Every NOT NULL column the rules_pdfs table requires must be present and
+  // non-empty, or the row fails at insert time.
+  expect(typeof row.title).toBe('string');
+  expect(row.title.length).toBeGreaterThan(0);
+  expect(typeof row.edition).toBe('string');
+  expect(row.edition.length).toBeGreaterThan(0);
+  expect(typeof row.storage_path).toBe('string');
+  expect(row.storage_path.length).toBeGreaterThan(0);
+
+  // Upload path convention (models/pdf.js storeRulesPdf): <rulesPdfId>/<name>.pdf
+  // — a seeded storage object must land where the app looks for it.
+  expect(row.storage_path.startsWith(`${STARTER_RULES_PDF_ID}/`)).toBe(true);
+  expect(row.storage_path.endsWith('.pdf')).toBe(true);
+});

--- a/util/starter-content.js
+++ b/util/starter-content.js
@@ -1,0 +1,20 @@
+// Starter content granted to every new profile (see models/profile.js).
+//
+// This module is the single source of truth for those ids: the id assigned
+// to a starter class row in util/seed-classes.js must be exactly the id the
+// starter-unlock grant references, or every new profile hits a foreign-key
+// violation and ends up with zero unlocked classes.
+
+const STARTER_RULES_PDF_ID = 'a10948ac-5f78-481f-9e53-c582b59926cd'; // Enclave: Advent v1
+
+// class name -> id granted by the starter unlock.
+const STARTER_CLASS_UNLOCKS = {
+  Gunslinger:  'b6ce893b-8207-4f89-abfc-a02ae0e9b65d',
+  Illusionist: '018fcdba-39cf-4cc8-8f4d-92e2023719cf',
+  Librarian:   'f0de4397-5e71-4ed6-a16a-26dc72c46801',
+  Thane:       'aa0f9690-37a6-4784-9119-1b2117f798a7',
+  Thunderbird: 'a605940b-f27f-45d8-af76-abda848b3e12',
+  Wanderer:    'ebd55f52-9768-400a-94d6-392cd07e2b24',
+};
+
+module.exports = { STARTER_RULES_PDF_ID, STARTER_CLASS_UNLOCKS };

--- a/views/nav-manage.handlebars
+++ b/views/nav-manage.handlebars
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-{{#if navItems.length}}
+{{#if items.length}}
 <div class="table-container">
   <table class="table is-fullwidth is-striped">
     <thead>
@@ -27,7 +27,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each navItems}}
+      {{#each items}}
         {{#with this}}
           {{> nav-item-row navItem=this level=0}}
         {{/with}}

--- a/views/partials/character-level-up.test.js
+++ b/views/partials/character-level-up.test.js
@@ -60,7 +60,13 @@ test('app.js no longer has the global modal Escape handler', () => {
 
 test('the htmx:afterSwap re-init hub is untouched', () => {
   const src = read('../../public/js/app.js');
-  expect(src).toContain("document.body.addEventListener('htmx:afterSwap'");
+  // Asserts the hub still exists and is still wired to htmx:afterSwap -- the
+  // original intent was to guard against this handler being deleted during
+  // the modal-to-Alpine conversion. It deliberately does NOT pin which node
+  // it's bound to (document vs document.body): that binding target is free
+  // to change (e.g. ar-h6rt moved it to `document` so it survives the
+  // redirectTo() body swap) without this test failing.
+  expect(src).toMatch(/document(?:\.body)?\.addEventListener\('htmx:afterSwap'/);
   expect(src).toContain('_initTooltips(targetEl || document)');
   expect(src).toContain('_initSearchableSelects(targetEl || document)');
   expect(src).toContain('_initImageCroppers(targetEl || document)');


### PR DESCRIPTION
Stacked on #143 (`alpine-adoption-trial`). **Base: `alpine-adoption-trial`.**

Auth-redirect fixes (`ar-h6rt`) plus local-dev seed corrections, and the design + plan for the e2e browser tier that follows in the next PR up the stack.

## Auth redirect (`ar-h6rt`)

`redirectTo()` performed an htmx body swap without touching `window.location`, so the address bar kept showing `/auth/check?r=%2Fnav%2Fmanage` while the body showed `/nav/manage`. `getRedirectUrl()` then re-read the same stale `?r=` on every later auth event and swapped the body back — an unescapable loop.

- `af2b098` sync the address bar with auth-driven redirects
- `43c6120` stop the deferred refresh undoing a boosted navigation
- `a324968` bind htmx listeners to document
- `c984b1b` stop `/nav/manage` clobbering the layout's navbar items
- `b072d4a` dispatch `INITIAL_SESSION` once per page load

## Local dev seed fixes

- `b827cbb` starter-unlock ids match the ids the seed assigns (`ar-w9d2`)
- `ef8f967` seed class gear and abilities from the const data (`ar-t2mv`)
- `122a6d9` seed a placeholder starter rules PDF (`ar-p8kq`)

## Two of these commits are worth a second look

The e2e suite in the next PR up the stack tested these fixes directly and found problems with two of them. Full evidence is in that PR's findings report; summarising here so it is not missed.

**`a324968` is built on a false premise.** Its rationale — that an `outerHTML` swap of `<body>` replaces the element and destroys its listeners — is not true for htmx 2.0.8, whose source reads `if (target.tagName === 'BODY') return swapInnerHTML(...)`. Verified against the shipped bytes: the SHA-384 of the CDN file matches the `integrity` attribute in `head.handlebars`. Reverting all seven listener bindings changed no test.

It *is* pinned by a unit test — one asserting `expect(document.body).not.toBe(bodyBeforeSwap)` as its own anti-vacuity guard. That assertion is false in production and passes only because the test's htmx stub calls `document.body.replaceWith(...)`, manufacturing the premise it then checks. The rationale has since been copy-pasted into four production comments.

**`43c6120` narrows its race but cannot close it.** Its guard reads `window.location`, which only moves when the swap completes, so it cannot see an *in-flight* boosted navigation. Measured on natural clicks with no network shaping: 14/60 collisions. It does help — 8/8 collisions with it reverted, versus 5/10 shipped. A complete fix lands at the top of this stack.

Neither blocks this PR; both improve on the status quo. But `a324968` should probably be revisited rather than trusted, since its stated reason for existing does not hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ2ByG25JsMuwiN8gJzRWw
