### PR TITLE
Fix the defects the e2e tier found: frozen Alpine classes, Pages RLS, class immutability, export downloads

### DIFF
--- a/e2e/specs/11-export-dropdowns.spec.js
+++ b/e2e/specs/11-export-dropdowns.spec.js
@@ -1,15 +1,33 @@
 // ar-7v3k check 11 -- the export dropdowns on the character and class pages --
 // plus the systemic follow-up to check 12.
 //
+// STATUS. This file was written to CHARACTERIZE four confirmed defects, four of
+// its tests deliberately red. All four defects have since been fixed on this
+// branch, so every test here is green and they are now REGRESSION GUARDS. The
+// long "EXPECTED TO FAIL" blocks below are kept verbatim as the defect record
+// and the reason each assertion is shaped the way it is; read them as history,
+// not as a current prediction. Two consequences of the fixes are recorded here
+// because they change what the file covers:
+//
+//   - The export links no longer navigate (they fetch with the auth header and
+//     download a Blob), so the test at the end of this file now passes AND the
+//     dropdown test below lost its original vehicle. That test was RE-POINTED at
+//     the one exit that can still strand an open dropdown in htmx's snapshot --
+//     the browser's own Forward/Back buttons. Its block comment carries the full
+//     reachability measurement, route by route.
+//   - The `:class` object form is now load-bearing production code at both
+//     dropdown sites and at the modal sites; the templates say so in comments.
+//
 // PART 1 (checks 11). Both global dropdown handlers were deleted from
 // public/js/app.js and replaced with per-dropdown Alpine state, so outside-click
 // and Escape went from document-level behaviour to per-component and are easy to
 // lose. The markup is identical in shape in both templates
-// (views/character.handlebars:161-171, views/class-view.handlebars:34-46):
+// (views/character.handlebars:161-171, views/class-view.handlebars:34-46),
+// shown here in the FIXED form this file's measurements produced:
 //
 //   <div class="dropdown is-right" id="export-dropdown"
-//        x-data="{ open: false }"
-//        :class="open && 'is-active'"
+//        x-data="exportDropdown"
+//        :class="{ 'is-active': open }"
 //        @click.outside="open = false"
 //        @keydown.escape.window="open = false">
 //
@@ -27,18 +45,24 @@
 // task's own export dropdown and the level-up modal.
 //
 // MEASURED ANSWER: it is systemic, and it is WORSE at the modal. See the block
-// comments above the three red tests at the bottom of this file.
+// comments above the three history-restore tests at the bottom of this file.
 //
 // REGRESSION vs PRE-EXISTING, because "is there a defect" and "did the refactor
 // cause it" are different questions and the second is the one that decides what
-// to revisit. Each red test states its own verdict against the deleted code; the
-// summary:
+// to revisit. Each of the four tests states its own verdict against the deleted
+// code; the summary:
 //
-//   dropdown stuck open after Back  -> REFACTOR REGRESSION (in recoverability)
+//   dropdown stuck open on restore  -> REFACTOR REGRESSION (in recoverability)
 //   modal stuck + undismissable     -> REFACTOR REGRESSION (the "no way out" is new)
 //   body.modal-open leaking forward -> PRE-EXISTING, and harmless (dead CSS)
 //   export links never download     -> PRE-EXISTING, never worked since 5855b7f
-//   no focus trap behind modals     -> PRE-EXISTING
+//   no focus trap behind modals     -> PRE-EXISTING, and STILL OPEN: it is the
+//                                      only one of the five not fixed on this
+//                                      branch. The two modal tests below rely on
+//                                      it (they tab out of an open modal), and
+//                                      each asserts that precondition rather
+//                                      than assuming it, so they report honestly
+//                                      if it is ever closed.
 //
 // The two regressions share one root cause and one fix: the
 // `:class="<expr> && 'is-active'"` idiom, replaced by the object form
@@ -454,39 +478,67 @@ test('the character page comes back from the back button with a closed, live dro
 });
 
 // ---------------------------------------------------------------------------
-// EXPECTED TO FAIL (1 of 3). Characterizes a real, confirmed, reproducible
-// product defect -- not a bug in the test. Do not "fix" it by changing
-// production code under this task and do not loosen the assertions. If it starts
-// passing because someone fixed the underlying bug, that is the correct way for
-// it to go green.
-//
 // THE ANSWER TO PART 2, HALF ONE: check 12's frozen-`:class` defect is NOT
 // navbar-specific. It reproduces verbatim on the export dropdown, on both the
 // character and class pages (both measured; only the character page is asserted
-// here, to keep one red test per defect rather than one per template).
+// here, to keep one test per defect rather than one per template).
 //
-// What makes it reachable, given the positive-control test above proves
-// @click.outside protects the ordinary route: the export links live INSIDE
-// #export-dropdown, so clicking one does not fire @click.outside. The dropdown
-// is still open when htmx's saveCurrentPageToHistory (dist line 3251) snapshots
-// body.innerHTML on the way out. Measured cached snapshot:
+// THIS TEST WAS RE-POINTED, and why matters more than what changed. It used to
+// reach the hazard by clicking an export link, because the export anchors live
+// INSIDE #export-dropdown and clicking one therefore never fired
+// @click.outside. That vehicle is gone -- removed by a FIX, not by anything that
+// makes the hazard safe. public/js/alpine-components.js's `exportDropdown`
+// now intercepts those clicks (`@click.prevent="download($el.href)"`), fetches
+// the file with the auth header, hands the browser a Blob, and sets
+// `open = false` on success. So an export click no longer navigates AND no
+// longer leaves the menu open: it can neither create a history snapshot nor put
+// `is-active` in one. The test was re-pointed at a route that still can, rather
+// than deleted, loosened, or left to time out against a precondition a fix had
+// removed.
 //
-//   <div class="dropdown is-right is-active" id="export-dropdown"
+// IS THE HAZARD STILL REACHABLE AT ALL? YES -- measured, not reasoned. Every
+// candidate exit was driven in a real browser and the result read straight out
+// of htmx's own snapshot cache (sessionStorage['htmx-history-cache'], keyed by
+// path), so "was `is-active` frozen?" is answered by the cache itself:
 //
-// Back -> restoreHistory (dist 3342) reinstates that markup verbatim -> Alpine
-// re-initialises with `open: false` -> evaluates `open && 'is-active'` -> false
-// -> setClassesFromString(el, '') -> adds nothing, and the undo pass removes
-// nothing, because Alpine only ever removes classes IT added.
+//   exit taken with the dropdown open        the dropdown class htmx froze
+//   ----------------------------------------------------------------------------
+//   click an export link (the old vehicle)   nothing cached: no navigation
+//                                            happens, and download() closes the
+//                                            menu on success
+//   keyboard Enter on a link OUTSIDE the     "dropdown is-right"  -- CLOSED.
+//   dropdown                                 Alpine's @click.outside DOES see a
+//                                            keyboard activation: Enter on an
+//                                            <a> produces a trusted click event
+//                                            (detail: 0) that reaches the
+//                                            document-level listener. Measured.
+//   full page load away -- typed URL,        nothing cached. htmx saves no
+//   bookmark, reload -- then Back            snapshot on unload; only its own
+//                                            navigations and popstate save one.
+//   some other link inside the dropdown      there is none. The only two
+//                                            anchors in #export-dropdown are
+//                                            the two export links.
+//   FORWARD/BACK ON THE BROWSER'S OWN        "dropdown is-right is-active"
+//   BUTTONS                                     <-- STILL REACHABLE. This test.
 //
-// Repro by hand: open the export dropdown, click "Markdown (.md)", press Back.
-// Observed on every run: `dropdown is-right is-active`, #export-menu
-// `display: block`, Alpine alive with `open: false`. NOTHING on that page
-// closes it -- measured after the restore: Escape does nothing, clicking
-// outside does nothing, and clicking the trigger toggles Alpine's `open`
-// true/false/true while the class never moves. The trigger also reports
-// `aria-expanded="false"` while the menu is visibly expanded, the same
-// alive-but-powerless a11y symptom Task 11 recorded on the navbar burger. Any
-// subsequent navigation clears it.
+// The live row is the one exit that fires no click anywhere, which is exactly
+// why @click.outside cannot protect it: htmx's popstate handler calls
+// restoreHistory(), and restoreHistory's FIRST statement is
+// saveCurrentPageToHistory() (htmx 2.0.8 dist line 3343). The page you are
+// LEAVING is snapshotted by the history navigation itself, with whatever Alpine
+// had painted on it. Ordinary user story, browser chrome only: open your
+// character page, open the export menu, change your mind and press Back, then
+// press Forward to come back.
+//
+// WHAT GOES WRONG WITHOUT THE FIX: htmx's restore (dist 3342) reinstates that
+// markup verbatim -> Alpine re-initialises with `open: false` -> evaluates
+// `open && 'is-active'` -> false -> setClassesFromString(el, '') -> adds
+// nothing, and removes nothing, because Alpine only ever removes classes IT
+// added. The menu is painted open over a component that believes it is closed,
+// the trigger reports `aria-expanded="false"` while the menu is visibly
+// expanded, and NOTHING on that page closes it: Escape, an outside click and
+// the trigger itself are all no-ops (all three measured under the reverted
+// binding). Only a further navigation clears it.
 //
 // REGRESSION CALL: **REFACTOR REGRESSION**, in recoverability rather than in
 // symptom. The old markup (efa7622^) froze `is-active` into the snapshot too --
@@ -501,15 +553,11 @@ test('the character page comes back from the back button with a closed, live dro
 // on outside click and on Escape. They removed a class they had not added, so a
 // restored stuck dropdown healed on the first Escape, the first click anywhere
 // outside it, or one click on its own trigger. Alpine's setClassesFromString
-// cannot. The refactor converted a benign, self-clearing frozen class into a
-// permanently stuck one. Verified against the deleted code at f8931dc, not
-// reasoned. Severity: Important -- 100% reproducible, user-visible, unclearable
-// in place, escapable by any subsequent navigation, costs no data.
+// cannot. Verified against the deleted code at f8931dc, not reasoned.
 //
-// RECOMMENDED FIX (a production change, deliberately NOT applied -- this branch
-// reports defects, it does not fix them):
+// THE FIX THIS TEST NOW GUARDS (applied on this branch):
 //
-//   views/character.handlebars:163  and  views/class-view.handlebars:36
+//   views/character.handlebars  and  views/class-view.handlebars
 //   -  :class="open && 'is-active'"
 //   +  :class="{ 'is-active': open }"
 //
@@ -517,8 +565,25 @@ test('the character page comes back from the back button with a closed, live dro
 // forRemove branch calls classList.remove on any falsy key already present);
 // setClassesFromString only ever removes what it added. Same fix, same reason,
 // as the one recorded in 10-back-button-snapshot.spec.js for
-// views/partials/nav.handlebars:6,14 -- and verified here the same way: applied
-// and reverted, this test goes green.
+// views/partials/nav.handlebars:6,14.
+//
+// Re-verified after the re-pointing, by reverting the object form on
+// views/character.handlebars alone and driving this exact Forward/Back sequence.
+// The snapshot freezes `dropdown is-right is-active` under BOTH bindings -- the
+// freeze is not what the fix prevents; surviving it is. Measured on restore:
+//
+//   binding                       restored class          menu     Alpine.open
+//   ----------------------------------------------------------------------------
+//   :class="{ 'is-active': open }"  "dropdown is-right"     none     false
+//   :class="open && 'is-active'"    "dropdown is-right      block    false
+//                                    is-active"
+//
+// and under the reverted binding nothing on the page recovers it: after Escape
+// still `is-active`/`block`, after an outside click still `is-active`/`block`,
+// and clicking the trigger flips Alpine's `open` to true while the class never
+// moves. This test goes RED there on `framesPaintedOpen` equal to
+// `framesSampled` (3 of 3 in the recorded window) with `framesAlpineOpen: 0` --
+// painted open over a component that says closed -- and green again on restore.
 //
 // DO NOT reach for hx-history="false" or historyCacheSize: 0 instead. Both make
 // this test pass and both are worse than the defect: with the snapshot cache out
@@ -527,43 +592,77 @@ test('the character page comes back from the back button with a closed, live dro
 // page on protected routes and a silently signed-out render on auth-optional
 // ones. See task-11-report.md.
 // ---------------------------------------------------------------------------
-test('going back after using an export link restores a closed dropdown', async ({ page }) => {
+
+// Reads htmx's own snapshot cache for a path and reports the class attribute the
+// export dropdown was frozen with. Runs in-page; sessionStorage survives a
+// boosted swap, so it can be read from whatever page the hop landed on.
+const frozenDropdownClass = (path) => {
+  const cache = JSON.parse(sessionStorage.getItem('htmx-history-cache') || '[]');
+  const entry = cache.find((c) => c.url === path || c.url.startsWith(path));
+  if (!entry) return { cached: false, cachedUrls: cache.map((c) => c.url) };
+  const match = /<div class="([^"]*)" id="export-dropdown"/.exec(entry.content);
+  return {
+    cached: true,
+    dropdownClass: match ? match[1] : '(no #export-dropdown in the snapshot)',
+    frozenOpen: !!match && /is-active/.test(match[1])
+  };
+};
+
+test('forward and back over an open export dropdown restores it closed', async ({ page }) => {
   await openPage(page, urlFor(CHARACTER_PAGE));
+  const charPath = `/characters/${character.id}`;
+
+  // One boosted hop out and straight back in, to build a real htmx history
+  // stack. This is not scene-setting: saveCurrentPageToHistory ends with
+  // `history.replaceState({ htmx: true }, ...)`, and htmx's popstate handler
+  // ignores any entry whose state lacks that flag. Without a prior htmx
+  // navigation the browser's Forward/Back buttons would not route through htmx
+  // at all, and the rest of this test would be measuring nothing.
+  await boostedHopToHome(page);
+  await page.goBack();
+  await page.waitForURL((url) => url.pathname.startsWith(charPath));
 
   const dropdown = page.locator('#export-dropdown');
   await expect(dropdown).not.toHaveClass(/is-active/); // assert the transition, not the end state
   await toggleFor(page).click();
   await expect(dropdown).toHaveClass(/is-active/);
 
-  // Leaving via a link INSIDE the dropdown: the one route @click.outside does
-  // not intercept, and the ordinary way a user leaves this page with the
-  // dropdown open (it is what the dropdown is FOR).
-  await page.evaluate(() => { window.__preNav = true; });
-  const exportLink = page.locator('#export-menu a[href*="format=markdown"]');
-  await expect(exportLink).toBeVisible();
-  await exportLink.click();
-  await page.waitForURL((url) => url.pathname.endsWith('/export'));
-  expect(
-    await page.evaluate(() => window.__preNav === true),
-    'expected a boosted body swap on the way out; a full page load caches no history snapshot'
-  ).toBe(true);
+  // Forward: a browser-chrome navigation. No click event exists anywhere in
+  // this step, which is the whole point -- @click.outside is structurally unable
+  // to intervene, unlike on every link-click exit (see the positive control
+  // above, which is what proves this is a different route and not a duplicate).
+  await page.goForward();
+  await page.waitForURL((url) => url.pathname === '/');
+
+  // Precondition, asserted rather than assumed: the hazard really was created.
+  // Without this the test could pass for the wrong reason -- a restore of a
+  // snapshot that never carried `is-active` proves nothing about Alpine's
+  // ability to remove one. If this line ever fails because `frozenOpen` is
+  // false, the freeze has been prevented upstream (some future close-on-popstate
+  // or snapshot-sanitising change), which is a legitimate fix too -- update this
+  // test to characterize THAT, do not delete the assertions below.
+  const frozen = await page.evaluate(frozenDropdownClass, charPath);
+  expect(frozen, `htmx snapshot for ${charPath}: ${JSON.stringify(frozen)}`).toMatchObject({
+    cached: true,
+    frozenOpen: true
+  });
 
   await page.evaluate(armRestoreProbe, {
     rootSelector: '#export-dropdown', panelSelector: '#export-menu', stateKey: 'open'
   });
   await page.goBack();
-  await page.waitForURL((url) => url.pathname.startsWith(`/characters/${character.id}`));
+  await page.waitForURL((url) => url.pathname.startsWith(charPath));
   await waitForFrames(page);
 
   const probe = await page.evaluate(() => window.__restoreProbe);
   const summary = summarise(probe);
   expect(summary.framesSampled).toBeGreaterThanOrEqual(3); // zero-iteration guard
 
-  // THE defect. framesPaintedOpen is what the user sees; framesAlpineOpen: 0
-  // holding at the same time is the signature that separates this from "Alpine
-  // restored open state" -- Alpine says closed, the screen says open.
-  // framesComponentMissing: 0 keeps that reading honest: a restore that produced
-  // no dropdown at all must report as its own failure, not as this one.
+  // THE defect this guards. framesPaintedOpen is what the user sees;
+  // framesAlpineOpen: 0 holding at the same time is the signature that separates
+  // it from "Alpine restored open state" -- Alpine says closed, the screen says
+  // open. framesComponentMissing: 0 keeps that reading honest: a restore that
+  // produced no dropdown at all must report as its own failure, not as this one.
   expect(summary, `restored-dropdown paint probe: ${JSON.stringify(probe)}`).toMatchObject({
     restoreObserved: true,
     framesComponentMissing: 0,
@@ -571,6 +670,11 @@ test('going back after using an export link restores a closed dropdown', async (
     framesWithoutAlpine: 0,
     framesAlpineOpen: 0
   });
+  // htmx served its own cached snapshot rather than re-fetching from the server.
+  // The cache-MISS path also fires htmx:historyRestore, so the cache hit is the
+  // only discriminator -- and a miss would re-render the page from scratch,
+  // which cannot carry a frozen class and would make everything above vacuous.
+  expect(probe.cacheHitPath).toBe(charPath);
 
   // Steady state, after every settle and microtask has had its chance. Weaker
   // than the probe (a retrying assertion cannot see a transient) but it would

--- a/models/pages.js
+++ b/models/pages.js
@@ -1,5 +1,13 @@
 const { supabase } = require('./_base');
 
+// Every query here takes the caller's client. `pages` has RLS on both halves:
+// the write policies require is_admin(), and the SELECT policies gate drafts and
+// access_level='admin'/'authenticated' rows the same way. The anon singleton
+// carries no user JWT, so bound to it an admin's UPDATE/DELETE match zero rows
+// and their drafts are simply invisible. `res.locals.supabase` (util/auth.js)
+// carries the caller's token — anon for signed-out visitors, so the default
+// keeps public reads working for callers with no request context.
+
 /**
  * Generate a URL-friendly slug from a title
  */
@@ -17,8 +25,8 @@ const generateSlug = (title) => {
 /**
  * Check if a slug is unique (excluding a specific page ID if provided)
  */
-const isSlugUnique = async (slug, excludeId = null) => {
-    let query = supabase
+const isSlugUnique = async (slug, excludeId = null, client = supabase) => {
+    let query = client
         .from('pages')
         .select('id')
         .eq('slug', slug)
@@ -39,8 +47,8 @@ const isSlugUnique = async (slug, excludeId = null) => {
 /**
  * Get all pages with optional filters
  */
-const getPages = async (filters = {}) => {
-    let query = supabase
+const getPages = async (filters = {}, client = supabase) => {
+    let query = client
         .from('pages')
         .select('*')
         .order('created_at', { ascending: false });
@@ -64,8 +72,8 @@ const getPages = async (filters = {}) => {
 /**
  * Get a single page by slug
  */
-const getPageBySlug = async (slug) => {
-    const { data, error } = await supabase
+const getPageBySlug = async (slug, client = supabase) => {
+    const { data, error } = await client
         .from('pages')
         .select('*')
         .eq('slug', slug)
@@ -80,8 +88,8 @@ const getPageBySlug = async (slug) => {
 /**
  * Get a single page by ID
  */
-const getPage = async (id) => {
-    const { data, error } = await supabase
+const getPage = async (id, client = supabase) => {
+    const { data, error } = await client
         .from('pages')
         .select('*')
         .eq('id', id)
@@ -96,7 +104,7 @@ const getPage = async (id) => {
 /**
  * Create a new page
  */
-const createPage = async (payload) => {
+const createPage = async (payload, client = supabase) => {
     // Generate slug if not provided
     if (!payload.slug && payload.title) {
         payload.slug = generateSlug(payload.title);
@@ -104,7 +112,7 @@ const createPage = async (payload) => {
 
     // Check slug uniqueness
     if (payload.slug) {
-        const { isUnique, error: slugError } = await isSlugUnique(payload.slug);
+        const { isUnique, error: slugError } = await isSlugUnique(payload.slug, null, client);
         if (slugError) {
             return { data: null, error: slugError };
         }
@@ -116,7 +124,7 @@ const createPage = async (payload) => {
         }
     }
 
-    const { data, error } = await supabase
+    const { data, error } = await client
         .from('pages')
         .insert(payload)
         .select()
@@ -131,7 +139,7 @@ const createPage = async (payload) => {
 /**
  * Update an existing page
  */
-const updatePage = async (id, updates) => {
+const updatePage = async (id, updates, client = supabase) => {
     // Generate slug if title changed and slug not provided
     if (updates.title && !updates.slug) {
         updates.slug = generateSlug(updates.title);
@@ -139,7 +147,7 @@ const updatePage = async (id, updates) => {
 
     // Check slug uniqueness if slug is being changed
     if (updates.slug) {
-        const { isUnique, error: slugError } = await isSlugUnique(updates.slug, id);
+        const { isUnique, error: slugError } = await isSlugUnique(updates.slug, id, client);
         if (slugError) {
             return { data: null, error: slugError };
         }
@@ -151,7 +159,7 @@ const updatePage = async (id, updates) => {
         }
     }
 
-    const { data, error } = await supabase
+    const { data, error } = await client
         .from('pages')
         .update(updates)
         .eq('id', id)
@@ -167,8 +175,8 @@ const updatePage = async (id, updates) => {
 /**
  * Delete a page
  */
-const deletePage = async (id) => {
-    const { error } = await supabase
+const deletePage = async (id, client = supabase) => {
+    const { error } = await client
         .from('pages')
         .delete()
         .eq('id', id);

--- a/public/js/alpine-components.js
+++ b/public/js/alpine-components.js
@@ -302,4 +302,105 @@ document.addEventListener('alpine:init', () => {
       rows.forEach((row) => body.appendChild(row));
     }
   }));
+
+  // The export dropdown on the character and class pages. Owns the same
+  // `open` state the inline `x-data="{ open: false }"` used to hold, plus the
+  // download itself.
+  //
+  // WHY THE DOWNLOAD CANNOT JUST BE AN <a href> -- do not "simplify" this
+  // component back into attributes; both attribute-only shapes were measured
+  // and both are worse:
+  //
+  //   * Left boosted (hx-boost="true" sits on <body>), the click becomes an
+  //     htmx AJAX GET. That request DOES carry the auth header, so the server
+  //     returns the real file -- and then htmx ignores Content-Disposition:
+  //     attachment and swaps the raw markdown/JSON into <body>. Nothing
+  //     downloads; the page is destroyed instead. That is how this feature
+  //     shipped, and it has never worked.
+  //   * hx-boost="false", with or without a `download` attribute, makes it a
+  //     real navigation. This app authenticates with an
+  //     `Authorization: Bearer` header that JavaScript writes from
+  //     localStorage (public/js/app.js's htmx:configRequest hook, ~:730) --
+  //     the browser never sends it on a navigation. So the request bounces
+  //     through /auth/check and what lands on disk is the ~6.6KB SIGN-IN
+  //     PAGE, saved as the user's export. A download fires, so it looks
+  //     fixed; it is not.
+  //
+  // The only shape that works is to make the request ourselves with the
+  // header, then hand the browser a Blob it is willing to save.
+  // `hx-boost="false"` on the anchors keeps htmx out of it, `@click.prevent`
+  // keeps the browser's own navigation out of it, and a synthetic
+  // `<a download>` over an object URL does the save.
+  Alpine.data('exportDropdown', () => ({
+    open: false,
+    error: '',
+    busy: false,
+
+    // The server already names the file (routes/characters.js:801,
+    // routes/classes.js:379); read that name back rather than reinventing it.
+    // The RFC 5987 `filename*` form is preferred over plain `filename=`
+    // because the latter has non-ASCII stripped out of it on the class route.
+    filenameFrom(disposition, url) {
+      const encoded = /filename\*=UTF-8''([^;]+)/i.exec(disposition || '');
+      if (encoded) {
+        try {
+          return decodeURIComponent(encoded[1]);
+        } catch (e) {
+          // Malformed percent-encoding: fall through to the plain form.
+        }
+      }
+      const plain = /filename="([^"]+)"/i.exec(disposition || '');
+      if (plain) return plain[1];
+      const format = new URL(url, window.location.origin).searchParams.get('format');
+      return 'export.' + (format === 'markdown' ? 'md' : 'json');
+    },
+
+    download(url) {
+      // Double-clicking a menu item must not start two downloads.
+      if (this.busy) return Promise.resolve();
+      this.busy = true;
+      this.error = '';
+
+      let objectUrl = null;
+      return fetch(url, { headers: CharacterCommon.getAuthHeader() }).then((response) => {
+        if (!response.ok) throw new Error('HTTP ' + response.status);
+        // `ok` is NOT enough, and this check is the whole difference between a
+        // working export and the bug this component exists to kill. An expired
+        // or missing token does not produce a 401: util/auth.js redirects to
+        // /auth/check, fetch follows that redirect transparently, and the
+        // response is a perfectly `ok` 200 carrying ~6.6KB of sign-in page.
+        // Saving that as the user's export is the exact false-green the
+        // hx-boost="false" download shortcut produces. Every export route sets
+        // Content-Disposition: attachment (routes/characters.js:800,
+        // routes/classes.js:379); the sign-in page never does.
+        const disposition = response.headers.get('Content-Disposition') || '';
+        if (!/attachment/i.test(disposition)) {
+          throw new Error('the server did not return a file (your session may have expired -- try reloading)');
+        }
+        return response.blob().then((blob) => {
+          objectUrl = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = objectUrl;
+          link.download = this.filenameFrom(response.headers.get('Content-Disposition'), url);
+          // Must be in the document for the synthetic click to count as a
+          // user-initiated download in every browser.
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+          this.open = false;
+        });
+      }).catch((err) => {
+        // A failed export must not look like a successful one: the menu stays
+        // open with the reason in it rather than closing on nothing at all.
+        this.error = 'Export failed: ' + ((err && err.message) || 'Unknown error');
+      }).finally(() => {
+        // Revoked on a delay, not synchronously after click(): the browser
+        // reads the blob out of the object URL asynchronously, and revoking
+        // straight away can cancel the download it just started. Nothing else
+        // holds a reference, so this is what keeps it from leaking.
+        if (objectUrl) setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+        this.busy = false;
+      });
+    }
+  }));
 });

--- a/public/js/alpine-components.js
+++ b/public/js/alpine-components.js
@@ -152,13 +152,40 @@ document.addEventListener('alpine:init', () => {
   // them -- the name-scoping check and the "already closed, don't double
   // -unlock the body" guard would otherwise have to be kept in sync by hand
   // in two places.
+  //
+  // `body.modal-open` is a DOCUMENT-level class owned by a COMPONENT-level
+  // lifetime, and a page can hold several modals at once (class-view ships
+  // two, my-classes renders one per row). A bare add/remove pair gets both
+  // ends of that wrong: an hx-boost swap tears an open modal out of the DOM
+  // without ever calling close(), so the class outlives the modal and rides
+  // along to a page that has none -- while a teardown that dropped the class
+  // unconditionally would unlock the body out from under a sibling modal that
+  // is still open. So the class is DERIVED from one shared count of modals
+  // that are currently open, and every transition (open, close, teardown)
+  // goes through that count.
+  //
+  // This is about not leaking stale state, not about restoring a scroll lock:
+  // `body.modal-open { overflow: hidden }` never reaches the viewport, because
+  // Bulma's minireset leaves <html> computing to `overflow: hidden scroll` and
+  // overflow only falls through to <body> when <html>'s own is `visible`. The
+  // lock has never worked in this app; fixing that is a separate decision.
+  let openModals = 0;
+
+  const syncBodyLock = () => {
+    document.body.classList.toggle('modal-open', openModals > 0);
+  };
+
   const modalBase = (name) => ({
     show: false,
 
     open(which) {
       if (which !== name) return;
+      // Already open: re-opening must not count a second time, or the body
+      // would stay locked after the one close() that follows.
+      if (this.show) return;
       this.show = true;
-      document.body.classList.add('modal-open');
+      openModals += 1;
+      syncBodyLock();
     },
 
     // which mirrors open()'s parameter but stays optional: every in-modal
@@ -170,7 +197,18 @@ document.addEventListener('alpine:init', () => {
       if (which !== undefined && which !== name) return;
       if (!this.show) return;
       this.show = false;
-      document.body.classList.remove('modal-open');
+      openModals -= 1;
+      syncBodyLock();
+    },
+
+    // Alpine calls destroy() when the component's element leaves the DOM --
+    // which is exactly what an hx-boost swap does to every modal on the page.
+    // Delegating to close() (rather than stripping the class outright) gives
+    // back only THIS modal's share of the count, so a sibling modal that is
+    // still open keeps the body locked, and the guards above make a teardown
+    // of an already-closed modal a no-op.
+    destroy() {
+      this.close();
     }
   });
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -958,6 +958,43 @@ const App = (function (document, supabase, htmx) {
     start();
   }
 
+  // ---------------------------------------------------------------------
+  // In-flight boosted navigations.
+  //
+  // htmx's boosted links move the page WITHOUT a page load, and they write
+  // window.location only once the swap COMPLETES. So reading the location
+  // cannot see a click whose response is still on the wire -- and that is
+  // precisely the case the deferred post-load refresh below has to avoid
+  // stomping on. htmx marks every boosted request with `detail.boosted` and
+  // fires htmx:beforeRequest while the click is still being handled, which is
+  // the earliest observable "the user is leaving this page" signal there is.
+  //
+  // Pendency is read off the XHR's own readyState rather than tracked with a
+  // matching htmx:afterRequest listener, because a boosted request's element
+  // can be detached by an unrelated body swap before its afterRequest fires,
+  // and an event dispatched on a detached node never reaches `document`. That
+  // would leave a counter stuck above zero and silently disable the refresh
+  // for the life of the page. readyState cannot get stuck.
+  //
+  // Registered at module scope, not inside start(): app.js is a deferred
+  // script, so this runs before DOMContentLoaded -- before htmx processes the
+  // document and before any click is possible. Bound to `document` for the
+  // usual reason: redirectTo() replaces <body> wholesale.
+  let _boostedNavXhrs = [];
+  const _isPendingXhr = (xhr) => !!xhr && xhr.readyState !== XMLHttpRequest.DONE;
+
+  document.addEventListener('htmx:beforeRequest', function (event) {
+    if (!event.detail || !event.detail.boosted) return;
+    // Prune on write as well as on read so this cannot grow unbounded.
+    _boostedNavXhrs = _boostedNavXhrs.filter(_isPendingXhr);
+    _boostedNavXhrs.push(event.detail.xhr);
+  });
+
+  function _boostedNavigationInFlight() {
+    _boostedNavXhrs = _boostedNavXhrs.filter(_isPendingXhr);
+    return _boostedNavXhrs.length > 0;
+  }
+
   // Only honor same-origin, in-app paths ("/foo"). Reject protocol-relative
   // ("//evil.com"), absolute ("https://evil.com"), and backslash-prefixed
   // values so a crafted ?r= cannot redirect the user off-site. Stricter than
@@ -1028,12 +1065,34 @@ const App = (function (document, supabase, htmx) {
           setTimeout(() => {
             // A boosted navigation can move the user to a different page
             // during this delay without a real page load, leaving this timer
-            // pending. Re-read the location and bail if it no longer matches
-            // what we captured, so we don't drag the user back to a page
-            // they already left. Do not simplify this to an unconditional
-            // redirectTo(current).
+            // pending. Bail if that has happened, so we don't drag the user
+            // back to a page they already left. TWO reads are needed, and
+            // they cover different halves of the same window:
+            //
+            //   - the location, for a boosted navigation that has already
+            //     COMPLETED (43c6120's guard);
+            //   - _boostedNavigationInFlight(), for one that is still on the
+            //     wire. window.location is not written until the swap
+            //     completes, so the location read is blind to a click made
+            //     inside this window whose response has not come back yet --
+            //     and that is the common case, not a corner: 14 of 60 natural
+            //     clicks straight after load, no network shaping at all.
+            //     redirectTo(current) would go out, its response would land
+            //     after the boosted swap, and the user would be left with the
+            //     address bar on the new page and the body on the old one.
+            //
+            // Nothing is lost by bailing. Boosted requests carry the
+            // Authorization header (the htmx:configRequest listener in
+            // start()), so the page the user navigated to is already the
+            // authed render this refresh exists to produce.
+            //
+            // Do not simplify this to an unconditional redirectTo(current) --
+            // and do not simplify it to an unconditional return either: a
+            // plain page load carries no Authorization header, so without
+            // this refresh a signed-in user is left looking at the guest
+            // render of the page they actually loaded.
             const now = window.location.pathname + window.location.search;
-            if (now !== current) return;
+            if (now !== current || _boostedNavigationInFlight()) return;
             redirectTo(current);
           }, 100);
         }

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -315,6 +315,47 @@ router.get('/:id/edit', isAuthenticated, async (req, res) => {
   } else {
     const { filteredAdvent, filteredAdventV1, filteredAdventV2, filteredAspirant, filteredAspirantV1, filteredAspirantV2, filteredPCC, filteredPCCAdventV1, filteredPCCAdventV2, filteredPCCAspirantV1, filteredPCCAspirantV2, filteredGear, filteredAbilities } = await filterClassDataForUser(res.locals.user);
 
+    let characterClass = null;
+    let effectiveVersion = 'v1';
+    if (character.class_id) {
+      try {
+        const { data: cls } = await getClass(character.class_id, res.locals.supabase);
+        if (cls) {
+          characterClass = cls;
+          if (cls.rules_version === 'v2') effectiveVersion = 'v2';
+        }
+      } catch (_) {}
+    }
+
+    // Inject the character's own class into the Class <select> options so the
+    // class it actually has still appears when the user no longer has it
+    // unlocked -- the same fallback the gear and ability pickers get below,
+    // and for the same reason.
+    //
+    // Without it the <select> has no <option> for the character's class, so it
+    // renders showing some OTHER class. That used to be a data-loss bug (the
+    // save obeyed the auto-selected option); class_id is now immutable on
+    // update (services/character/service.js#updateCharacter), so what is left
+    // is a form that lies about what the character is. Injecting the class
+    // makes the template's existing `selected` check match, so the real class
+    // renders and is selected.
+    if (characterClass && ![...filteredAdvent, ...filteredAspirant, ...filteredPCC].some(c => c.id === characterClass.id)) {
+      const isV2 = characterClass.rules_version === 'v2';
+      const isAspirant = characterClass.rules_edition === 'aspirant';
+      if (characterClass.is_player_created) {
+        filteredPCC.push(characterClass);
+        (isAspirant
+          ? (isV2 ? filteredPCCAspirantV2 : filteredPCCAspirantV1)
+          : (isV2 ? filteredPCCAdventV2 : filteredPCCAdventV1)).push(characterClass);
+      } else if (isAspirant) {
+        filteredAspirant.push(characterClass);
+        (isV2 ? filteredAspirantV2 : filteredAspirantV1).push(characterClass);
+      } else {
+        filteredAdvent.push(characterClass);
+        (isV2 ? filteredAdventV2 : filteredAdventV1).push(characterClass);
+      }
+    }
+
     // Inject existing character gear/abilities into dropdown options so
     // items from classes the user no longer has unlocked still appear
     const allFilteredClasses = [...filteredAdvent, ...filteredAspirant, ...filteredPCC];
@@ -341,18 +382,6 @@ router.get('/:id/edit', isAuthenticated, async (req, res) => {
         if (!filteredAbilities[className]) filteredAbilities[className] = [];
         if (!filteredAbilities[className].includes(a.name)) filteredAbilities[className].push(a.name);
       }
-    }
-
-    let characterClass = null;
-    let effectiveVersion = 'v1';
-    if (character.class_id) {
-      try {
-        const { data: cls } = await getClass(character.class_id, res.locals.supabase);
-        if (cls) {
-          characterClass = cls;
-          if (cls.rules_version === 'v2') effectiveVersion = 'v2';
-        }
-      } catch (_) {}
     }
 
     const [missionsRes, offscreenRes] = await Promise.all([

--- a/routes/nav.js
+++ b/routes/nav.js
@@ -85,7 +85,7 @@ router.get('/new', isAuthenticated, requireAdmin, async (req, res) => {
     const { profile } = res.locals;
 
     // Get pages for dropdown
-    const { data: pages } = await getPages();
+    const { data: pages } = await getPages({}, res.locals.supabase);
     
     // Get dropdown parents
     const { data: dropdownParents } = await getDropdownParents();
@@ -141,7 +141,7 @@ router.post('/', isAuthenticated, requireAdmin, async (req, res) => {
     if (error) {
         const status = error.message && error.message.includes('required') ? 400 : 500;
         if (status === 400) {
-            const { data: pages } = await getPages();
+            const { data: pages } = await getPages({}, res.locals.supabase);
             const { data: dropdownParents } = await getDropdownParents();
             return res.status(400).render('nav-form', {
                 profile,
@@ -185,7 +185,7 @@ router.get('/:id/edit', isAuthenticated, requireAdmin, async (req, res) => {
     }
 
     // Get pages for dropdown
-    const { data: pages } = await getPages();
+    const { data: pages } = await getPages({}, res.locals.supabase);
     
     // Get dropdown parents (exclude self to prevent circular references)
     const { data: allDropdownParents } = await getDropdownParents();
@@ -242,7 +242,7 @@ router.post('/:id', isAuthenticated, requireAdmin, async (req, res) => {
 
     if (resolvedType === 'page' && !updates.page_id) {
         const { profile } = res.locals;
-        const { data: pages } = await getPages();
+        const { data: pages } = await getPages({}, res.locals.supabase);
         const { data: allDropdownParents } = await getDropdownParents();
         const dropdownParents = (allDropdownParents || []).filter(p => p.id !== id);
         return res.status(400).render('nav-form', {
@@ -265,7 +265,7 @@ router.post('/:id', isAuthenticated, requireAdmin, async (req, res) => {
         const status = error.message && error.message.includes('required') ? 400 : 500;
         if (status === 400) {
             const { profile } = res.locals;
-            const { data: pages } = await getPages();
+            const { data: pages } = await getPages({}, res.locals.supabase);
             const { data: allDropdownParents } = await getDropdownParents();
             const dropdownParents = (allDropdownParents || []).filter(p => p.id !== id);
             return res.status(400).render('nav-form', {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -28,7 +28,7 @@ const normalizeBoolean = (value, fallback = false) => {
 router.get('/manage', isAuthenticated, requireAdmin, async (req, res) => {
     const { profile } = res.locals;
 
-    const { data: pages, error } = await getPages();
+    const { data: pages, error } = await getPages({}, res.locals.supabase);
     if (error) {
         return sendError(req, res, error, { message: 'Failed to load pages' });
     }
@@ -78,7 +78,7 @@ router.post('/', isAuthenticated, requireAdmin, async (req, res) => {
         created_by: profile?.id || null
     };
 
-    const { data: page, error } = await createPage(payload);
+    const { data: page, error } = await createPage(payload, res.locals.supabase);
     if (error) {
         return sendError(req, res, error, { message: 'Failed to create page' });
     }
@@ -91,7 +91,7 @@ router.get('/:id/edit', isAuthenticated, requireAdmin, async (req, res) => {
     const { profile } = res.locals;
     const { id } = req.params;
 
-    const { data: page, error } = await getPage(id);
+    const { data: page, error } = await getPage(id, res.locals.supabase);
     if (error || !page) {
         return sendError(req, res, error, { status: 404, message: 'Page not found' });
     }
@@ -113,7 +113,7 @@ router.post('/:id', isAuthenticated, requireAdmin, async (req, res) => {
     const { id } = req.params;
     const { title, slug, content, access_level, is_published } = req.body;
 
-    const { data: existingPage, error: loadError } = await getPage(id);
+    const { data: existingPage, error: loadError } = await getPage(id, res.locals.supabase);
     if (loadError || !existingPage) {
         return sendError(req, res, loadError, { status: 404, message: 'Page not found' });
     }
@@ -126,7 +126,7 @@ router.post('/:id', isAuthenticated, requireAdmin, async (req, res) => {
         is_published: normalizeBoolean(is_published, existingPage.is_published)
     };
 
-    const { error } = await updatePage(id, updates);
+    const { error } = await updatePage(id, updates, res.locals.supabase);
     if (error) {
         return sendError(req, res, error, { message: 'Failed to update page' });
     }
@@ -138,7 +138,7 @@ router.post('/:id', isAuthenticated, requireAdmin, async (req, res) => {
 router.delete('/:id', isAuthenticated, requireAdmin, async (req, res) => {
     const { id } = req.params;
 
-    const { error } = await deletePage(id);
+    const { error } = await deletePage(id, res.locals.supabase);
     if (error) {
         return sendError(req, res, error, { message: 'Failed to delete page' });
     }
@@ -160,7 +160,7 @@ router.get('/:slug', authOptional, async (req, res) => {
     if (isValidUuid(slug)) {
         // If it's a UUID, try to find by ID first (for backwards compatibility)
         // But this shouldn't normally happen since slugs shouldn't be UUIDs
-        const { data: pageById, error: idError } = await getPage(slug);
+        const { data: pageById, error: idError } = await getPage(slug, res.locals.supabase);
         if (!idError && pageById) {
             // Redirect to slug-based URL if page exists
             return res.redirect(`/pages/${pageById.slug}`);
@@ -168,7 +168,7 @@ router.get('/:slug', authOptional, async (req, res) => {
         // If not found by ID, continue to try as slug
     }
 
-    const { data: page, error } = await getPageBySlug(slug);
+    const { data: page, error } = await getPageBySlug(slug, res.locals.supabase);
     if (error || !page) {
         return sendError(req, res, error, { status: 404, message: 'Page not found' });
     }

--- a/services/character/service.js
+++ b/services/character/service.js
@@ -158,13 +158,58 @@ class CharacterService {
       throw new AuthorizationError('Not authorized to modify this character', { reason: 'not_owner' });
     }
 
-    let rulesVersion = await this.adapter.getRulesVersion(input.class_id);
+    // A character's class is IMMUTABLE on update: the STORED class_id always
+    // wins over whatever was submitted.
+    //
+    // Why: the edit form's Class <select> is built from the *editing user's*
+    // currently-unlocked classes (routes/characters.js#filterClassDataForUser),
+    // so as soon as a character's class stops being unlocked -- a
+    // class_unlocks.expires_at lapsing, or a class's is_public flipping false --
+    // the form renders no <option> for it, the browser auto-selects the first
+    // enabled one, `required` is satisfied, and an otherwise-untouched save
+    // silently reassigns the character to an unrelated class. The user never
+    // touches the Class field; every ordinary edit does it, repeatedly.
+    //
+    // That reassignment is not cosmetic. The save rewrites class_abilities
+    // wholesale (saveCharacterAtomic below / the save_character_atomic RPC) and
+    // character_perks.class_ability_id is ON DELETE CASCADE, so the character's
+    // perks are deleted along with the old ability rows -- and they are not
+    // necessarily rebuilt, because the rebuild is gated on `rulesVersion`,
+    // which used to be derived from the submitted (wrong) class as well.
+    // Characterized by e2e/specs/03b-class-reassignment.spec.js.
+    //
+    // Deliberate class changes have their own validated capability --
+    // upgradeClass() below, behind POST /characters/:id/upgrade -- and never
+    // come through here. The mismatch is IGNORED rather than rejected on
+    // purpose: a player whose unlock has lapsed must still be able to edit
+    // their character normally, not be locked out of every save until someone
+    // restores the unlock.
+    const storedClassId = existing.data.class_id ?? null;
     let prepared = cloneInput(input);
+    const submittedClassId = prepared.class_id ?? null;
+    if (submittedClassId !== null && submittedClassId !== storedClassId) {
+      // Surfaced so this state is diagnosable rather than invisible: it only
+      // happens when the editor's unlocked set no longer covers the class.
+      console.warn(
+        `[updateCharacter] Ignoring submitted class_id "${submittedClassId}" for character ${id}: ` +
+        `class is immutable on update, keeping "${storedClassId}"`
+      );
+    }
+    // Both keys, not just class_id: resolveClassReference re-derives class_id
+    // from a submitted class NAME, so pinning the id alone would leave a
+    // bypass -- and keeping the submitted name would desync the denormalized
+    // `class` column from class_id. Dropping `class` lets resolveClassReference
+    // fill it back in from the stored id.
+    prepared.class_id = storedClassId;
+    delete prepared.class;
+
+    // Resolved from the stored class, never the submitted one: this gates both
+    // the v2-only field strip below and the perk rebuild in saveCharacterAtomic.
+    const rulesVersion = await this.adapter.getRulesVersion(storedClassId);
     if (rulesVersion !== 'v2') {
       for (const field of V2_ONLY_FIELDS) delete prepared[field];
     }
     prepared = await this.adapter.resolveClassReference(prepared);
-    rulesVersion = await this.adapter.getRulesVersion(prepared.class_id);
 
     const normalized = normalizeCharacterInput(prepared, {
       rulesVersion,

--- a/views/character-form.handlebars
+++ b/views/character-form.handlebars
@@ -405,8 +405,13 @@
 
 {{#unless isNew}}
 {{#unless character.is_deceased}}
+{{!-- Object form is load-bearing: the string form (`show && 'is-active'`) cannot
+     clear an `is-active` that htmx froze into its history snapshot -- Alpine
+     only removes classes it added itself -- so the modal restores stuck open
+     with its overlay swallowing every click on the page.
+     See public/js/alpine-components.js. --}}
 <div id="deceased-modal" class="modal" x-data="modal('deceased')"
-     :class="show && 'is-active'"
+     :class="{ 'is-active': show }"
      @open-modal.window="open($event.detail)"
      @close-modal.window="close($event.detail)"
      @keydown.escape.window="close()">

--- a/views/character-form.test.js
+++ b/views/character-form.test.js
@@ -17,7 +17,7 @@ test('deceased modal opens through the modal Alpine component, not App.openModal
 
 // ar-7v3k fix wave, Fix 4: the test above only pinned x-data and the
 // $dispatch call -- not the bindings that actually make the modal Alpine
-// component work. Deleting `:class="show && 'is-active'"` from the
+// component work. Deleting `:class="{ 'is-active': show }"` from the
 // template left every test in this file green (proven by deleting it and
 // re-running before writing this test): the modal would open in JS state
 // but never gain the `is-active` class, so it stays invisible. Brings
@@ -26,7 +26,9 @@ test('deceased modal opens through the modal Alpine component, not App.openModal
 // bindings on the real template.
 test('deceased-modal carries all four modal bindings on the real template', () => {
   const html = source();
-  expect(html).toContain(":class=\"show && 'is-active'\"");
+  // Object form, deliberately -- the string form cannot remove a frozen
+  // `is-active` (see public/js/alpine-components.js).
+  expect(html).toContain(":class=\"{ 'is-active': show }\"");
   expect(html).toContain('@open-modal.window="open($event.detail)"');
   expect(html).toContain('@close-modal.window="close($event.detail)"');
   expect(html).toContain('@keydown.escape.window="close()"');

--- a/views/character.handlebars
+++ b/views/character.handlebars
@@ -163,7 +163,7 @@
              snapshot, because Alpine only removes classes it added itself, and
              the dropdown restores stuck open. See public/js/alpine-components.js. --}}
         <div class="dropdown is-right" id="export-dropdown"
-             x-data="{ open: false }"
+             x-data="exportDropdown"
              :class="{ 'is-active': open }"
              @click.outside="open = false"
              @keydown.escape.window="open = false">
@@ -172,16 +172,24 @@
               <span class="icon"><i class="fas fa-ellipsis-vertical"></i></span>
             </button>
           </div>
+          {{!-- hx-boost="false" AND @click.prevent, both load-bearing: the
+                export routes are authenticated by a header JavaScript writes,
+                so neither an htmx-boosted swap nor a real navigation can
+                download the file. The component fetches it with the header and
+                hands the browser a Blob. See public/js/alpine-components.js. --}}
           <div class="dropdown-menu" id="export-menu" role="menu">
             <div class="dropdown-content">
-              <a href="/characters/{{character.id}}/export?format=markdown" class="dropdown-item">
+              <a href="/characters/{{character.id}}/export?format=markdown" class="dropdown-item"
+                 hx-boost="false" @click.prevent="download($el.href)">
                 <span class="icon"><i class="fas fa-file-alt"></i></span>
                 <span>Markdown (.md)</span>
               </a>
-              <a href="/characters/{{character.id}}/export?format=json" class="dropdown-item">
+              <a href="/characters/{{character.id}}/export?format=json" class="dropdown-item"
+                 hx-boost="false" @click.prevent="download($el.href)">
                 <span class="icon"><i class="fas fa-file-code"></i></span>
                 <span>JSON (.json)</span>
               </a>
+              <div class="notification is-danger is-light m-2 p-2 is-size-7" x-show="error" x-text="error"></div>
             </div>
           </div>
         </div>

--- a/views/character.handlebars
+++ b/views/character.handlebars
@@ -158,9 +158,13 @@
         </div>
       </div>
       <div class="control">
+        {{!-- Object form is load-bearing: the string form (`open && 'is-active'`)
+             cannot clear an `is-active` that htmx froze into its history
+             snapshot, because Alpine only removes classes it added itself, and
+             the dropdown restores stuck open. See public/js/alpine-components.js. --}}
         <div class="dropdown is-right" id="export-dropdown"
              x-data="{ open: false }"
-             :class="open && 'is-active'"
+             :class="{ 'is-active': open }"
              @click.outside="open = false"
              @keydown.escape.window="open = false">
           <div class="dropdown-trigger">

--- a/views/character.test.js
+++ b/views/character.test.js
@@ -6,7 +6,7 @@ beforeAll(async () => { await setupAlpine(); });
 const DROPDOWN = `
   <div class="dropdown is-right" id="export-dropdown"
        x-data="{ open: false }"
-       :class="open && 'is-active'"
+       :class="{ 'is-active': open }"
        @click.outside="open = false"
        @keydown.escape.window="open = false">
     <div class="dropdown-trigger">

--- a/views/class-view.handlebars
+++ b/views/class-view.handlebars
@@ -37,7 +37,7 @@
        itself, so the element restores stuck open -- and a stuck modal overlay
        swallows every click on the page. See public/js/alpine-components.js. --}}
   <div class="dropdown is-right" id="export-dropdown"
-       x-data="{ open: false }"
+       x-data="exportDropdown"
        :class="{ 'is-active': open }"
        @click.outside="open = false"
        @keydown.escape.window="open = false">
@@ -48,16 +48,24 @@
         <span class="icon is-small"><i class="fas fa-angle-down"></i></span>
       </button>
     </div>
+    {{!-- hx-boost="false" AND @click.prevent, both load-bearing: the export
+          routes are authenticated by a header JavaScript writes, so neither an
+          htmx-boosted swap nor a real navigation can download the file. The
+          component fetches it with the header and hands the browser a Blob.
+          See public/js/alpine-components.js. --}}
     <div class="dropdown-menu" id="export-menu" role="menu">
       <div class="dropdown-content">
-        <a href="/classes/{{class.id}}/export?format=markdown" class="dropdown-item">
+        <a href="/classes/{{class.id}}/export?format=markdown" class="dropdown-item"
+           hx-boost="false" @click.prevent="download($el.href)">
           <span class="icon"><i class="fas fa-file-alt"></i></span>
           <span>Markdown (.md)</span>
         </a>
-        <a href="/classes/{{class.id}}/export?format=json" class="dropdown-item">
+        <a href="/classes/{{class.id}}/export?format=json" class="dropdown-item"
+           hx-boost="false" @click.prevent="download($el.href)">
           <span class="icon"><i class="fas fa-code"></i></span>
           <span>JSON (.json)</span>
         </a>
+        <div class="notification is-danger is-light m-2 p-2 is-size-7" x-show="error" x-text="error"></div>
       </div>
     </div>
   </div>
@@ -319,3 +327,9 @@
 
 {{/or}}
 {{/if}}
+
+{{!-- CharacterCommon.getAuthHeader(): the export dropdown above needs the
+     Authorization header to fetch the export itself. alpine-components.js
+     loads from <head> on every page, but this helper module did not load on
+     this one -- character.handlebars pulls it in the same way. --}}
+<script src="/js/character-common.js" defer></script>

--- a/views/class-view.handlebars
+++ b/views/class-view.handlebars
@@ -31,9 +31,14 @@
   {{#unless (or (eq class.status 'beta') (eq class.status 'alpha'))}}
   <button class="button is-info" @click="$dispatch('open-modal', 'unlockCode')">Generate Unlock Code</button>
   {{/unless}}
+  {{!-- Object form is load-bearing here and on the two modals below: the string
+       form (`open && 'is-active'`) cannot clear an `is-active` that htmx froze
+       into its history snapshot, because Alpine only removes classes it added
+       itself, so the element restores stuck open -- and a stuck modal overlay
+       swallows every click on the page. See public/js/alpine-components.js. --}}
   <div class="dropdown is-right" id="export-dropdown"
        x-data="{ open: false }"
-       :class="open && 'is-active'"
+       :class="{ 'is-active': open }"
        @click.outside="open = false"
        @keydown.escape.window="open = false">
     <div class="dropdown-trigger">
@@ -215,7 +220,7 @@
 {{#or (eq profile.role 'admin') (eq profile.id class.creator_id)}}
 <!-- Duplicate Modal -->
 <div id="duplicateModal-{{class.id}}" class="modal" x-data="modal('duplicate')"
-     :class="show && 'is-active'"
+     :class="{ 'is-active': show }"
      @open-modal.window="open($event.detail)"
      @close-modal.window="close($event.detail)"
      @keydown.escape.window="close()">
@@ -260,7 +265,7 @@
 </div>
 <!-- Unlock Code Modal -->
 <div id="unlockCodeModal" class="modal" x-data="clearingModal('unlockCode')"
-     :class="show && 'is-active'"
+     :class="{ 'is-active': show }"
      @open-modal.window="open($event.detail)"
      @close-modal.window="closeAndClear($event.detail)"
      @keydown.escape.window="closeAndClear()">

--- a/views/class-view.test.js
+++ b/views/class-view.test.js
@@ -41,7 +41,7 @@ test('class-view wires up both modals through the shared modal components', () =
 // component names, dispatches, and x-ref -- never the real template's
 // `:class`/`@open-modal.window`/`@close-modal.window`/
 // `@keydown.escape.window` bindings themselves. Deleting
-// `:class="show && 'is-active'"` from either real modal in
+// `:class="{ 'is-active': show }"` from either real modal in
 // class-view.handlebars left every test in this file green (proven by
 // deleting each and re-running before writing this test): the modal would
 // open in JS state but never actually become visible. Brings this up to
@@ -49,7 +49,9 @@ test('class-view wires up both modals through the shared modal components', () =
 test('the real duplicate modal carries all four modal bindings', () => {
   const duplicateChunk = SRC.slice(SRC.indexOf('id="duplicateModal-'), SRC.indexOf('id="unlockCodeModal"'));
   expect(duplicateChunk).toContain("x-data=\"modal('duplicate')\"");
-  expect(duplicateChunk).toContain(":class=\"show && 'is-active'\"");
+  // Object form, deliberately -- the string form cannot remove a frozen
+  // `is-active` (see public/js/alpine-components.js).
+  expect(duplicateChunk).toContain(":class=\"{ 'is-active': show }\"");
   expect(duplicateChunk).toContain('@open-modal.window="open($event.detail)"');
   expect(duplicateChunk).toContain('@close-modal.window="close($event.detail)"');
   expect(duplicateChunk).toContain('@keydown.escape.window="close()"');
@@ -57,7 +59,7 @@ test('the real duplicate modal carries all four modal bindings', () => {
 
 test('the real unlock-code modal carries all four modal bindings', () => {
   const unlockChunk = SRC.slice(SRC.indexOf('id="unlockCodeModal"'));
-  expect(unlockChunk).toContain(":class=\"show && 'is-active'\"");
+  expect(unlockChunk).toContain(":class=\"{ 'is-active': show }\"");
   expect(unlockChunk).toContain('@open-modal.window="open($event.detail)"');
   expect(unlockChunk).toContain('@close-modal.window="closeAndClear($event.detail)"');
   expect(unlockChunk).toContain('@keydown.escape.window="closeAndClear()"');
@@ -78,7 +80,7 @@ test('class-view does not inline the clearing logic itself', () => {
 // shared shell: name-scoped open/close, Escape, and the body scroll lock.
 const DUPLICATE_MODAL = `
   <div id="duplicateModal-c1" class="modal" x-data="modal('duplicate')"
-       :class="show && 'is-active'"
+       :class="{ 'is-active': show }"
        @open-modal.window="open($event.detail)"
        @close-modal.window="close($event.detail)"
        @keydown.escape.window="close()">
@@ -101,7 +103,7 @@ const DUPLICATE_MODAL = `
 // this suite.
 const UNLOCK_MODAL = `
   <div id="unlockCodeModal" class="modal" x-data="clearingModal('unlockCode')"
-       :class="show && 'is-active'"
+       :class="{ 'is-active': show }"
        @open-modal.window="open($event.detail)"
        @close-modal.window="closeAndClear($event.detail)"
        @keydown.escape.window="closeAndClear()">

--- a/views/lfg-post.handlebars
+++ b/views/lfg-post.handlebars
@@ -86,9 +86,18 @@
               {{/if}}
             </td>
             <td>
+              <!-- No hx-history="false"/hx-push-url="false" here. They were
+                   inert from birth (37efac4: the hx-get they would have
+                   modified was already commented out, and this is now a plain
+                   Alpine toggle that issues no htmx request at all), but
+                   htmx queries [hx-history="false"] DOCUMENT-WIDE before
+                   snapshotting, so their mere presence suppressed the history
+                   snapshot of /lfg/:id itself. Back then missed the cache and
+                   fell through to htmx's unauthenticated restore XHR, which
+                   this authOptional route answers with a full SIGNED-OUT
+                   render (measured: body 16326 -> 7180 bytes, nav showing
+                   LOGIN/SIGNUP). Do not add them back. -->
               <button class="button is-small is-info"
-                hx-history="false"
-                hx-push-url="false"
                 @click="open = !open">
                 Details
               </button>

--- a/views/my-classes.handlebars
+++ b/views/my-classes.handlebars
@@ -115,8 +115,13 @@
             <button class="button is-danger" hx-delete="/classes/{{this.id}}" hx-target="#row-{{this.id}}" hx-swap="outerHTML" hx-confirm="Delete this class?">Delete</button>
           </div>
           <!-- Duplicate Modal -->
+          {{!-- Object form is load-bearing: the string form (`show && 'is-active'`)
+               cannot clear an `is-active` that htmx froze into its history
+               snapshot -- Alpine only removes classes it added itself -- so the
+               modal restores stuck open with its overlay swallowing every click
+               on the page. See public/js/alpine-components.js. --}}
           <div id="duplicateModal-{{this.id}}" class="modal" x-data="modal('duplicate-{{this.id}}')"
-               :class="show && 'is-active'"
+               :class="{ 'is-active': show }"
                @open-modal.window="open($event.detail)"
                @close-modal.window="close($event.detail)"
                @keydown.escape.window="close()">

--- a/views/partials/character-level-up.handlebars
+++ b/views/partials/character-level-up.handlebars
@@ -1,5 +1,10 @@
+{{!-- Object form is load-bearing: the string form (`show && 'is-active'`) cannot
+     clear an `is-active` that htmx froze into its history snapshot -- Alpine
+     only removes classes it added itself -- so the modal restores stuck open
+     with its overlay swallowing every click on the page.
+     See public/js/alpine-components.js. --}}
 <div id="levelUpModal" class="modal" x-data="modal('levelUp')"
-     :class="show && 'is-active'"
+     :class="{ 'is-active': show }"
      @open-modal.window="open($event.detail)"
      @close-modal.window="close($event.detail)"
      @keydown.escape.window="close()">

--- a/views/partials/character-level-up.test.js
+++ b/views/partials/character-level-up.test.js
@@ -92,7 +92,7 @@ test('no template calls App.openModal or App.closeModal', () => {
 test('a dispatched open-modal event for levelUp opens the level-up modal', async () => {
   await render(`
     <div id="levelUpModal" class="modal" x-data="modal('levelUp')"
-         :class="show && 'is-active'"
+         :class="{ 'is-active': show }"
          @open-modal.window="open($event.detail)"
          @close-modal.window="close($event.detail)"
          @keydown.escape.window="close()">
@@ -108,7 +108,7 @@ test('a dispatched open-modal event for levelUp opens the level-up modal', async
 test('an open-modal event for a different name does not open the level-up modal', async () => {
   await render(`
     <div id="levelUpModal" class="modal" x-data="modal('levelUp')"
-         :class="show && 'is-active'"
+         :class="{ 'is-active': show }"
          @open-modal.window="open($event.detail)"
          @close-modal.window="close($event.detail)"
          @keydown.escape.window="close()"></div>

--- a/views/partials/character-stats-editor.handlebars
+++ b/views/partials/character-stats-editor.handlebars
@@ -28,7 +28,12 @@
       <button type="button" class="button" id="statsCancelBtn" @click="cancel()">Cancel</button>
     </p>
     <p class="control">
-      <button type="submit" class="button is-primary" id="statsSaveBtn" :disabled="saving" :class="saving && 'is-loading'">
+      {{!-- Object form for the same reason as every other :class in these views:
+           the string form can only add a class, never remove one it did not
+           add, so a frozen `is-loading` would stick. This button is not an
+           overlay and no test exercises it, so this one is consistency rather
+           than a measured defect. See public/js/alpine-components.js. --}}
+      <button type="submit" class="button is-primary" id="statsSaveBtn" :disabled="saving" :class="{ 'is-loading': saving }">
         <span class="icon"><i class="fas fa-save"></i></span>
         <span>Save stats</span>
       </button>

--- a/views/partials/character-stats-editor.test.js
+++ b/views/partials/character-stats-editor.test.js
@@ -191,7 +191,9 @@ test('character-stats-editor.handlebars carries the Alpine bindings', () => {
   expect(src).toContain('@submit.prevent="save()"');
   expect(src).toContain('@click="cancel()"');
   expect(src).toContain(':disabled="saving"');
-  expect(src).toContain(":class=\"saving && 'is-loading'\"");
+  // Object form, matching every other :class in these views: the string form
+  // can only add a class, never remove one Alpine did not add itself.
+  expect(src).toContain(":class=\"{ 'is-loading': saving }\"");
   expect(src).toContain('x-show="error" x-text="error"');
 
   expect(src).not.toContain('character-stats.js');

--- a/views/partials/modal.test.js
+++ b/views/partials/modal.test.js
@@ -17,7 +17,7 @@ beforeEach(() => {
 });
 
 const MODAL = `
-  <div id="m" class="modal" x-data="modal('demo')" :class="show && 'is-active'"
+  <div id="m" class="modal" x-data="modal('demo')" :class="{ 'is-active': show }"
        @open-modal.window="open($event.detail)"
        @close-modal.window="close($event.detail)"
        @keydown.escape.window="close()">
@@ -42,11 +42,11 @@ const TRIGGER_AND_MODAL = `
 // window -- this is the exact shape of Task 18's per-row modals inside an
 // {{#each}}.
 const TWO_MODALS = `
-  <div id="a" class="modal" x-data="modal('alpha')" :class="show && 'is-active'"
+  <div id="a" class="modal" x-data="modal('alpha')" :class="{ 'is-active': show }"
        @open-modal.window="open($event.detail)"
        @close-modal.window="close($event.detail)"
        @keydown.escape.window="close()"></div>
-  <div id="b" class="modal" x-data="modal('beta')" :class="show && 'is-active'"
+  <div id="b" class="modal" x-data="modal('beta')" :class="{ 'is-active': show }"
        @open-modal.window="open($event.detail)"
        @close-modal.window="close($event.detail)"
        @keydown.escape.window="close()"></div>
@@ -166,4 +166,43 @@ test('a close-modal event scoped to a different name does not close the open mod
 
   expect(document.getElementById('a').classList.contains('is-active')).toBe(true);
   expect(document.body.classList.contains('modal-open')).toBe(true);
+});
+
+// ar-7v3k Fix 1: `body.modal-open` is a document-level class with a
+// component-level lifetime. An hx-boost swap replaces body.innerHTML and never
+// calls close(), and `<body>`'s own class attribute is not part of the swap --
+// so before modalBase grew a destroy(), an open modal's lock followed the user
+// to the next page, which had no modal left to clear it. render() replaces the
+// body exactly the way a boosted swap does.
+test('tearing down an open modal releases the body lock', async () => {
+  await render(MODAL);
+  window.dispatchEvent(new window.CustomEvent('open-modal', { detail: 'demo' }));
+  await tick();
+  expect(document.body.classList.contains('modal-open')).toBe(true);
+
+  await render('<p>a page with no modal on it</p>');
+  expect(document.body.classList.contains('modal-open')).toBe(false);
+});
+
+// ...and the reason destroy() delegates to close() instead of just stripping
+// the class: a page can hold several modals at once (class-view ships two,
+// my-classes renders one per row). Removing one of them -- an inner htmx swap,
+// an x-if going false -- must not unlock the body while another is still open.
+test('tearing down one modal does not release a still-open modal\'s body lock', async () => {
+  await render(TWO_MODALS);
+  window.dispatchEvent(new window.CustomEvent('open-modal', { detail: 'alpha' }));
+  window.dispatchEvent(new window.CustomEvent('open-modal', { detail: 'beta' }));
+  await tick();
+  expect(document.body.classList.contains('modal-open')).toBe(true);
+
+  document.getElementById('b').remove();
+  await tick();
+
+  expect(document.getElementById('a').classList.contains('is-active')).toBe(true);
+  expect(document.body.classList.contains('modal-open')).toBe(true);
+
+  // ...and the last one leaving does release it.
+  document.getElementById('a').remove();
+  await tick();
+  expect(document.body.classList.contains('modal-open')).toBe(false);
 });

--- a/views/partials/nav.handlebars
+++ b/views/partials/nav.handlebars
@@ -1,9 +1,15 @@
+{{!-- The `:class` bindings below MUST stay in object form. `open && 'is-active'`
+     routes through Alpine's setClassesFromString, which only ever removes
+     classes Alpine itself added -- so an `is-active` that htmx froze into its
+     history snapshot survives re-init and the menu comes back permanently
+     stuck open. The object form uses setClassesFromObject, which does remove a
+     falsy class it did not add. Full mechanism: public/js/alpine-components.js. --}}
 <nav class="navbar is-dark" role="navigation" aria-label="main navigation" x-data="{ open: false }">
   <div class="navbar-brand">
     <a class="navbar-item" href="/">
       <strong>Agent Resources</strong>
     </a>
-    <button class="navbar-burger" id="navbar-burger" role="button" aria-label="menu" :class="open && 'is-active'" :aria-expanded="open" @click="open = !open">
+    <button class="navbar-burger" id="navbar-burger" role="button" aria-label="menu" :class="{ 'is-active': open }" :aria-expanded="open" @click="open = !open">
       <span aria-hidden="true"></span>
       <span aria-hidden="true"></span>
       <span aria-hidden="true"></span>
@@ -11,7 +17,7 @@
     </button>
   </div>
 
-  <div class="navbar-menu" id="navbar-menu" :class="open && 'is-active'">
+  <div class="navbar-menu" id="navbar-menu" :class="{ 'is-active': open }">
     <div class="navbar-end">
       {{#if navItems}}
         {{#if navItems.length}}

--- a/views/partials/nav.test.js
+++ b/views/partials/nav.test.js
@@ -9,10 +9,10 @@ const NAV = `
   <nav class="navbar is-dark" x-data="{ open: false }">
     <div class="navbar-brand">
       <button class="navbar-burger" id="navbar-burger"
-              :class="open && 'is-active'" :aria-expanded="open"
+              :class="{ 'is-active': open }" :aria-expanded="open"
               @click="open = !open"></button>
     </div>
-    <div class="navbar-menu" id="navbar-menu" :class="open && 'is-active'"></div>
+    <div class="navbar-menu" id="navbar-menu" :class="{ 'is-active': open }"></div>
   </nav>
 `;
 
@@ -56,7 +56,11 @@ test('real nav.handlebars has Alpine directives and no hx-on:click on burger', (
 
   // Assert new Alpine directives are present
   expect(content).toContain('x-data="{ open: false }"');
-  expect(content).toContain(':class="open && \'is-active\'"');
+  // Object form, deliberately: the string form (`open && 'is-active'`) cannot
+  // remove an `is-active` that htmx froze into a history snapshot, which left
+  // the restored menu permanently stuck open. Pinned so a "tidy-up" back to the
+  // shorter form is caught here. See public/js/alpine-components.js.
+  expect(content).toContain(':class="{ \'is-active\': open }"');
   expect(content).toContain(':aria-expanded="open"');
   expect(content).toContain('@click="open = !open"');
 


### PR DESCRIPTION
Stacked on #147. **Base: `e2e-browser-tier`.**

Fixes the defects that #147's suite characterized. Every commit here turns specific red tests green.

**Suite goes from 71 passed / 9 failed to 80 passed / 0 failed.** `bun run check`, unit (88 files), http, and integration all exit 0.

## Commits

| Commit | Fix | Reds closed |
|---|---|---|
| `0d8b3ba` | `:class` object form across 10 sites + body-lock lifetime | 4 |
| `318506e` | Pages CMS runs as the caller, not as anon | 1 |
| `91fedf0` | `/lfg/:id` no longer suppresses its own history snapshot | 1 |
| `cdea696` | Deferred auth refresh cannot stomp an in-flight boosted nav | 1 |
| `1f4d563` | A character's class is immutable on update | 1 |
| `316848c` | Export links actually download | 1 |
| `d6e65a7` | Re-point a test whose precondition a fix removed | — |

## Notes on the less obvious ones

**Frozen class (`0d8b3ba`).** `setClassesFromString` only removes classes Alpine added; `setClassesFromObject` removes falsy ones it did not. That is the whole fix. The `body.modal-open` lock is now *derived from a count of open modals* rather than stripped unconditionally — the unconditional form is right for a boosted swap, where all modals die together, but wrong when one of several is destroyed alone (`class-view` ships two, `my-classes` one per row), where it would unlock the body under a still-open modal. Five companion unit tests pinned the old string and were updated with it.

**Pages (`318506e`).** Threads the caller's client so RLS evaluates against their JWT. Explicitly **not** `supabaseAdmin` — that bypasses RLS and contradicts `fcb331e`; it was only ever a diagnostic. Found two call sites the investigation missed in `routes/nav.js`, where the page picker was silently omitting drafts, and the same binding was breaking `access_level='authenticated'` pages for signed-in non-admins.

**Class immutability (`1f4d563`).** Pins both `class_id` **and** the denormalized class name, because `resolveCharacterClassReference` re-derives the id from a submitted name — pinning the id alone left a bypass. The edit still succeeds and the mismatch is logged, so a player whose unlock expired can keep editing rather than being locked out. Path audit found exactly one legitimate class change on update — `upgradeClass` via `POST /:id/upgrade` — which writes through a different repository method and is untouched.

**Export downloads (`316848c`).** `download` + `hx-boost="false"` does *not* work: a real navigation carries no `Authorization` header, so it bounces to `/auth/check` and the browser saves the sign-in page as your `.md`. Instead an Alpine component fetches with the header, wraps the response in a Blob, and clicks a synthetic `<a download>`. It requires `Content-Disposition: attachment` before treating the response as a file — `response.ok` alone is not enough, because an expired token yields a transparently-followed redirect and a perfectly good 200. The first version shipped the sign-in page and reported success.

**The re-pointed test (`d6e65a7`).** `11-export-dropdowns.spec.js:530` reached its scenario by clicking an export link to navigate away with the dropdown open — the only exit that did not fire `@click.outside`. Working downloads removed that route. Rather than assume the hazard was gone, every candidate exit was driven in real Chromium with the verdict read out of htmx's own snapshot cache. It is **still reachable**: open the menu, press Back, press Forward. Browser-chrome navigation fires no click at all, and `restoreHistory()` calls `saveCurrentPageToHistory()` first, so `@click.outside` cannot intervene. The test was re-pointed there and proven to still catch a regression.

## Still open, documented not fixed

- The general htmx cache-miss blank page — the `/lfg/:id` instance is fixed; `loadHistoryFromServer` ignoring `HX-Redirect` is not
- A latent token-exfil primitive in `redirectTo`: a guard-*rejected* url still reaches `htmx.ajax` with `Authorization` attached, blocked today only by htmx's `selfRequestsOnly`
- `models/nav.js` has the same anon binding as `models/pages.js` had
- A residual in-flight window: if a boosted click lands *after* the refresh request goes out, no fire-time signal can see it (5/5 under a forced 2s delay, 0/60 unshaped)

## Running it

`reuseExistingServer` means a long-lived server on port 3100 will **not** pick up the server-side fixes here. Restart it or use a fresh `E2E_PORT`, or you will see failures that are not real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ2ByG25JsMuwiN8gJzRWw
