### PR TITLE
Replace stat text boxes with a star-rating block selector

### DIFF
--- a/docs/superpowers/plans/2026-08-05-stat-block-selector.md
+++ b/docs/superpowers/plans/2026-08-05-stat-block-selector.md
@@ -1,0 +1,1978 @@
+# Stat Block Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Revert the square-plus stat icons back to blocks, and replace every stat number input with a star-rating block control — click the Nth block to set the stat to N.
+
+**Architecture:** One pure function (`resolveStatTarget`) holds the click rule. One Alpine component (`statBlocks`) and one Handlebars partial (`stat-blocks`) wrap it for the four surfaces that currently render number inputs. The character wizard keeps its own imperative grid but calls the same pure function, so the two cannot drift.
+
+**Tech Stack:** Express + express-handlebars, Alpine.js 3.15.12, Bulma, vanilla browser JS (IIFE modules on `window`), bun:test + jsdom for unit tests, Playwright for e2e.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-stat-block-selector-design.md`
+
+## Global Constraints
+
+- **Branch:** `stat-block-selector`, already created, stacked on `fix-alpine-frozen-class-and-pages-rls`.
+- **Unit tests run with:** `bun run test:unit`. A single file: `bun test <path>`.
+- **The unit runner only scans `models`, `routes`, `services`, `test`, `util`, `views`** (`scripts/run-tests.mjs:31`). A test placed under `public/` will never execute. All new unit tests in this plan live under `views/`.
+- **`public/js/alpine-components.js` loads from `<head>` with `defer` and must stay above the Alpine CDN tag** (`views/partials/head.handlebars:16-20`). Alpine calls `Alpine.start()` in a microtask right after its own tag, so anything calling `Alpine.data()` has to be registered before it. Do not move this script.
+- **`:class` must use the object form**, never the string form. Alpine only removes classes it added itself, so a string-form binding can leave a class frozen into an htmx history snapshot. Every existing `:class` in these views follows this rule.
+- **`{{json x}}`** emits `JSON.stringify(x ?? null)` — a `null` for a missing value, never an empty string. Always seed Alpine values through it; a bare `{{lookup ...}}` renders nothing for a null stat and produces invalid JS inside an `x-data` expression.
+- **Handlebars helpers available:** `capitalize`, `add`, `subtract`, `gt`, `lt` (from `handlebars-helpers`), `range` (from `handlebars-helper-range`, iterating `[start, end)`), and `concat`, `json`, `times`, `lookup` from `util/handlebars.js`. **There is no `min` helper** — branch with `{{#if (gt ...)}}` instead.
+- **Per-stat block counts:** 5 for character stats, 3 for a class stat spread.
+- **Stat values above the block count are preserved, never silently clamped.** They only drop when the user clicks a block.
+- **Commit after every task.** Co-author trailer on every commit:
+  ```
+  Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+  ```
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `public/js/alpine-components.js` | **Modify.** Adds `window.StatBlocks.resolveStatTarget` (the click rule) and `Alpine.data('statBlocks')`. Fixes `characterStats.edit()`'s focus target. |
+| `views/partials/stat-blocks.handlebars` | **Create.** The interactive control. One per stat. |
+| `views/partials/stat-blocks-readonly.handlebars` | **Create.** Display-only blocks for `lfg-post`. No JS. |
+| `views/partials/stat-blocks.test.js` | **Create.** Unit tests for the rule, the component, and the real partial. |
+| `public/css/styles.css` | **Modify.** `.is-set` / `.is-empty` / `.is-preview` / `.is-preview-off` states, `.stat-blocks` layout. |
+| `views/partials/character-stats-editor.handlebars` | **Modify.** Number input → partial. |
+| `views/partials/character-level-up.handlebars` | **Modify.** Number input → partial. |
+| `views/character-form.handlebars` | **Modify.** Number inputs → partial (native POST via hidden input). |
+| `views/class-form.handlebars` | **Modify.** Number inputs → partial, `max=3`. |
+| `views/lfg-post.handlebars` | **Modify.** Literal `+` characters → read-only blocks. |
+| `public/js/character-level-up.js` | **Modify.** Live total listens for `stat-change` instead of `input`. |
+| `public/js/character-wizard.js` | **Modify.** `onStatBoxClick` → jump-to-N via the shared rule; hover preview. |
+
+## Deviation from the spec
+
+The spec calls for `public/js/character-wizard.test.js` covering the two changed wizard functions. Two things force a change:
+
+1. The unit runner does not scan `public/`, so that path would never run.
+2. `public/js/character-wizard.js` is a 1698-line IIFE that bails immediately without a `#wizard-data` element, makes 43 `getElementById` calls at init, and calls `Math.random()`, `localStorage`, `requestAnimationFrame`, and `setTimeout` during startup. Mounting it under jsdom is its own project.
+
+**Instead:** the arithmetic both surfaces need is extracted into `resolveStatTarget`, which is exhaustively unit-tested in Task 2 — including every wizard case (class floor, per-stat cap, short budget). Task 9 wires the wizard to that function and asserts at the source level that it calls it rather than reimplementing it. The wizard's DOM behavior is covered by the manual browser check in Task 10.
+
+---
+
+### Task 1: Revert the square-plus icons
+
+**Files:**
+- Revert: commit `e13cbd3` (touches `public/css/styles.css`, `public/js/character-wizard.js`, `views/character.handlebars`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `.wizard-stat-box` is a bordered square again (`border: 2.5px solid var(--bulma-border, #1a1a1a); border-radius: 3px; background: var(--wizard-stat-empty)`), with states `.is-class` / `.is-user` / `.is-assignable` / `.is-locked`. The CSS custom property `--wizard-stat-locked` no longer exists. Later tasks build `.is-set` / `.is-empty` / `.is-preview` on top of this base rule.
+
+- [ ] **Step 1: Revert the commit**
+
+```bash
+git revert --no-edit e13cbd3
+```
+
+This applies cleanly onto HEAD (verified). It restores the filled/bordered squares and the `--wizard-stat-class: #1a1a1a` ramp in `styles.css`, drops `--wizard-stat-locked`, and removes `<i class="fa-regular fa-square-plus">` from the box markup in both `public/js/character-wizard.js` and `views/character.handlebars`.
+
+- [ ] **Step 2: Verify no plus icons survive**
+
+Run:
+
+```bash
+grep -rn "square-plus" public/ views/ ; echo "exit: $?"
+```
+
+Expected: no matches, `exit: 1`.
+
+- [ ] **Step 3: Run the unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS. No existing test asserts on the icon markup, so this is a regression check, not a new signal.
+
+- [ ] **Step 4: Amend the revert message**
+
+```bash
+git commit --amend -F - <<'EOF'
+Revert "feat: render wizard stat boxes as square-plus icons"
+
+This reverts commit e13cbd32032a148b6ee955f44fdac7fb22e52944.
+
+The blocks read better than the plus glyphs, and the star-rating stat
+control built on top of this needs a filled/empty square to express
+"set" versus "unset" -- a plus icon has no natural empty state.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 2: The click rule and the `statBlocks` component
+
+**Files:**
+- Modify: `public/js/alpine-components.js` (add `resolveStatTarget` + `window.StatBlocks` above the `alpine:init` listener; add `Alpine.data('statBlocks')` inside it)
+- Test: `views/partials/stat-blocks.test.js` (create)
+
+**Interfaces:**
+- Consumes: Task 1's `.wizard-stat-box` base rule (for the classes it emits).
+- Produces:
+  - `window.StatBlocks.resolveStatTarget({ slot, current, floor, ceiling })` → `number`. `slot` is 1-based. Returns the new total a click on that block should produce.
+  - `Alpine.data('statBlocks', (initial, max, stat) => ...)` with reactive `value` (number) and `preview` (number | null), the getters `ceiling` and `previewValue`, and the methods `set(i)`, `commit(next)`, `key(event)`, `boxClass(i)`, `tabIndex(i)`, `focusBlock(n)`. `value` is what a parent binds to when Task 3's partial is given a `model`.
+  - A bubbling `stat-change` CustomEvent with `detail: { stat, value }`, dispatched on every committed change.
+
+- [ ] **Step 1: Write the failing tests for the rule**
+
+Create `views/partials/stat-blocks.test.js`:
+
+```js
+const { test, expect, beforeAll } = require('bun:test');
+const { setupAlpine, render, tick } = require('../../test/helpers/alpine-dom');
+
+beforeAll(async () => {
+  await setupAlpine();
+  require('../../public/js/alpine-components.js');
+  document.dispatchEvent(new window.CustomEvent('alpine:init'));
+});
+
+// --- the shared rule ------------------------------------------------------
+//
+// resolveStatTarget is the single source of truth for "what does clicking
+// this block do". It is exported on window rather than closed over because
+// public/js/character-wizard.js drives its own imperative grid and must
+// apply the identical rule; two copies of this arithmetic is exactly how
+// the wizard and the editor would drift apart.
+
+const resolve = (args) => window.StatBlocks.resolveStatTarget(args);
+
+test('clicking the Nth block targets N', () => {
+  expect(resolve({ slot: 3, current: 0, floor: 0, ceiling: 5 })).toBe(3);
+});
+
+test('clicking the block you are already on steps down by one', () => {
+  expect(resolve({ slot: 3, current: 3, floor: 0, ceiling: 5 })).toBe(2);
+});
+
+test('clicking the first block at value 1 reaches zero', () => {
+  expect(resolve({ slot: 1, current: 1, floor: 0, ceiling: 5 })).toBe(0);
+});
+
+test('the ceiling caps the target', () => {
+  // The wizard's short-budget case: 1 class point, 2 points left in the
+  // budget, user clicks the 5th block. The most it can reach is 3.
+  expect(resolve({ slot: 5, current: 1, floor: 1, ceiling: 3 })).toBe(3);
+});
+
+test('the floor keeps class- and personality-assigned points untouchable', () => {
+  expect(resolve({ slot: 1, current: 4, floor: 2, ceiling: 5 })).toBe(2);
+});
+
+test('a value above the block count can step down but the rule never invents one', () => {
+  // 7 points, 5 blocks: clicking the 3rd block drops it to 3, not to 5.
+  expect(resolve({ slot: 3, current: 7, floor: 0, ceiling: 7 })).toBe(3);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: FAIL — `TypeError: undefined is not an object (evaluating 'window.StatBlocks.resolveStatTarget')`.
+
+- [ ] **Step 3: Implement the rule**
+
+In `public/js/alpine-components.js`, insert immediately **above** the `document.addEventListener('alpine:init', ...)` line (after the `slugify` helper):
+
+```js
+// The one rule every stat block control obeys: clicking the block at
+// 1-based position `slot` sets the stat to `slot`, EXCEPT that clicking the
+// block you are already on steps DOWN by one -- that is how a stat reaches
+// zero, and it matches what the wizard's grid already did when you clicked
+// a point you had assigned.
+//
+// `floor` is the number of points the click may not take the stat below
+// (class + personality points in the wizard; 0 everywhere else). `ceiling`
+// is the highest total the click may produce (the per-stat cap, or the
+// remaining point budget, whichever binds first).
+//
+// Exported on `window` rather than closed over because
+// public/js/character-wizard.js renders its own imperative grid and has to
+// apply the identical rule. Two copies of this arithmetic is exactly how
+// the wizard and the editor would drift apart. alpine-components.js is a
+// deferred <head> script and character-wizard.js a deferred body script, so
+// deferred-script document order guarantees this is defined first.
+const resolveStatTarget = ({ slot, current, floor = 0, ceiling }) => {
+  const target = slot === current ? slot - 1 : slot;
+  return Math.max(floor, Math.min(target, ceiling));
+};
+
+window.StatBlocks = { resolveStatTarget };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Write the failing tests for the component**
+
+Append to `views/partials/stat-blocks.test.js`:
+
+```js
+// --- the Alpine component -------------------------------------------------
+//
+// This fixture mirrors views/partials/stat-blocks.handlebars by hand so the
+// component's behaviour is pinned independently of the template. Task 3
+// adds tests that mount the REAL partial, which is what catches the two
+// drifting apart.
+
+const mount = (value, max) => render(`
+  <div class="stat-blocks" role="radiogroup" aria-label="Might"
+       x-data="statBlocks(${value}, ${max}, 'might')"
+       @mouseleave="preview = null" @keydown="key($event)">
+    <input type="hidden" name="might" :value="value" class="stat-blocks-value" data-stat="might">
+    <template x-for="i in max" :key="i">
+      <span class="wizard-stat-box" role="radio"
+            :class="boxClass(i)" :aria-checked="i === value" :tabindex="tabIndex(i)"
+            @click="set(i)" @mouseenter="preview = i"></span>
+    </template>
+    <span class="stat-blocks-over" x-show="value > max" x-text="value"></span>
+  </div>
+`);
+
+const blocks = () => Array.from(document.querySelectorAll('[role="radio"]'));
+const classesOf = () => blocks().map((b) => b.className.replace('wizard-stat-box ', ''));
+const hidden = () => document.querySelector('.stat-blocks-value');
+
+test('renders max blocks, filled up to the seeded value', async () => {
+  await mount(2, 5);
+  await tick();
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+test('clicking the Nth block sets the value and updates the hidden input', async () => {
+  await mount(2, 5);
+  await tick();
+  blocks()[3].click();
+  await tick();
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-set', 'is-set', 'is-empty']);
+  expect(hidden().value).toBe('4');
+});
+
+test('clicking the active block drops to N-1', async () => {
+  await mount(3, 5);
+  await tick();
+  blocks()[2].click();
+  await tick();
+  expect(hidden().value).toBe('2');
+});
+
+test('clicking the first block at value 1 reaches zero', async () => {
+  await mount(1, 5);
+  await tick();
+  blocks()[0].click();
+  await tick();
+  expect(hidden().value).toBe('0');
+  expect(classesOf().every((c) => c === 'is-empty')).toBe(true);
+});
+
+test('hovering above the value previews the blocks a click would fill', async () => {
+  await mount(2, 5);
+  await tick();
+  blocks()[3].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  expect(classesOf()).toEqual(['is-preview', 'is-preview', 'is-preview', 'is-preview', 'is-empty']);
+  // The committed value is untouched until a click.
+  expect(hidden().value).toBe('2');
+});
+
+test('hovering below the value previews the drop, not just a fill', async () => {
+  await mount(5, 5);
+  await tick();
+  blocks()[1].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  expect(classesOf()).toEqual(['is-preview', 'is-preview', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+test('hovering the active block previews N-1, matching what the click does', async () => {
+  await mount(3, 5);
+  await tick();
+  blocks()[2].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  expect(classesOf()).toEqual(['is-preview', 'is-preview', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+test('mouseleave restores the committed state', async () => {
+  await mount(2, 5);
+  await tick();
+  blocks()[4].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  document.querySelector('.stat-blocks').dispatchEvent(new window.Event('mouseleave'));
+  await tick();
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+const press = async (key) => {
+  document.querySelector('.stat-blocks').dispatchEvent(
+    new window.KeyboardEvent('keydown', { key, bubbles: true })
+  );
+  await tick();
+};
+
+test('arrow keys adjust by one and clamp at both ends', async () => {
+  await mount(2, 5);
+  await tick();
+  await press('ArrowRight');
+  expect(hidden().value).toBe('3');
+  await press('ArrowLeft');
+  await press('ArrowLeft');
+  await press('ArrowLeft');
+  await press('ArrowLeft');
+  expect(hidden().value).toBe('0');
+  await press('ArrowUp');
+  expect(hidden().value).toBe('1');
+});
+
+test('Home and End jump to the ends', async () => {
+  await mount(2, 5);
+  await tick();
+  await press('End');
+  expect(hidden().value).toBe('5');
+  await press('Home');
+  expect(hidden().value).toBe('0');
+});
+
+test('exactly one block is tabbable and aria-checked tracks the value', async () => {
+  await mount(3, 5);
+  await tick();
+  expect(blocks().filter((b) => b.getAttribute('tabindex') === '0').length).toBe(1);
+  expect(blocks()[2].getAttribute('tabindex')).toBe('0');
+  expect(blocks().map((b) => b.getAttribute('aria-checked')))
+    .toEqual(['false', 'false', 'true', 'false', 'false']);
+});
+
+test('at value 0 the first block is the tabbable one', async () => {
+  await mount(0, 5);
+  await tick();
+  expect(blocks()[0].getAttribute('tabindex')).toBe('0');
+});
+
+test('a value above max fills every block, shows the number, and does not clamp', async () => {
+  await mount(7, 5);
+  await tick();
+  expect(classesOf().every((c) => c === 'is-set')).toBe(true);
+  expect(hidden().value).toBe('7');
+  expect(document.querySelector('.stat-blocks-over').textContent).toBe('7');
+});
+
+test('an over-max value drops to the clicked block, and cannot grow again', async () => {
+  await mount(7, 5);
+  await tick();
+  await press('ArrowRight');
+  expect(hidden().value).toBe('7');   // no-op: blocks cannot invent a 6th
+  blocks()[2].click();
+  await tick();
+  expect(hidden().value).toBe('3');
+});
+
+test('committing dispatches a bubbling stat-change with the stat and value', async () => {
+  await mount(2, 5);
+  await tick();
+  let seen = null;
+  document.body.addEventListener('stat-change', (e) => { seen = e.detail; });
+  blocks()[3].click();
+  await tick();
+  expect(seen).toEqual({ stat: 'might', value: 4 });
+});
+
+test('hovering alone never commits, so it dispatches nothing', async () => {
+  await mount(2, 5);
+  await tick();
+  let count = 0;
+  document.body.addEventListener('stat-change', () => { count += 1; });
+  blocks()[4].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  document.querySelector('.stat-blocks').dispatchEvent(new window.Event('mouseleave'));
+  await tick();
+  expect(count).toBe(0);
+});
+
+test('a keypress that changes nothing dispatches nothing', async () => {
+  await mount(5, 5);
+  await tick();
+  let count = 0;
+  document.body.addEventListener('stat-change', () => { count += 1; });
+  await press('ArrowRight');   // already at max
+  await press('End');          // already at max
+  expect(count).toBe(0);
+  expect(hidden().value).toBe('5');
+});
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: FAIL — Alpine logs `statBlocks is not defined` and no blocks render.
+
+- [ ] **Step 7: Implement the component**
+
+Inside the `document.addEventListener('alpine:init', ...)` callback in `public/js/alpine-components.js`, after the `characterStats` registration:
+
+```js
+  // Star-rating stat selector. Backs every stat-editing surface: the inline
+  // stats editor, the level-up modal, the character form, and the class
+  // form. Replaces the number inputs all four used to render.
+  //
+  // `value` is the committed points, `preview` the block the pointer is
+  // currently over (or null). `previewValue` deliberately runs the hovered
+  // block through the same resolveStatTarget the click uses, so the preview
+  // shows what will HAPPEN, not merely what is under the cursor -- hovering
+  // the block you are already on previews one lower, because that is what
+  // clicking it does.
+  //
+  // Keyboard commits immediately rather than previewing: arrowing IS the
+  // preview, and a focus-driven preview would fight the click preview for
+  // the same `preview` slot every time focusBlock() moved focus after a
+  // click.
+  Alpine.data('statBlocks', (initial, max, stat) => ({
+    value: parseInt(initial, 10) || 0,
+    preview: null,
+    max: max,
+    stat: stat,
+
+    // A stat already above `max` (the editor historically allowed 0-20) can
+    // step DOWN through the blocks but must never be raised by them, so the
+    // ceiling floats up to the current value and ratchets back down as the
+    // value falls.
+    get ceiling() {
+      return Math.max(this.max, this.value);
+    },
+
+    get previewValue() {
+      if (this.preview === null) return null;
+      return resolveStatTarget({
+        slot: this.preview, current: this.value, floor: 0, ceiling: this.ceiling
+      });
+    },
+
+    boxClass(i) {
+      const shown = this.previewValue;
+      if (shown !== null) return i <= shown ? 'is-preview' : 'is-empty';
+      return i <= this.value ? 'is-set' : 'is-empty';
+    },
+
+    tabIndex(i) {
+      // Roving tabindex: the grid costs one tab stop per stat, exactly what
+      // the 12 number inputs it replaces cost.
+      return i === Math.max(1, Math.min(this.value, this.max)) ? 0 : -1;
+    },
+
+    set(i) {
+      this.commit(resolveStatTarget({
+        slot: i, current: this.value, floor: 0, ceiling: this.ceiling
+      }));
+      this.focusBlock(this.value);
+    },
+
+    commit(next) {
+      const clamped = Math.max(0, Math.min(next, this.ceiling));
+      this.preview = null;
+      if (clamped === this.value) return;
+      this.value = clamped;
+      // Surfaces without Alpine state (the level-up modal) read the hidden
+      // input, which fires no native `input` event when set programmatically.
+      this.$dispatch('stat-change', { stat: this.stat, value: this.value });
+    },
+
+    focusBlock(n) {
+      const idx = Math.max(1, Math.min(n, this.max));
+      this.$nextTick(() => {
+        const el = this.$root.querySelectorAll('[role="radio"]')[idx - 1];
+        if (el) el.focus();
+      });
+    },
+
+    key(e) {
+      if (e.key === ' ' || e.key === 'Enter') {
+        const all = Array.prototype.slice.call(this.$root.querySelectorAll('[role="radio"]'));
+        const idx = all.indexOf(e.target);
+        if (idx === -1) return;
+        e.preventDefault();
+        this.set(idx + 1);
+        return;
+      }
+      let next;
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = this.value - 1;
+      else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = this.value + 1;
+      else if (e.key === 'Home') next = 0;
+      else if (e.key === 'End') next = this.max;
+      else return;
+      // Otherwise arrows scroll the page out from under the control.
+      e.preventDefault();
+      this.commit(next);
+      this.focusBlock(this.value);
+    }
+  }));
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: PASS, all tests.
+
+- [ ] **Step 9: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add public/js/alpine-components.js views/partials/stat-blocks.test.js
+git commit -F - <<'EOF'
+feat: add the statBlocks star-rating stat control
+
+resolveStatTarget holds the one click rule -- clicking the Nth block sets
+the stat to N, clicking the block you are already on steps down by one --
+and is exported on window so the character wizard's imperative grid can
+apply the identical rule instead of growing a second copy.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 3: The partial and its styles
+
+**Files:**
+- Create: `views/partials/stat-blocks.handlebars`
+- Modify: `public/css/styles.css`
+- Test: `views/partials/stat-blocks.test.js` (append)
+
+**Interfaces:**
+- Consumes: `Alpine.data('statBlocks')` from Task 2.
+- Produces: the partial `{{> stat-blocks stat=… name=… value=… max=… model=… inputClass=…}}`.
+  - `stat` (required) — the stat key, e.g. `"might"`. Drives the accessible name and `data-stat`.
+  - `name` (required) — the `name` on the hidden input, i.e. what POSTs.
+  - `value` (required) — the seeded points. `null`/`undefined` becomes 0.
+  - `max` (required) — how many blocks render.
+  - `model` (optional) — an expression like `"stats.might"`; when present the control two-way binds into the surrounding `x-data` via `x-modelable`.
+  - `inputClass` (optional) — an extra class on the hidden input, for surfaces that query it by class.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `views/partials/stat-blocks.test.js`:
+
+```js
+// --- the real partial -----------------------------------------------------
+//
+// Everything above mounts a hand-written fixture. These compile the actual
+// template with the app's real helper set and mount THAT, so the fixture
+// and the shipped partial cannot quietly drift apart.
+
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../../util/handlebars');
+
+const PARTIAL_SRC = fs.readFileSync(path.join(__dirname, 'stat-blocks.handlebars'), 'utf8');
+
+const renderPartial = (context) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(PARTIAL_SRC)(context);
+};
+
+test('the partial renders a labelled radiogroup with a POSTable hidden input', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 3, max: 5 }));
+  await tick();
+  const group = document.querySelector('.stat-blocks');
+  expect(group.getAttribute('role')).toBe('radiogroup');
+  expect(group.getAttribute('aria-label')).toBe('Might');
+  expect(document.querySelector('input[type="hidden"]').name).toBe('might');
+  expect(document.querySelectorAll('[role="radio"]').length).toBe(5);
+});
+
+test('the real partial mounts and clicks through to the right value', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 1, max: 5 }));
+  await tick();
+  document.querySelectorAll('[role="radio"]')[3].click();
+  await tick();
+  expect(document.querySelector('input[type="hidden"]').value).toBe('4');
+});
+
+test('a null value seeds zero rather than breaking the x-data expression', async () => {
+  // {{json v}} emits `null` for a missing stat; a bare {{lookup}} would emit
+  // nothing at all and produce `statBlocks(, 5, "luck")` -- a SyntaxError
+  // that takes the whole component down, which is the exact defect
+  // character-stats-editor.test.js documents for the #statsBox seed.
+  await render(renderPartial({ stat: 'luck', name: 'luck', value: null, max: 5 }));
+  await tick();
+  expect(document.querySelector('input[type="hidden"]').value).toBe('0');
+  expect(document.querySelectorAll('.is-empty').length).toBe(5);
+});
+
+test('max drives the block count, so a class spread renders three', async () => {
+  await render(renderPartial({ stat: 'might', name: 'stat_spread[might]', value: 2, max: 3 }));
+  await tick();
+  expect(document.querySelectorAll('[role="radio"]').length).toBe(3);
+  expect(document.querySelector('input[type="hidden"]').name).toBe('stat_spread[might]');
+});
+
+test('inputClass lands on the hidden input for surfaces that query it', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 0, max: 5, inputClass: 'level-up-stat' }));
+  await tick();
+  const input = document.querySelector('input[type="hidden"]');
+  expect(input.classList.contains('level-up-stat')).toBe(true);
+  expect(input.getAttribute('data-stat')).toBe('might');
+});
+
+test('model wires x-modelable so a parent x-data sees every change', async () => {
+  const inner = renderPartial({ stat: 'might', name: 'might', value: 1, max: 5, model: 'stats.might' });
+  await render(`<div x-data="{ stats: { might: 1 } }"><span id="mirror" x-text="stats.might"></span>${inner}</div>`);
+  await tick();
+  document.querySelectorAll('[role="radio"]')[3].click();
+  await tick();
+  expect(document.getElementById('mirror').textContent).toBe('4');
+});
+
+test('the partial omits the model bindings entirely when no model is passed', () => {
+  // x-modelable is emitted only alongside x-model. On its own it has no
+  // parent binding to attach to, and leaving it on every surface would be a
+  // directive that silently does nothing on three of the four.
+  const html = renderPartial({ stat: 'might', name: 'might', value: 1, max: 5 });
+  expect(html).not.toMatch(/\sx-model="/);
+  expect(html).not.toMatch(/\sx-modelable="/);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: FAIL — `ENOENT: no such file or directory, open '.../views/partials/stat-blocks.handlebars'`.
+
+- [ ] **Step 3: Create the partial**
+
+Create `views/partials/stat-blocks.handlebars`:
+
+```hbs
+{{!-- Star-rating stat selector. One control per stat. Replaces the number
+      inputs the stats editor, level-up modal, character form, and class
+      form used to render.
+
+      Params:
+        stat        the stat key ("might"). Accessible name + data-stat.
+        name        the hidden input's name -- what actually POSTs.
+        value       seeded points. null/undefined becomes 0.
+        max         how many blocks render (5 for character stats, 3 for a
+                    class stat spread).
+        model       optional expression ("stats.might"); when present the
+                    control two-way binds into the surrounding x-data.
+        inputClass  optional extra class on the hidden input, for surfaces
+                    that query it by class (the level-up modal).
+
+      The hidden input is what makes this work on native form POSTs: it
+      carries the same `name` the number input it replaced carried, so no
+      route or payload changes. A value ABOVE max is preserved -- every
+      block fills and the real number shows beside them -- and only drops
+      when the user clicks a block. Nothing clamps silently.
+
+      `value` goes through {{json}} rather than being interpolated bare: a
+      null stat renders as nothing at all under {{lookup}}, producing
+      `statBlocks(, 5, "luck")` -- a SyntaxError that takes the whole
+      component down. --}}
+<div class="stat-blocks" role="radiogroup" aria-label="{{capitalize stat}}"
+     data-stat="{{stat}}"
+     x-data="statBlocks({{json value}}, {{max}}, {{json stat}})"
+     {{#if model}}x-modelable="value" x-model="{{model}}"{{/if}}
+     @mouseleave="preview = null"
+     @keydown="key($event)">
+  <input type="hidden" name="{{name}}" :value="value"
+         class="stat-blocks-value{{#if inputClass}} {{inputClass}}{{/if}}"
+         data-stat="{{stat}}">
+  <template x-for="i in max" :key="i">
+    <span class="wizard-stat-box" role="radio"
+          :class="boxClass(i)"
+          :aria-checked="i === value"
+          :aria-label="`{{capitalize stat}}: ${i}`"
+          :tabindex="tabIndex(i)"
+          @click="set(i)"
+          @mouseenter="preview = i"></span>
+  </template>
+  <span class="stat-blocks-over" x-show="value > max" x-cloak x-text="value"></span>
+</div>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Add the styles**
+
+In `public/css/styles.css`, add one custom property to the `:root` block, beside the other `--wizard-stat-*` entries:
+
+```css
+  --wizard-stat-preview: #a8a8a8;
+```
+
+Then, immediately after the `.wizard-stat-box.is-locked { ... }` rule the Task 1 revert restored, add:
+
+```css
+/* Interactive stat block control (views/partials/stat-blocks.handlebars).
+   Shares .wizard-stat-box with the wizard's grid so the two read as one
+   control. States:
+     .is-set      a committed point
+     .is-empty    an unfilled slot
+     .is-preview  what a click on the hovered block would produce -- used in
+                  BOTH directions, so hovering below the current value shows
+                  the drop rather than pretending nothing would change */
+.stat-blocks {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+.wizard-stat-box.is-set {
+  background: var(--wizard-stat-user);
+  border-color: var(--wizard-stat-user-edge);
+  cursor: pointer;
+}
+.wizard-stat-box.is-empty {
+  background: var(--wizard-stat-empty);
+  border-color: var(--wizard-stat-user);
+  cursor: pointer;
+}
+.wizard-stat-box.is-empty:hover {
+  background: var(--wizard-stat-empty-hover);
+}
+.wizard-stat-box.is-preview {
+  background: var(--wizard-stat-preview);
+  border-color: var(--wizard-stat-user-edge);
+  cursor: pointer;
+}
+/* Roving tabindex means only one block per stat is in the tab order; that
+   block must show where focus is or keyboard users are navigating blind. */
+.stat-blocks [role="radio"]:focus-visible {
+  outline: 2px solid var(--bulma-link, #2e63b8);
+  outline-offset: 2px;
+}
+/* The numeral shown beside a full row when a stat exceeds its block count. */
+.stat-blocks-over {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--bulma-text, #4a4a4a);
+  margin-left: 0.15rem;
+}
+.stat-blocks.is-readonly .wizard-stat-box { cursor: default; }
+```
+
+- [ ] **Step 6: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add views/partials/stat-blocks.handlebars views/partials/stat-blocks.test.js public/css/styles.css
+git commit -F - <<'EOF'
+feat: add the stat-blocks partial and its styles
+
+The hidden input carries the same name the number input it replaces
+carried, so native form POSTs need no route changes, and x-modelable lets
+Alpine surfaces bind the value straight into their own state.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 4: The inline stats editor
+
+**Files:**
+- Modify: `views/partials/character-stats-editor.handlebars:5-25`
+- Modify: `public/js/alpine-components.js` (`characterStats.edit()`, around line 96)
+- Test: `views/partials/character-stats-editor.test.js`
+
+**Interfaces:**
+- Consumes: the `stat-blocks` partial (Task 3).
+- Produces: `#statsEditor` renders 12 `.stat-blocks` groups instead of 12 `.stats-input` number inputs. `characterStats.stats.<name>` remains the source of truth and the `total` getter is unchanged.
+
+- [ ] **Step 1: Update the failing tests**
+
+In `views/partials/character-stats-editor.test.js`, replace the three `<input class="stats-input">` lines in the `mount` fixture (lines 22-24) with mounted partials. Add at the top of the file, after the existing requires:
+
+```js
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+
+const STAT_BLOCKS_SRC = fs.readFileSync(
+  path.join(__dirname, 'stat-blocks.handlebars'), 'utf8'
+);
+
+// Renders the REAL stat-blocks partial into the fixture rather than a
+// hand-copied stand-in, so a regression in the shipped partial fails here
+// too instead of only in stat-blocks.test.js.
+const statBlocks = (stat, value) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(STAT_BLOCKS_SRC)({
+    stat, name: stat, value, max: 5, model: `stats.${stat}`
+  });
+};
+```
+
+Replace lines 22-24 with:
+
+```js
+      ${statBlocks('vitality', stats.vitality)}
+      ${statBlocks('might', stats.might)}
+      ${statBlocks('resilience', stats.resilience)}
+```
+
+Replace the focus test (lines 54-60):
+
+```js
+test('Edit moves focus to the first stat block', async () => {
+  await mount(STATS);
+  document.getElementById('edit').click();
+  await settle();
+  // Not a truthy-only assertion: statList starts with 'vitality', and both
+  // #statsReadOnly and #statsEditor iterate it, so the first .stat-blocks in
+  // DOM order is vitality's. Focus landing on the wrong stat's control must
+  // fail here, which a bare "something is focused" check would not catch.
+  const first = document.querySelector('.stat-blocks[data-stat="vitality"] [role="radio"][tabindex="0"]');
+  expect(first).not.toBe(null);
+  expect(document.activeElement).toBe(first);
+});
+```
+
+Replace the "total recomputes" test (lines 67-76):
+
+```js
+test('total recomputes as blocks are clicked', async () => {
+  await mount(STATS);
+  document.getElementById('edit').click();
+  await tick();
+  // vitality 3 -> 5, so 3+2+1 = 6 becomes 5+2+1 = 8.
+  document.querySelectorAll('.stat-blocks[data-stat="vitality"] [role="radio"]')[4].click();
+  await tick();
+  expect(document.getElementById('statsTotalSum').textContent).toBe('8');
+});
+```
+
+Replace the Cancel test body (lines 78-91) so it drives a block instead of an input:
+
+```js
+test('Cancel restores the original values and exits edit mode', async () => {
+  await mount(STATS);
+  document.getElementById('edit').click();
+  await tick();
+  document.querySelectorAll('.stat-blocks[data-stat="vitality"] [role="radio"]')[4].click();
+  await tick();
+  expect(document.getElementById('statsTotalSum').textContent).toBe('8');
+
+  document.getElementById('cancel').click();
+  await settle();
+  expect(document.getElementById('editor').style.display).toBe('none');
+  expect(document.getElementById('statsTotalSum').textContent).toBe('6');
+});
+```
+
+Replace the save test's edit (lines 122-125). The blocks cannot produce 99, so the clamp is no longer reachable from the UI; assert the value the blocks DO produce, and keep the clamp covered by the component's own logic:
+
+```js
+    document.querySelectorAll('.stat-blocks[data-stat="vitality"] [role="radio"]')[4].click();
+    await tick();
+```
+
+and change the payload assertion (line 138):
+
+```js
+  expect(JSON.parse(captured.options.body).vitality).toBe(5);
+```
+
+Finally, update the template-source test (lines 183-201):
+
+```js
+test('character-stats-editor.handlebars carries the Alpine bindings', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, 'character-stats-editor.handlebars'),
+    'utf8'
+  );
+
+  expect(src).toContain('x-text="total"');
+  expect(src).toContain('{{> stat-blocks');
+  expect(src).toContain('model=(concat "stats." this)');
+  expect(src).toContain('@submit.prevent="save()"');
+  expect(src).toContain('@click="cancel()"');
+  expect(src).toContain(':disabled="saving"');
+  // Object form, matching every other :class in these views: the string form
+  // can only add a class, never remove one Alpine did not add itself.
+  expect(src).toContain(":class=\"{ 'is-loading': saving }\"");
+  expect(src).toContain('x-show="error" x-text="error"');
+
+  // The number inputs this replaced must be gone, not merely hidden.
+  expect(src).not.toContain('stats-input');
+  expect(src).not.toContain('type="number"');
+  expect(src).not.toContain('character-stats.js');
+  expect(src).not.toContain('CharacterStats');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/partials/character-stats-editor.test.js`
+Expected: FAIL — the focus test fails (`edit()` still queries `.stats-input`, so `activeElement` is the body), and the template-source test fails on `{{> stat-blocks`.
+
+- [ ] **Step 3: Update the partial**
+
+Replace lines 5-25 of `views/partials/character-stats-editor.handlebars`:
+
+```hbs
+  <div class="wizard-stat-grid">
+    {{#each statList}}
+    <div class="wizard-stat-row" data-stat="{{this}}">
+      <div class="wizard-stat-name">{{capitalize this}}</div>
+      {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5 model=(concat "stats." this)}}
+    </div>
+    {{/each}}
+  </div>
+```
+
+The `<label for="stat-input-…">` is gone with the input it pointed at — a `for` aimed at a missing id is worse than no label at all. The control names itself through the radiogroup's `aria-label`.
+
+- [ ] **Step 4: Fix the focus target**
+
+In `public/js/alpine-components.js`, in `characterStats.edit()`, replace the `querySelector` line:
+
+```js
+    edit() {
+      this.error = '';
+      this.editing = true;
+      this.$nextTick(() => {
+        // The blocks use a roving tabindex, so the one tabbable block per
+        // stat is the right landing spot; the fallback covers the tick
+        // before Alpine has evaluated :tabindex on a freshly-revealed
+        // editor. Still scoped to this.root, not $el, for the reason in
+        // init() above: $el inside edit() is the Edit button, which
+        // contains no blocks at all.
+        const first = this.root.querySelector('.stat-blocks [role="radio"][tabindex="0"]')
+          || this.root.querySelector('.stat-blocks [role="radio"]');
+        if (first) first.focus();
+      });
+    },
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test views/partials/character-stats-editor.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add views/partials/character-stats-editor.handlebars views/partials/character-stats-editor.test.js public/js/alpine-components.js
+git commit -F - <<'EOF'
+feat: make the inline stats editor a block selector
+
+edit() now focuses the tabbable block rather than a .stats-input that no
+longer exists -- the e2e spec asserts focus lands on vitality's control,
+so a silently-null query would be a real keyboard regression.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 5: The level-up modal
+
+**Files:**
+- Modify: `views/partials/character-level-up.handlebars:54-77`
+- Modify: `public/js/character-level-up.js:214-218`
+- Test: `views/partials/character-level-up.test.js`
+
+**Interfaces:**
+- Consumes: the `stat-blocks` partial (Task 3) and its `stat-change` event.
+- Produces: `#levelUpStatGrid` renders `.stat-blocks` groups whose hidden inputs keep the `level-up-stat` class and `data-stat` attribute, so the save payload builder at `character-level-up.js:247` works unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `views/partials/character-level-up.test.js`:
+
+```js
+// --- stat blocks in the modal --------------------------------------------
+
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../../util/handlebars');
+
+const renderStatBlocks = (stat, value) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(read('stat-blocks.handlebars'))({
+    stat, name: stat, value, max: 5, inputClass: 'level-up-stat'
+  });
+};
+
+test('character-level-up.handlebars renders stat blocks, not number inputs', () => {
+  const src = read('character-level-up.handlebars');
+  expect(src).toContain('{{> stat-blocks');
+  expect(src).toContain('inputClass="level-up-stat"');
+  expect(src).not.toContain('type="number"');
+  expect(src).not.toContain('class="input is-small level-up-stat"');
+});
+
+test('the hidden inputs keep the class and data-stat the save payload reads', async () => {
+  await render(`<div id="levelUpStatGrid">${renderStatBlocks('might', 2)}</div>`);
+  await tick();
+  const input = document.querySelector('.level-up-stat');
+  expect(input.getAttribute('data-stat')).toBe('might');
+  expect(input.value).toBe('2');
+});
+
+test('clicking a block updates the value the save payload would read', async () => {
+  await render(`<div id="levelUpStatGrid">${renderStatBlocks('might', 2)}</div>`);
+  await tick();
+  document.querySelectorAll('[role="radio"]')[3].click();
+  await tick();
+  expect(document.querySelector('.level-up-stat').value).toBe('4');
+});
+
+test('character-level-up.js recomputes the total from stat-change, not input', () => {
+  const src = read('../../public/js/character-level-up.js');
+  // A hidden input set programmatically fires no native `input` event, so
+  // the old per-field 'input' listener would leave #levelUpTotal frozen at
+  // its seeded value for the whole session.
+  expect(src).toContain("addEventListener('stat-change', updateStatTotal)");
+  expect(src).not.toContain("el.addEventListener('input', updateStatTotal)");
+});
+
+test('a stat-change bubbling out of the grid drives the live total', async () => {
+  await render(`
+    <div id="levelUpStatGrid">
+      ${renderStatBlocks('might', 2)}
+      ${renderStatBlocks('vitality', 3)}
+    </div>
+    <strong id="levelUpTotal">0</strong>
+  `);
+  await tick();
+
+  // Mirrors the wiring in character-level-up.js:215 exactly: one delegated
+  // listener on the grid, summing every .level-up-stat.
+  const updateStatTotal = () => {
+    const sum = Array.from(document.querySelectorAll('.level-up-stat'))
+      .reduce((s, el) => s + (parseInt(el.value, 10) || 0), 0);
+    document.getElementById('levelUpTotal').textContent = sum;
+  };
+  document.getElementById('levelUpStatGrid')
+    .addEventListener('stat-change', updateStatTotal);
+  updateStatTotal();
+  expect(document.getElementById('levelUpTotal').textContent).toBe('5');
+
+  document.querySelectorAll('[data-stat="might"] [role="radio"]')[4].click();
+  await tick();
+  expect(document.getElementById('levelUpTotal').textContent).toBe('8');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/partials/character-level-up.test.js`
+Expected: FAIL — `ENOENT` on `stat-blocks.handlebars` is not the failure (Task 3 created it); the source assertions fail on `{{> stat-blocks` and on `addEventListener('stat-change'`.
+
+- [ ] **Step 3: Update the modal template**
+
+Replace lines 54-77 of `views/partials/character-level-up.handlebars` (the `#levelUpStatGrid` block):
+
+```hbs
+      <div class="wizard-stat-grid" id="levelUpStatGrid">
+        {{#each statList}}
+        <div class="wizard-stat-row" data-stat="{{this}}">
+          <div class="wizard-stat-name">{{capitalize this}}</div>
+          {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5 inputClass="level-up-stat"}}
+        </div>
+        {{/each}}
+      </div>
+```
+
+- [ ] **Step 4: Rewire the live total**
+
+In `public/js/character-level-up.js`, replace lines 214-218:
+
+```js
+    // Wire the live stat total. One delegated listener on the grid, not one
+    // per field: the blocks write through a hidden input, and a hidden
+    // input set programmatically fires no native `input` event, so the old
+    // per-field 'input' listener would never fire again and #levelUpTotal
+    // would sit frozen at its seeded value.
+    const statGrid = document.getElementById('levelUpStatGrid');
+    if (statGrid) statGrid.addEventListener('stat-change', updateStatTotal);
+    updateStatTotal();
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test views/partials/character-level-up.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add views/partials/character-level-up.handlebars views/partials/character-level-up.test.js public/js/character-level-up.js
+git commit -F - <<'EOF'
+feat: make the level-up modal's stats a block selector
+
+The live total moves to one delegated stat-change listener: the blocks
+write through a hidden input, which fires no native input event when set
+programmatically, so the old per-field listener would never fire again.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 6: The character form
+
+**Files:**
+- Modify: `views/character-form.handlebars:188-203`
+- Test: `views/character-form.test.js`
+
+**Interfaces:**
+- Consumes: the `stat-blocks` partial (Task 3).
+- Produces: the character form POSTs all 12 stats as before, from hidden inputs. No route or payload change.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `views/character-form.test.js`:
+
+```js
+// --- stat blocks ----------------------------------------------------------
+//
+// This form is a plain native POST -- no fetch, no Alpine state carrying the
+// values -- so the hidden input inside each control is the ONLY thing that
+// makes a stat reach the server. A test that only checked the blocks render
+// would pass on a form that silently posts no stats at all.
+
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../util/handlebars');
+const { statList } = require('../util/enclave-consts');
+
+const FORM_SRC = fs.readFileSync(path.join(__dirname, 'character-form.handlebars'), 'utf8');
+
+test('character-form renders stat blocks instead of number inputs', () => {
+  expect(FORM_SRC).toContain('{{> stat-blocks stat=this name=this');
+  // The old field had `type="number" name="{{this}}" ... required`.
+  expect(FORM_SRC).not.toMatch(/type="number"\s+name="\{\{this\}\}"/);
+});
+
+test('the stat fields are no longer `required`', () => {
+  // A hidden input always has a value and 0 is a legitimate stat, so a
+  // `required` here could only ever be a false gate.
+  const statsSection = FORM_SRC.slice(
+    FORM_SRC.indexOf('<label class="label">Stats</label>'),
+    FORM_SRC.indexOf('Signature Gear')
+  );
+  expect(statsSection).not.toContain('required');
+});
+
+test('every stat POSTs its own name from a hidden input', async () => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  hb.registerPartial('stat-blocks', fs.readFileSync(
+    path.join(__dirname, 'partials', 'stat-blocks.handlebars'), 'utf8'
+  ));
+
+  const statsSection = FORM_SRC.slice(
+    FORM_SRC.indexOf('<label class="label">Stats</label>'),
+    FORM_SRC.indexOf('Signature Gear')
+  );
+  const character = Object.fromEntries(statList.map((s, i) => [s, i % 6]));
+  await render(hb.compile(statsSection)({ statList, character }));
+  await tick();
+
+  const posted = Array.from(document.querySelectorAll('input[type="hidden"]'))
+    .map((el) => el.name);
+  expect(posted.sort()).toEqual([...statList].sort());
+  expect(document.querySelector('input[name="might"]').value)
+    .toBe(String(character.might));
+});
+```
+
+`views/character-form.test.js` already requires `fs` and `path` (lines 2-3) but has no Alpine bootstrap. Add to its requires and add a `beforeAll` after them:
+
+```js
+const { setupAlpine, render, tick } = require('../test/helpers/alpine-dom');
+
+beforeAll(async () => {
+  await setupAlpine();
+  require('../public/js/alpine-components.js');
+  document.dispatchEvent(new window.CustomEvent('alpine:init'));
+});
+```
+
+and extend line 1's destructure to `const { test, expect, beforeAll } = require('bun:test');`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/character-form.test.js`
+Expected: FAIL — `expect(FORM_SRC).toContain('{{> stat-blocks stat=this name=this')` fails.
+
+- [ ] **Step 3: Update the template**
+
+Replace lines 191-201 of `views/character-form.handlebars` (the `{{#each statList}}` body inside the Stats field):
+
+```hbs
+      {{#each statList}}
+      <div class="column is-one-third">
+        <div class="field">
+          <label class="label">{{capitalize this}}</label>
+          <div class="control">
+            {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5}}
+          </div>
+        </div>
+      </div>
+      {{/each}}
+```
+
+The `required` attribute is dropped along with the number input: a hidden input always carries a value, and 0 is a legitimate stat, so it could only ever be a gate that never fires. The `{{#if}}/{{else}}0` default is dropped too — `{{json value}}` emits `null` for a missing stat and the component's `parseInt(initial, 10) || 0` turns that into 0.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test views/character-form.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add views/character-form.handlebars views/character-form.test.js
+git commit -F - <<'EOF'
+feat: make the character form's stats a block selector
+
+The hidden input keeps the same name the number input posted, so the
+route and payload are untouched -- and the new test asserts all 12 names
+actually reach the form, since a native POST has nothing else carrying
+them.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 7: The class form stat spread
+
+**Files:**
+- Modify: `views/class-form.handlebars:100-110`
+- Test: `views/class-form.test.js` (create)
+
+**Interfaces:**
+- Consumes: the `stat-blocks` partial (Task 3).
+- Produces: the class form POSTs `stat_spread[<stat>]` for all 12 stats, unchanged in name and shape, so `parseStatSpread` in `routes/classes.js:56-70` needs no change.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `views/class-form.test.js`:
+
+```js
+// The class form's stat spread is a native POST using bracket notation
+// (stat_spread[might]=2), parsed by parseStatSpread in routes/classes.js.
+// Swapping the number inputs for blocks must not disturb those names --
+// parseStatSpread reads body['stat_spread[<stat>]'] literally, so a renamed
+// field silently yields an empty spread and the class ships with no stats.
+const { test, expect, beforeAll } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../util/handlebars');
+const { statList } = require('../util/enclave-consts');
+const { setupAlpine, render, tick } = require('../test/helpers/alpine-dom');
+
+beforeAll(async () => {
+  await setupAlpine();
+  require('../public/js/alpine-components.js');
+  document.dispatchEvent(new window.CustomEvent('alpine:init'));
+});
+
+const SRC = fs.readFileSync(path.join(__dirname, 'class-form.handlebars'), 'utf8');
+
+const renderSpread = async (statSpread) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  hb.registerPartial('stat-blocks', fs.readFileSync(
+    path.join(__dirname, 'partials', 'stat-blocks.handlebars'), 'utf8'
+  ));
+  const section = SRC.slice(
+    SRC.indexOf('<label class="label">Class Stats</label>'),
+    SRC.indexOf('<label class="label" for="class-image">')
+  );
+  await render(hb.compile(section)({ statList, class: { stat_spread: statSpread } }));
+  await tick();
+};
+
+test('class-form renders stat blocks instead of number inputs', () => {
+  expect(SRC).toContain('{{> stat-blocks');
+  expect(SRC).not.toMatch(/name="stat_spread\[\{\{this\}\}\]"\s*value=/);
+  expect(SRC).not.toContain('type="number"');
+});
+
+test('every stat posts under its bracket-notation name', async () => {
+  await renderSpread({ might: 2, resilience: 1 });
+  const posted = Array.from(document.querySelectorAll('input[type="hidden"]'))
+    .map((el) => el.name);
+  expect(posted.sort()).toEqual(statList.map((s) => `stat_spread[${s}]`).sort());
+});
+
+test('a class spread renders three blocks per stat, not five', async () => {
+  await renderSpread({ might: 2 });
+  const might = document.querySelector('.stat-blocks[data-stat="might"]');
+  expect(might.querySelectorAll('[role="radio"]').length).toBe(3);
+});
+
+test('seeded points fill and unseeded stats start empty', async () => {
+  await renderSpread({ might: 2 });
+  expect(document.querySelector('input[name="stat_spread[might]"]').value).toBe('2');
+  expect(document.querySelector('input[name="stat_spread[luck]"]').value).toBe('0');
+});
+
+test('clicking a block updates the value that would post', async () => {
+  await renderSpread({ might: 2 });
+  document.querySelectorAll('.stat-blocks[data-stat="might"] [role="radio"]')[2].click();
+  await tick();
+  expect(document.querySelector('input[name="stat_spread[might]"]').value).toBe('3');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/class-form.test.js`
+Expected: FAIL — `expect(SRC).toContain('{{> stat-blocks')` fails.
+
+- [ ] **Step 3: Update the template**
+
+Replace lines 102-109 of `views/class-form.handlebars` (the `{{#each statList}}` body):
+
+```hbs
+      {{#each statList}}
+      <div class="column is-2-tablet is-4-mobile">
+        <label class="label is-small is-capitalized">{{this}}</label>
+        <div class="control">
+          {{> stat-blocks stat=this name=(concat "stat_spread[" this "]") value=(lookup ../class.stat_spread this) max=3}}
+        </div>
+      </div>
+      {{/each}}
+```
+
+The `for="stat-{{this}}"` and matching `id` go with the input they linked; the radiogroup names itself through its `aria-label`. The existing help text ("Most classes total 3 points; leave a stat at 0 to omit it") stays accurate.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test views/class-form.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole unit suite, including the route contract**
+
+Run: `bun run test:unit && bun run test:http`
+Expected: PASS. `routes/classes-stat-spread.test.js` exercises `parseStatSpread` against the bracket names and must be unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add views/class-form.handlebars views/class-form.test.js
+git commit -F - <<'EOF'
+feat: make the class stat spread a block selector
+
+parseStatSpread reads body['stat_spread[<stat>]'] literally, so the new
+test pins all 12 bracket names -- a renamed field would yield an empty
+spread and ship a class with no stats, with no error anywhere.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 8: Read-only blocks on the LFG post page
+
+**Files:**
+- Create: `views/partials/stat-blocks-readonly.handlebars`
+- Modify: `views/lfg-post.handlebars:110-119` (per-character details) and `:177-189` (party stats)
+- Test: `views/lfg-post.test.js` (create)
+
+**Interfaces:**
+- Consumes: the `.wizard-stat-box`, `.is-set`, `.is-empty`, and `.stat-blocks.is-readonly` styles from Tasks 1 and 3.
+- Produces: `{{> stat-blocks-readonly value=… max=…}}` — server-rendered blocks with no JS, no ARIA group, and no interaction.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `views/lfg-post.test.js`:
+
+```js
+// The LFG post page showed stats as literal '+' characters. It predates the
+// square-plus commit but is the same "stats as pluses" look, so it converts
+// with the rest.
+const { test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../util/handlebars');
+
+const READONLY_SRC = fs.readFileSync(
+  path.join(__dirname, 'partials', 'stat-blocks-readonly.handlebars'), 'utf8'
+);
+const LFG_SRC = fs.readFileSync(path.join(__dirname, 'lfg-post.handlebars'), 'utf8');
+
+const renderReadonly = (context) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(READONLY_SRC)(context);
+};
+
+const count = (html, cls) => (html.match(new RegExp(cls, 'g')) || []).length;
+
+test('renders one filled block per point and dims the rest to max', () => {
+  const html = renderReadonly({ value: 2, max: 5 });
+  expect(count(html, 'is-set')).toBe(2);
+  expect(count(html, 'is-empty')).toBe(3);
+});
+
+test('a value at max fills every block and dims none', () => {
+  const html = renderReadonly({ value: 5, max: 5 });
+  expect(count(html, 'is-set')).toBe(5);
+  expect(count(html, 'is-empty')).toBe(0);
+});
+
+test('a value above max fills every block without overflowing the row', () => {
+  // Party totals routinely exceed 5; the row must cap rather than render 14
+  // blocks. The caller shows the real number alongside.
+  const html = renderReadonly({ value: 14, max: 5 });
+  expect(count(html, 'is-set')).toBe(5);
+  expect(count(html, 'is-empty')).toBe(0);
+});
+
+test('a zero or missing value renders an all-dim row', () => {
+  expect(count(renderReadonly({ value: 0, max: 5 }), 'is-empty')).toBe(5);
+  expect(count(renderReadonly({ max: 5 }), 'is-empty')).toBe(5);
+});
+
+test('the read-only control carries no interactive affordances', () => {
+  const html = renderReadonly({ value: 3, max: 5 });
+  expect(html).toContain('is-readonly');
+  expect(html).not.toContain('role="radio"');
+  expect(html).not.toContain('x-data');
+  expect(html).not.toContain('@click');
+  expect(html).not.toContain('tabindex');
+});
+
+test('lfg-post renders blocks and no longer prints plus characters', () => {
+  expect(LFG_SRC).toContain('{{> stat-blocks-readonly');
+  // Both {{#range}} loops that printed a bare '+' per point are gone.
+  expect(LFG_SRC).not.toMatch(/\{\{#range 0 \(lookup [^)]*\)\}\}\+/);
+  expect(LFG_SRC).not.toMatch(/\{\{#range 0 \(lookup [^)]*\)\}\}\s*\n\s*\+/);
+});
+
+test('party stats keep their numeral, since totals routinely exceed five', () => {
+  const partySection = LFG_SRC.slice(LFG_SRC.indexOf('Party Stats'));
+  expect(partySection).toContain('({{lookup ../partyStats this}})');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/lfg-post.test.js`
+Expected: FAIL — `ENOENT: ... stat-blocks-readonly.handlebars`.
+
+- [ ] **Step 3: Create the read-only partial**
+
+Create `views/partials/stat-blocks-readonly.handlebars`:
+
+```hbs
+{{!-- Display-only stat blocks. No Alpine, no ARIA group, no interaction --
+      this is the same visual vocabulary as views/partials/stat-blocks.handlebars
+      for surfaces that only report a value.
+
+      Params:
+        value  the points to show (null/missing renders an empty row)
+        max    how many blocks the row holds
+
+      A value above max fills every block and stops there rather than
+      spilling a 14-block row across the layout; callers that can exceed
+      max (party totals) print the real number alongside. There is no `min`
+      helper registered, hence the branch. --}}
+<span class="stat-blocks is-readonly">
+  {{#if (gt value max)}}
+  {{#range 0 max}}<span class="wizard-stat-box is-set"></span>{{/range}}
+  {{else}}
+  {{#range 0 value}}<span class="wizard-stat-box is-set"></span>{{/range}}
+  {{#range value max}}<span class="wizard-stat-box is-empty"></span>{{/range}}
+  {{/if}}
+</span>
+```
+
+- [ ] **Step 4: Update the per-character details block**
+
+Replace lines 113-119 of `views/lfg-post.handlebars`:
+
+```hbs
+                      {{#each ../statList}}
+                      <div class="column is-6">
+                        <p class="mb-1"><strong>{{capitalize this}}</strong></p>
+                        {{> stat-blocks-readonly value=(lookup ../this.character this) max=5}}
+                      </div>
+                      {{/each}}
+```
+
+- [ ] **Step 5: Update the party stats block**
+
+Replace lines 179-187 of `views/lfg-post.handlebars`:
+
+```hbs
+      {{#each statList}}
+      <div class="column is-3">
+        <p class="mb-1"><strong>{{capitalize this}}</strong> ({{lookup ../partyStats this}})</p>
+        {{> stat-blocks-readonly value=(lookup ../partyStats this) max=5}}
+      </div>
+      {{/each}}
+```
+
+The numeral stays: a party of four routinely totals well above 5, and the capped row alone would read as "5" for every stat.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `bun test views/lfg-post.test.js`
+Expected: PASS.
+
+- [ ] **Step 7: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add views/partials/stat-blocks-readonly.handlebars views/lfg-post.handlebars views/lfg-post.test.js
+git commit -F - <<'EOF'
+feat: show LFG stats as blocks instead of plus characters
+
+Party totals routinely exceed the five-block row, so the row caps and the
+real number stays beside it rather than spilling a 14-block row across
+the layout.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 9: Jump-to-N and hover preview in the wizard
+
+**Files:**
+- Modify: `public/js/character-wizard.js` (`renderStatGrid` ~:818, `onStatBoxClick` ~:905, and the listener wiring)
+- Modify: `public/css/styles.css` (add `.is-preview-off`)
+- Test: `views/partials/stat-blocks.test.js` (append)
+
+**Interfaces:**
+- Consumes: `window.StatBlocks.resolveStatTarget` from Task 2. Load order is safe: `alpine-components.js` is a deferred `<head>` script (`head.handlebars:16`) and `character-wizard.js` a deferred body script (`character-wizard.handlebars:284`), and deferred scripts execute in document order.
+- Produces: no new exports. The wizard's `state.userStats` shape is unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `views/partials/stat-blocks.test.js`:
+
+```js
+// --- the wizard's use of the shared rule ----------------------------------
+//
+// public/js/character-wizard.js is a 1698-line IIFE that returns immediately
+// without a #wizard-data element and touches localStorage, Math.random, and
+// rAF at init, so mounting it under jsdom is its own project. Instead the
+// arithmetic it needs lives in resolveStatTarget and is pinned here with the
+// wizard's own numbers, and a source assertion proves the wizard calls it
+// rather than growing a second copy.
+
+// Mirrors the call the wizard makes: floor is the class + personality
+// points the user may not remove, ceiling is whichever binds first -- the
+// per-stat cap, or what the remaining budget can pay for.
+const wizardTarget = ({ slot, cp, pp, up, remaining, cap }) =>
+  window.StatBlocks.resolveStatTarget({
+    slot,
+    current: cp + pp + up,
+    floor: cp + pp,
+    ceiling: Math.min(cap, cp + pp + up + remaining)
+  }) - cp - pp;
+
+test('wizard: clicking the 4th block assigns the whole jump when the budget covers it', () => {
+  // Level 2+: cap 5. One class point, nothing user-assigned, 4 points left.
+  expect(wizardTarget({ slot: 4, cp: 1, pp: 0, up: 0, remaining: 4, cap: 5 })).toBe(3);
+});
+
+test('wizard: a short budget assigns only what remains', () => {
+  expect(wizardTarget({ slot: 5, cp: 1, pp: 0, up: 0, remaining: 2, cap: 5 })).toBe(2);
+});
+
+test('wizard: the per-stat cap binds before the budget at level 1', () => {
+  // Level 1: cap 3. Clicking the 5th block can only reach 3 total.
+  expect(wizardTarget({ slot: 5, cp: 1, pp: 0, up: 0, remaining: 5, cap: 3 })).toBe(2);
+});
+
+test('wizard: clicking the topmost user-assigned block removes one point', () => {
+  // 1 class + 2 user = 3. Clicking the 3rd block steps down to 2 total.
+  expect(wizardTarget({ slot: 3, cp: 1, pp: 0, up: 2, remaining: 3, cap: 5 })).toBe(1);
+});
+
+test('wizard: a click can never take a stat below its class and personality points', () => {
+  // 1 class + 1 personality + 2 user. Clicking the 1st block floors at 2.
+  expect(wizardTarget({ slot: 1, cp: 1, pp: 1, up: 2, remaining: 2, cap: 5 })).toBe(0);
+});
+
+test('character-wizard.js applies the shared rule instead of its own arithmetic', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'js', 'character-wizard.js'), 'utf8'
+  );
+  expect(src).toContain('StatBlocks.resolveStatTarget');
+  // The old one-point-at-a-time branches must be gone, not left beside it.
+  expect(src).not.toContain('state.userStats[stat] = up + 1');
+  expect(src).not.toContain('state.userStats[stat] = up - 1');
+});
+
+test('character-wizard.js wires the hover preview', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'js', 'character-wizard.js'), 'utf8'
+  );
+  expect(src).toContain("addEventListener('mouseover', onStatBoxHover)");
+  expect(src).toContain("addEventListener('mouseleave', clearStatPreview)");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: FAIL — the five `wizardTarget` cases PASS already (they only exercise Task 2's function), and the two source assertions FAIL on `StatBlocks.resolveStatTarget`.
+
+- [ ] **Step 3: Replace `onStatBoxClick`**
+
+In `public/js/character-wizard.js`, replace the whole `onStatBoxClick` function (around line 905) with:
+
+```js
+  // Resolve what a click or hover on `slot` (0-based DOM index) should make
+  // this stat's TOTAL. Shared by the click handler and the hover preview so
+  // the preview cannot promise something the click won't deliver.
+  const resolveWizardTotal = (stat, slot) => {
+    const classPts = getClassPoints();
+    const persPts = getPersonalityPoints();
+    const cp = classPts[stat] || 0;
+    const pp = persPts[stat] || 0;
+    const up = state.userStats[stat] || 0;
+    const remaining = Math.max(0, getTotalPoints()
+      - sumPoints(classPts) - sumPoints(persPts) - getUserPointsTotal());
+    return window.StatBlocks.resolveStatTarget({
+      slot: slot + 1,
+      current: cp + pp + up,
+      // Class- and personality-assigned points are the floor: no click can
+      // take the stat below them.
+      floor: cp + pp,
+      // Whichever binds first -- the per-stat cap for this level, or what
+      // the remaining budget can actually pay for.
+      ceiling: Math.min(getMaxAssignable(), cp + pp + up + remaining)
+    });
+  };
+
+  // Click handler for stat boxes. Star-rating semantics, matching the
+  // statBlocks component every other surface uses: clicking the Nth block
+  // sets the stat to N, except that clicking the block you are already on
+  // steps down by one.
+  const onStatBoxClick = (e) => {
+    const box = e.target.closest('.wizard-stat-box');
+    if (!box || !box.hasAttribute('data-clickable')) return;
+    const stat = box.getAttribute('data-stat');
+    const slot = parseInt(box.getAttribute('data-slot'), 10);
+    const classPts = getClassPoints();
+    const persPts = getPersonalityPoints();
+    const cp = classPts[stat] || 0;
+    const pp = persPts[stat] || 0;
+
+    const userTarget = Math.max(0, resolveWizardTotal(stat, slot) - cp - pp);
+    if (userTarget === (state.userStats[stat] || 0)) return;
+
+    if (userTarget <= 0) delete state.userStats[stat];
+    else state.userStats[stat] = userTarget;
+
+    renderStatGrid();
+    updateStatsDisplay();
+    renderSummary();
+  };
+
+  // Hover preview. Shows the total a click would produce -- in both
+  // directions, so hovering below the current value previews the drop
+  // rather than pretending nothing would change.
+  const clearStatPreview = () => {
+    if (!statGrid) return;
+    Array.prototype.forEach.call(
+      statGrid.querySelectorAll('.is-preview, .is-preview-off'),
+      (el) => el.classList.remove('is-preview', 'is-preview-off')
+    );
+  };
+
+  const onStatBoxHover = (e) => {
+    const box = e.target.closest && e.target.closest('.wizard-stat-box');
+    clearStatPreview();
+    if (!box || !box.hasAttribute('data-clickable')) return;
+    const stat = box.getAttribute('data-stat');
+    const slot = parseInt(box.getAttribute('data-slot'), 10);
+    const row = box.closest('.wizard-stat-row');
+    if (!row) return;
+    const classPts = getClassPoints();
+    const persPts = getPersonalityPoints();
+    const floor = (classPts[stat] || 0) + (persPts[stat] || 0);
+    const total = resolveWizardTotal(stat, slot);
+
+    Array.prototype.forEach.call(row.querySelectorAll('.wizard-stat-box'), (b, i) => {
+      if (i < floor) return;                          // class/personality: never previewed
+      if (i < total) b.classList.add('is-preview');    // would be filled
+      else if (b.classList.contains('is-user')) b.classList.add('is-preview-off'); // would be given back
+    });
+  };
+```
+
+- [ ] **Step 4: Wire the hover listeners**
+
+Replace line 994 — currently `if (statGrid) statGrid.addEventListener('click', onStatBoxClick);` — with:
+
+```js
+  if (statGrid) {
+    statGrid.addEventListener('click', onStatBoxClick);
+    // mouseover, not mouseenter: this is delegated to the grid and has to
+    // fire as the pointer crosses between individual boxes, which mouseenter
+    // on the container does not do. mouseleave on the container is still the
+    // right clear signal -- it fires once, when the pointer leaves the grid.
+    statGrid.addEventListener('mouseover', onStatBoxHover);
+    statGrid.addEventListener('mouseleave', clearStatPreview);
+  }
+```
+
+- [ ] **Step 5: Add the preview-off style**
+
+In `public/css/styles.css`, immediately after the `.wizard-stat-box.is-preview` rule added in Task 3:
+
+```css
+/* A point the hovered click would give BACK. Dimming it (rather than
+   emptying it) keeps the row's shape stable while the pointer moves. */
+.wizard-stat-box.is-preview-off {
+  opacity: 0.4;
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `bun test views/partials/stat-blocks.test.js`
+Expected: PASS.
+
+- [ ] **Step 7: Run the whole unit suite**
+
+Run: `bun run test:unit`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add public/js/character-wizard.js public/css/styles.css views/partials/stat-blocks.test.js
+git commit -F - <<'EOF'
+feat: give the wizard's stat grid jump-to-N and hover preview
+
+The wizard calls the same resolveStatTarget the statBlocks component
+does, so the two surfaces cannot drift; the per-stat cap and the budget
+reconciliation are untouched and still bound every click through the
+ceiling argument.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 10: End-to-end specs and the browser check
+
+**Files:**
+- Modify: `e2e/specs/04-stats-editor.spec.js:55-106`
+- Modify: `e2e/specs/05-level-up-modal.spec.js` (the stat-editing steps)
+
+**Interfaces:**
+- Consumes: every prior task.
+- Produces: nothing further depends on this.
+
+- [ ] **Step 1: Update the stats-editor spec**
+
+In `e2e/specs/04-stats-editor.spec.js`, replace the note at lines 38-45 and the four owner tests that drive number inputs. The scoping note still applies — the level-up modal renders its own grid with the same `data-stat` values on the same page — so keep every locator scoped to `#statsEditor`:
+
+```js
+  // NOTE: every stat locator below is scoped to `#statsEditor`. The character
+  // show page also renders the (separate, hidden-by-default) level-up modal
+  // from views/partials/character-level-up.handlebars, whose stat grid uses
+  // the same `data-stat` convention. An unscoped locator matches both and
+  // Playwright's strict mode throws. This is test-selector scoping, not a
+  // product defect -- the two controls belong to unrelated features that both
+  // happen to live on the same page.
+  const blocks = (page, stat) =>
+    page.locator(`#statsEditor .stat-blocks[data-stat="${stat}"] [role="radio"]`);
+  const posted = (page, stat) =>
+    page.locator(`#statsEditor input[name="${stat}"]`);
+
+  test('the stats box renders with the editor hidden', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await expect(page.locator('#statsBox')).toBeVisible();
+    await expect(page.locator('#statsReadOnly')).toBeVisible();
+    await expect(page.locator('#statsEditor')).toBeHidden();
+    await expect(page.locator('#statsUnlockBtn')).toBeVisible();
+  });
+
+  test('Edit reveals the editor and focuses the first stat block', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+
+    await expect(page.locator('#statsEditor')).toBeVisible();
+    await expect(page.locator('#statsReadOnly')).toBeHidden();
+
+    // `vitality` by name, not just "something is focused": edit() takes the
+    // first .stat-blocks in DOM order, and util/enclave-consts.js's statList
+    // (the array both #statsReadOnly and #statsEditor iterate) starts with
+    // 'vitality'. A truthy-only assertion would still pass with focus on the
+    // wrong stat.
+    await expect(
+      page.locator('#statsEditor .stat-blocks[data-stat="vitality"] [role="radio"][tabindex="0"]')
+    ).toBeFocused();
+  });
+
+  test('the live total tracks block clicks', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+
+    const before = Number(await page.locator('#statsTotalSum').innerText());
+    await blocks(page, 'might').nth(4).click();   // 5th block -> 5
+    await expect
+      .poll(async () => Number(await page.locator('#statsTotalSum').innerText()))
+      .toBe(before - 1 + 5);                      // seeded value is 1
+  });
+
+  test('clicking the block a stat is already on steps it down', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+
+    await blocks(page, 'might').nth(2).click();   // 3rd block -> 3
+    await expect(posted(page, 'might')).toHaveValue('3');
+    await blocks(page, 'might').nth(2).click();   // same block -> 2
+    await expect(posted(page, 'might')).toHaveValue('2');
+  });
+
+  test('Cancel restores the original values and hides the editor', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+    await blocks(page, 'might').nth(3).click();
+    await page.locator('#statsCancelBtn').click();
+
+    await expect(page.locator('#statsEditor')).toBeHidden();
+    await page.locator('#statsUnlockBtn').click();
+    await expect(posted(page, 'might')).toHaveValue('1');
+  });
+
+  test('Save persists to the database', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+    await blocks(page, 'might').nth(4).click();   // 5th block -> 5
+    await page.locator('#statsSaveBtn').click();
+
+    await expect(page.locator('#statsEditor')).toBeHidden();
+    await expect.poll(async () => {
+      const { rows } = await db.query('select might from characters where id = $1', [character.id]);
+      return rows[0].might;
+    }).toBe(5);
+  });
+```
+
+- [ ] **Step 2: Update the level-up spec**
+
+In `e2e/specs/05-level-up-modal.spec.js`, replace lines 106-107 of the "completing a level-up persists the new level and the edited stat" test:
+
+```js
+  // The blocks write through a hidden input, so there is nothing to fill;
+  // clicking the Nth block is how a stat reaches N. Capped at the 5-block
+  // row rather than blindly incrementing, so a seeded 5 doesn't ask for a
+  // sixth block that does not exist.
+  const editedMight = before.might >= 5 ? 4 : before.might + 1;
+  await page.locator('#levelUpModal .stat-blocks[data-stat="might"] [role="radio"]')
+    .nth(editedMight - 1).click();
+```
+
+`editedMight` keeps its name and meaning, so the persistence assertion at line 134 (`toEqual({ level: before.level + 1, might: editedMight })`) needs no change. Leave every other assertion in the file alone — what the save persists has not changed.
+
+- [ ] **Step 3: Run the unit suite one more time**
+
+Run: `bun run test:unit && bun run test:http`
+Expected: PASS.
+
+- [ ] **Step 4: Run the e2e suite**
+
+Run: `bun run test:e2e`
+Expected: PASS. This tier needs a local Supabase and the app running — follow `docs/` for the e2e tier setup if it is not already up. If the tier cannot be started, say so explicitly rather than reporting the specs as passing.
+
+- [ ] **Step 5: Manual browser check**
+
+Hover preview and focus rings are not things jsdom or these specs confirm. Start the app (`bun run dev`) and check each surface:
+
+| Surface | Check |
+|---|---|
+| `/characters/:id` → Edit | Blocks render; hover previews up and down; clicking the active block steps down; Tab reaches one block per stat; arrows adjust; the total tracks |
+| `/characters/:id` → Level Up | Same, and `#levelUpTotal` tracks |
+| `/characters/:id/edit` | Blocks render; save persists all 12 stats |
+| `/classes/new` | Three blocks per stat; save persists the spread |
+| `/characters/new` wizard step 2 | Clicking the 4th block jumps; a short budget assigns only what remains; class points stay unclickable; hover previews |
+| `/lfg/:id` | Party stats and per-character stats show blocks, no `+` characters |
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/specs/04-stats-editor.spec.js e2e/specs/05-level-up-modal.spec.js
+git commit -F - <<'EOF'
+test: drive the stat blocks instead of number inputs in e2e
+
+Adds coverage for the step-down click, which has no equivalent in a
+number input and is the only way a stat reaches zero from the UI.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+```

--- a/docs/superpowers/specs/2026-08-05-stat-block-selector-design.md
+++ b/docs/superpowers/specs/2026-08-05-stat-block-selector-design.md
@@ -1,0 +1,271 @@
+# Stat Block Selector — Design
+
+**Date:** 2026-08-05
+**Branch:** `stat-block-selector`, stacked on `fix-alpine-frozen-class-and-pages-rls`
+**Status:** Approved, awaiting implementation plan
+
+## Problem
+
+Two things are wrong with how the app presents stats.
+
+**Stats render as plus icons.** Commit `e13cbd3` ("feat: render wizard stat
+boxes as square-plus icons") replaced the filled/bordered point squares in the
+character wizard's stat grid with `fa-square-plus` glyphs, and recolored the
+`.wizard-stat-box` states to drive the icon instead of the box border. The
+blocks read better. `views/lfg-post.handlebars` independently renders stats as
+literal `+` text characters, so the plus look is not confined to that commit.
+
+**Editing a stat means typing a number.** Four surfaces present the 12 stats as
+number inputs:
+
+| Surface | Field |
+|---|---|
+| `views/partials/character-stats-editor.handlebars:10` | `input.stats-input`, 0–20, Alpine `x-model.number` |
+| `views/partials/character-level-up.handlebars:59` | `input.level-up-stat`, 0–20, vanilla JS |
+| `views/character-form.handlebars:196` | `input`, native form POST, `required` |
+| `views/class-form.handlebars:105` | `input`, `stat_spread[x]`, 0–3 |
+
+Typing "3" into a box is a poor fit for a value whose whole range is 0–5 and
+which is already drawn as five blocks two inches away on the same page. The
+character wizard already does the right thing — its grid is clickable blocks —
+but it assigns one point per click, so even it does not read as "pick a
+rating".
+
+## Goal
+
+Restore blocks everywhere, and make every stat-editing surface a star-rating
+control: click the Nth block to set the stat to N, with the unset blocks
+visible but dimmed. Remove the stat number inputs entirely.
+
+## Non-goals
+
+- Changing the stat range, the point budget formula (`getTotalPoints`:
+  `6 + (level−1)×2`), or the per-stat cap (`getMaxAssignable`: 3 at level 1,
+  5 above). The UI changes; the rules do not.
+- Changing any route, payload shape, or server-side validation.
+  `services/character/input.js:131` keeps clamping submitted stats exactly as
+  it does today.
+- Backfilling test coverage for `public/js/character-wizard.js` beyond the two
+  functions this change touches. The module is otherwise untested and stays
+  that way.
+- Rewriting the wizard's step-2 state management.
+
+## Decisions
+
+Settled during brainstorming; recorded here because several are non-obvious.
+
+**Five blocks per stat, 0–20 still saveable.** Five matches the wizard's
+per-stat cap and the read-only grid on `views/character.handlebars:221`. A
+value above 5 — which the current 0–20 editor permits — renders five filled
+blocks plus a numeric badge, and is preserved on save. Nothing clamps a stat
+down silently; a value only drops when the user clicks a block. `class-form`
+renders 3 blocks, matching its existing 0–3 range.
+
+**Clicking the active block drops to N−1.** At value 3, clicking the 3rd block
+gives 2. This matches the wizard's existing behavior — clicking a
+user-assigned box removes that point — so the two feel like one control. It
+also means clicking the 1st block at value 1 is how you reach 0.
+
+**The wizard adopts jump-to-N.** Clicking the 4th block from value 1 assigns 3
+points at once if the budget covers it, and as many as remain if it does not.
+Without this the wizard would be the one surface that clicks differently.
+
+**Buttons plus a hidden input, not radios.** Each block is a focusable element
+in a `role="radiogroup"` with roving tabindex; a hidden input carries the value
+for native form POST. The alternative — six visually-hidden radios per stat,
+72 per grid — gets native keyboard and POST for free but still needs JS for
+the drop-to-N−1 rule, and triples the element count.
+
+**Hover previews the value.** Hovering the 4th block lights blocks 1–4 in a
+muted shade; leaving the row restores the committed value. Keyboard focus does
+the same. Without it the control reads as five unrelated toggles.
+
+## Architecture
+
+One partial and one Alpine component serve the four text-box surfaces. The
+wizard keeps its own imperative renderer and shares only the CSS and the
+interaction rules.
+
+```
+views/partials/stat-blocks.handlebars     new — the control
+public/js/alpine-components.js            new Alpine.data('statBlocks')
+public/css/styles.css                     .wizard-stat-box states + .is-preview
+
+  consumed by:
+    views/partials/character-stats-editor.handlebars   x-model into characterStats
+    views/partials/character-level-up.handlebars       stat-change → vanilla JS
+    views/character-form.handlebars                    hidden input → native POST
+    views/class-form.handlebars                        hidden input → native POST
+
+  parallel implementation (own state, shared CSS):
+    public/js/character-wizard.js          renderStatGrid + onStatBoxClick
+```
+
+The wizard is deliberately not folded into the shared component. Its grid is
+re-rendered imperatively from a closure on every trait change, and its per-box
+state is a function of class points, personality points, and remaining budget —
+none of which the shared component knows. Bridging it to Alpine would be a
+rewrite of wizard step 2, against a module with no unit tests.
+
+## The control
+
+`views/partials/stat-blocks.handlebars`, invoked as
+`{{> stat-blocks stat=this name=this value=(lookup ../character this) max=5}}`:
+
+```hbs
+<div class="stat-blocks" role="radiogroup" aria-label="{{capitalize stat}}"
+     x-data="statBlocks({{json value}}, {{max}})" x-modelable="value"
+     @mouseleave="preview = null" @keydown="key($event)">
+  <input type="hidden" name="{{name}}" :value="value"
+         class="stat-blocks-value" data-stat="{{stat}}">
+  <template x-for="i in max" :key="i">
+    <span class="wizard-stat-box" role="radio"
+          :class="boxClass(i)" :aria-checked="i === value"
+          :tabindex="i === (value || 1) ? 0 : -1"
+          :aria-label="`{{capitalize stat}}: ${i}`"
+          @click="set(i)" @mouseenter="preview = i" @focus="preview = i"></span>
+  </template>
+  <span class="stat-blocks-over" x-show="value > max" x-text="value"></span>
+</div>
+```
+
+`Alpine.data('statBlocks', (initial, max) => ...)`:
+
+| Member | Behavior |
+|---|---|
+| `value` | current points; exposed via `x-modelable` for two-way parent binding |
+| `preview` | hovered or focused index, or `null` |
+| `set(i)` | `value = (i === value) ? i - 1 : i`, then dispatch `stat-change` |
+| `previewValue` | what a click on `preview` would produce: `(preview === value) ? preview - 1 : preview` |
+| `boxClass(i)` | while `preview` is set: `is-preview` when `i <= previewValue`, else `is-empty`. Otherwise `is-set` when `i <= value`, else `is-empty`. |
+| `key(e)` | `←/↓` −1, `→/↑` +1, `Home` → 0, `End` → max, `Space`/`Enter` sets the focused block. Each `preventDefault`s so arrows don't scroll the page. |
+
+**Preview runs in both directions and shows the real outcome.** At value 5,
+hovering the 2nd block previews two blocks — the control tells you it is about
+to drop the stat, not just that it could raise it. Hovering the *active* block
+previews N−1, matching what the click will actually do rather than showing a
+no-op.
+
+**Roving tabindex** keeps each stat to one tab stop, so the grid costs 12 tab
+stops — the same as the 12 number inputs it replaces.
+
+**Two output paths, both always rendered.** The hidden input preserves the
+`name` and POST body of the field it replaces, so `character-form` and
+`class-form` need no server-side change. `x-modelable` lets Alpine surfaces
+bind `value` into their own state. Surfaces driven by vanilla JS read the
+hidden input and listen for the bubbling `stat-change` event — detail
+`{ stat, value }` — because a programmatically-set hidden input fires no
+native `input` event.
+
+**CSS** reuses the states the revert restores: `.is-set` maps onto the filled
+square, `.is-empty` onto the dimmed bordered one, plus one new `.is-preview`
+shade. The wizard's existing `.is-class` / `.is-user` / `.is-assignable` /
+`.is-locked` are untouched.
+
+## Changes by surface
+
+**Revert `e13cbd3`.** Applies cleanly onto HEAD (verified). Restores the
+filled/bordered squares in `public/css/styles.css`, the gray ramp
+(`--wizard-stat-class: #1a1a1a`, dropping `--wizard-stat-locked`), and removes
+the `<i class="fa-square-plus">` from both `public/js/character-wizard.js:853`
+and `views/character.handlebars:226,231`. Taken as a real `git revert` commit.
+
+**`character-stats-editor.handlebars`** — the number input becomes the partial
+with `x-model="stats.{{this}}"`. The `total` getter and the 0–20 save clamp in
+`characterStats` are unchanged. `edit()` in
+`public/js/alpine-components.js:96` focuses `.stats-input`, which will no
+longer exist; it becomes the first block carrying `tabindex="0"`. That focus
+behavior has e2e coverage and a load-bearing comment about `$el` scoping, so it
+must keep working, not merely stop erroring.
+
+**`character-level-up.handlebars`** — same swap.
+`public/js/character-level-up.js` queries `.level-up-stat` for the live total
+(:215) and the payload (:247) and reads `.value`; both keep working once the
+hidden input carries that class. The live-total wiring changes from a
+per-field `input` listener to one delegated `stat-change` listener on
+`#levelUpStatGrid`.
+
+**`character-form.handlebars`** — swap the 12 inputs for the partial. Native
+form POST is carried by the hidden inputs; no route change. `required` is
+dropped: a hidden input always has a value, and 0 is legitimate.
+
+**`class-form.handlebars`** — same, with `max=3` and
+`name="stat_spread[{{this}}]"`. The existing help text stays accurate.
+
+**`lfg-post.handlebars`** — the two `{{#range}}`-of-`+` blocks (:113 per-character
+details, :179 party stats) become read-only blocks: `min(value, 5)` filled,
+dimmed out to 5, no buttons and no ARIA group. Party stats keep their `({{n}})`
+numeral, since party totals routinely exceed 5.
+
+The read-only grid on `views/character.handlebars:221` is **not** converted. It
+already renders blocks via `.is-class` / `.is-locked`, and the revert restores
+its correct appearance; re-expressing it in the new `.is-set` / `.is-empty`
+classes would be churn with no visible change.
+
+**`character-wizard.js`** — two functions change:
+
+- `onStatBoxClick` (:905) — clicking slot `i` targets `i+1` rather than ±1.
+  The user portion is `target − cp − pp`, floored at 0 and capped by the
+  remaining budget, so clicking the 4th block with 2 points left assigns 2 and
+  stops. Clicking the topmost user-assigned slot decrements.
+- `renderStatGrid` (:818) — gains an `.is-preview` pass driven by delegated
+  `mouseover`/`mouseleave` on the grid.
+
+Class- and personality-assigned slots stay non-clickable, and `capUserStats`
+(:665) and `getMaxAssignable` (:645) are untouched — jump-to-N feeds through
+the same clamps, so no click can produce a state the existing logic would not.
+
+## Testing
+
+Per the repo's TDD practice, each behavior gets a failing test first.
+
+**New — `views/partials/stat-blocks.test.js`** (jsdom, matching the existing
+partial tests):
+
+- renders `max` blocks; 1..N carry `is-set`, the rest `is-empty`
+- click block N sets the value to N and updates the hidden input
+- click the active block N drops to N−1; block 1 at value 1 gives 0
+- hovering block N marks exactly blocks 1..N `is-preview` and the rest
+  `is-empty`, both when N is above and below the set value; `mouseleave`
+  restores the committed state
+- hovering the active block N previews N−1, matching what the click does
+- `←/→/↑/↓` adjust by 1 and clamp at 0 and max; `Home`/`End` jump
+- exactly one block has `tabindex="0"`; `aria-checked` tracks the value
+- a value above max renders max filled blocks plus the badge, and does not
+  clamp until a block is clicked
+- `set()` dispatches a bubbling `stat-change`
+
+**Updated:**
+
+- `views/partials/character-stats-editor.test.js` — the three `.stats-input`
+  fixtures and the assertions that query them move to blocks; adds a test that
+  `edit()` focuses the first block
+- `views/partials/character-level-up.test.js` — the live total recomputes on
+  `stat-change`; the payload build reads the hidden inputs
+- `views/character-form.test.js` — the form POSTs all 12 stat names with
+  block-set values
+- New `views/class-form.test.js` — `stat_spread[x]` names survive the swap,
+  `max=3`
+
+**New — `public/js/character-wizard.test.js`**, scoped to the two changed
+functions: jump-to-N respects the remaining budget, partial assignment when the
+budget is short, clicking the top user slot decrements, class and personality
+slots stay unclickable.
+
+**E2E:** `e2e/specs/04-stats-editor.spec.js` and
+`e2e/specs/05-level-up-modal.spec.js` drive number inputs today; their
+selectors and `fill()` calls become block clicks. What they assert about
+persistence is unchanged.
+
+**Manual check before calling it done:** the four surfaces plus the wizard in a
+real browser. Hover preview and focus rings are not things jsdom can confirm.
+
+## Risks
+
+- `character-wizard.js` has no existing unit tests and its stat step is the
+  most stateful code in the change. Mitigated by adding tests for the two
+  changed functions and by leaving the budget and cap logic alone.
+- The stats editor's focus behavior is asserted in e2e and carries a comment
+  explaining a past `$el`-scoping defect. Changing the focus target risks
+  silently reintroducing a null-target no-op; the updated test asserts focus
+  lands on the block, not merely that no error is thrown.

--- a/e2e/specs/04-stats-editor.spec.js
+++ b/e2e/specs/04-stats-editor.spec.js
@@ -35,14 +35,17 @@ test.afterAll(async () => {
 test.describe('as the owner', () => {
   test.use({ storageState: ADMIN_STATE });
 
-  // NOTE: `input[name="might"]` is scoped to `#statsEditor` everywhere below.
-  // The character show page also renders the (separate, hidden-by-default)
-  // level-up modal from views/partials/character-level-up.handlebars, whose
-  // stat grid uses the same bare `name="{{this}}"` convention (id
-  // `level-up-might`). An unscoped `input[name="might"]` locator matches both
-  // and Playwright's strict mode throws. This is a test-selector scoping fix,
-  // not a product defect -- the two inputs belong to unrelated features that
-  // both happen to live on the same page.
+  // NOTE: every stat locator below is scoped to `#statsEditor`. The character
+  // show page also renders the (separate, hidden-by-default) level-up modal
+  // from views/partials/character-level-up.handlebars, whose stat grid uses
+  // the same `data-stat` convention. An unscoped locator matches both and
+  // Playwright's strict mode throws. This is test-selector scoping, not a
+  // product defect -- the two controls belong to unrelated features that both
+  // happen to live on the same page.
+  const blocks = (page, stat) =>
+    page.locator(`#statsEditor .stat-blocks[data-stat="${stat}"] [role="radio"]`);
+  const posted = (page, stat) =>
+    page.locator(`#statsEditor input[name="${stat}"]`);
 
   test('the stats box renders with the editor hidden', async ({ page }) => {
     await page.goto(`/characters/${character.id}`);
@@ -52,50 +55,59 @@ test.describe('as the owner', () => {
     await expect(page.locator('#statsUnlockBtn')).toBeVisible();
   });
 
-  test('Edit reveals the editor and focuses the first input', async ({ page }) => {
+  test('Edit reveals the editor and focuses the first stat block', async ({ page }) => {
     await page.goto(`/characters/${character.id}`);
     await page.locator('#statsUnlockBtn').click();
 
     await expect(page.locator('#statsEditor')).toBeVisible();
     await expect(page.locator('#statsReadOnly')).toBeHidden();
 
-    // The old imperative code focused the first input on reveal; the Alpine
-    // edit() must still do it or keyboard users land nowhere. `vitality` is
-    // asserted by name, not just "some input is focused": edit() focuses
-    // this.root.querySelector('.stats-input'), the first .stats-input in DOM
-    // order, and util/enclave-consts.js's statList (the array both
-    // #statsReadOnly and #statsEditor iterate via {{#each statList}}, per
-    // routes/characters.js) literally starts with 'vitality'. A truthy-only
-    // assertion would still pass if focus landed on the wrong stat.
-    await expect(page.locator('#statsEditor input[name="vitality"]')).toBeFocused();
+    // `vitality` by name, not just "something is focused": edit() takes the
+    // first .stat-blocks in DOM order, and util/enclave-consts.js's statList
+    // (the array both #statsReadOnly and #statsEditor iterate) starts with
+    // 'vitality'. A truthy-only assertion would still pass with focus on the
+    // wrong stat.
+    await expect(
+      page.locator('#statsEditor .stat-blocks[data-stat="vitality"] [role="radio"][tabindex="0"]')
+    ).toBeFocused();
   });
 
-  test('the live total tracks edits', async ({ page }) => {
+  test('the live total tracks block clicks', async ({ page }) => {
     await page.goto(`/characters/${character.id}`);
     await page.locator('#statsUnlockBtn').click();
 
     const before = Number(await page.locator('#statsTotalSum').innerText());
-    await page.locator('#statsEditor input[name="might"]').fill('7');
+    await blocks(page, 'might').nth(4).click();   // 5th block -> 5
     await expect
       .poll(async () => Number(await page.locator('#statsTotalSum').innerText()))
-      .toBe(before - 1 + 7); // seeded value is 1
+      .toBe(before - 1 + 5);                      // seeded value is 1
+  });
+
+  test('clicking the block a stat is already on steps it down', async ({ page }) => {
+    await page.goto(`/characters/${character.id}`);
+    await page.locator('#statsUnlockBtn').click();
+
+    await blocks(page, 'might').nth(2).click();   // 3rd block -> 3
+    await expect(posted(page, 'might')).toHaveValue('3');
+    await blocks(page, 'might').nth(2).click();   // same block -> 2
+    await expect(posted(page, 'might')).toHaveValue('2');
   });
 
   test('Cancel restores the original values and hides the editor', async ({ page }) => {
     await page.goto(`/characters/${character.id}`);
     await page.locator('#statsUnlockBtn').click();
-    await page.locator('#statsEditor input[name="might"]').fill('9');
+    await blocks(page, 'might').nth(3).click();
     await page.locator('#statsCancelBtn').click();
 
     await expect(page.locator('#statsEditor')).toBeHidden();
     await page.locator('#statsUnlockBtn').click();
-    await expect(page.locator('#statsEditor input[name="might"]')).toHaveValue('1');
+    await expect(posted(page, 'might')).toHaveValue('1');
   });
 
   test('Save persists to the database', async ({ page }) => {
     await page.goto(`/characters/${character.id}`);
     await page.locator('#statsUnlockBtn').click();
-    await page.locator('#statsEditor input[name="might"]').fill('5');
+    await blocks(page, 'might').nth(4).click();   // 5th block -> 5
     await page.locator('#statsSaveBtn').click();
 
     await expect(page.locator('#statsEditor')).toBeHidden();

--- a/e2e/specs/05-level-up-modal.spec.js
+++ b/e2e/specs/05-level-up-modal.spec.js
@@ -103,8 +103,13 @@ test('completing a level-up persists the new level and the edited stat', async (
   // is derived server-side from mission rows
   // (services/character/service.js:491-514), not from the modal's stat
   // inputs.
-  const editedMight = before.might + 1;
-  await page.locator('#levelUpModal input[name="might"]').fill(String(editedMight));
+  // The blocks write through a hidden input, so there is nothing to fill;
+  // clicking the Nth block is how a stat reaches N. Capped at the 5-block
+  // row rather than blindly incrementing, so a seeded 5 doesn't ask for a
+  // sixth block that does not exist.
+  const editedMight = before.might >= 5 ? 4 : before.might + 1;
+  await page.locator('#levelUpModal .stat-blocks[data-stat="might"] [role="radio"]')
+    .nth(editedMight - 1).click();
   const missionInputs = page.locator('#levelUpMissingMissions .level-up-mission');
   await expect(missionInputs).toHaveCount(2);
   await missionInputs.nth(0).fill(`${prefix}-mission-1`);

--- a/e2e/specs/16-stat-block-touch-targets.spec.js
+++ b/e2e/specs/16-stat-block-touch-targets.spec.js
@@ -1,0 +1,117 @@
+// The coarse-pointer tap targets for the stat block control.
+//
+// This spec exists because the rule it guards is protected only by SOURCE
+// ORDER, which nothing else in the repo can check. `@media (pointer: coarse)`
+// adds no specificity and no priority: `@media (pointer: coarse) {
+// .stat-blocks { gap: 0.5rem } }` and a plain `.stat-blocks { gap: 0.3rem }`
+// are both (0,1,0), so whichever comes LAST in public/css/styles.css wins.
+// The media block therefore has to sit below every base rule it overrides.
+// It once did not, and the result was a declaration that read like a fix and
+// did nothing: 2rem blocks (that half worked, because `.wizard-stat-box`'s
+// base rule happened to be above the media block) separated by 0.3rem gaps
+// on a phone, replacing what used to be a full-width <input type="number">.
+//
+// The unit tier cannot catch this -- jsdom performs no layout and evaluates
+// no media queries -- and the rest of the e2e suite runs a single desktop
+// Chromium project with a fine pointer, so nothing else here ever matches
+// `pointer: coarse` at all.
+//
+// Chromium reports `pointer: coarse` when the PRIMARY pointer is touch, which
+// is what a mobile-emulated context (isMobile + hasTouch) produces. CDP's
+// Emulation.setEmulatedMedia does not support a `pointer` feature; setting it
+// leaves matchMedia('(pointer: coarse)') false, which is why the coarse case
+// below asserts matchesCoarse rather than trusting the emulation.
+//
+// Everything is measured in rem, not px: this app's root font size is 14px,
+// not 16px, so hard-coded pixel expectations would encode Bulma's typography
+// into a test about tap targets.
+const { test, expect } = require('@playwright/test');
+const { connect, newPrefix, profileForEmail, cleanupByPrefix } = require('../fixtures/db');
+const { seedClass } = require('../fixtures/class');
+const { seedCharacter } = require('../fixtures/character');
+const { ADMIN_EMAIL, ADMIN_STATE } = require('../global-setup');
+
+const prefix = newPrefix('touch');
+let db;
+let character;
+
+test.beforeAll(async () => {
+  db = await connect();
+  const profile = await profileForEmail(db, ADMIN_EMAIL);
+  const classRow = await seedClass(prefix);
+  character = await seedCharacter(prefix, profile, classRow, { is_public: 'on' });
+});
+
+test.afterAll(async () => {
+  await cleanupByPrefix(db, prefix);
+  await db.end();
+});
+
+// Measures the real shipped stylesheet against the real stats editor. The
+// wizard's own container is injected rather than driven, because its grid only
+// renders once three traits are picked and the question here is about the
+// stylesheet's cascade, not about the wizard's markup.
+const measure = (page) => page.evaluate(() => {
+  const rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
+  const wrap = document.createElement('div');
+  wrap.innerHTML = '<div class="wizard-stat-boxes" id="probe-wizard">'
+    + '<div class="wizard-stat-box"></div><div class="wizard-stat-box"></div></div>';
+  document.body.appendChild(wrap);
+  const statBlocks = document.querySelector('#statsEditor .stat-blocks');
+  const statBlock = statBlocks.querySelector('[role="radio"]');
+  const wizBoxes = document.getElementById('probe-wizard');
+  const wizBox = wizBoxes.querySelector('.wizard-stat-box');
+  const inRem = (px) => +(parseFloat(px) / rem).toFixed(3);
+  const out = {
+    matchesCoarse: window.matchMedia('(pointer: coarse)').matches,
+    statBlocksGap: inRem(getComputedStyle(statBlocks).columnGap),
+    statBlockWidth: inRem(getComputedStyle(statBlock).width),
+    statBlockHeight: inRem(getComputedStyle(statBlock).height),
+    wizardBoxesGap: inRem(getComputedStyle(wizBoxes).columnGap),
+    wizardBoxWidth: inRem(getComputedStyle(wizBox).width)
+  };
+  wrap.remove();
+  return out;
+});
+
+const openEditor = async (page) => {
+  await page.goto(`/characters/${character.id}`);
+  await page.locator('#statsUnlockBtn').click();
+  return measure(page);
+};
+
+test('a fine pointer keeps the dense desktop layout', async ({ browser, baseURL }) => {
+  const context = await browser.newContext({ storageState: ADMIN_STATE, baseURL });
+  const page = await context.newPage();
+  const fine = await openEditor(page);
+
+  expect(fine.matchesCoarse).toBe(false);
+  expect(fine.statBlocksGap).toBe(0.3);
+  expect(fine.statBlockWidth).toBe(1.4);
+  expect(fine.wizardBoxesGap).toBe(0.3);
+  expect(fine.wizardBoxWidth).toBe(1.4);
+  await context.close();
+});
+
+test('a coarse pointer enlarges both the blocks and the gaps between them', async ({ browser, baseURL }) => {
+  const context = await browser.newContext({
+    storageState: ADMIN_STATE, baseURL,
+    viewport: { width: 393, height: 851 }, isMobile: true, hasTouch: true,
+    deviceScaleFactor: 2
+  });
+  const page = await context.newPage();
+  const coarse = await openEditor(page);
+
+  expect(coarse.matchesCoarse).toBe(true);
+  // The size and the GAP are asserted separately on purpose. They come from
+  // two different declarations in the same media block, and the failure this
+  // spec was written for had the size applying while the gap did not -- so an
+  // assertion on size alone would have passed straight through the defect.
+  expect(coarse.statBlockWidth).toBe(2);
+  expect(coarse.statBlockHeight).toBe(2);
+  expect(coarse.statBlocksGap).toBe(0.5);
+  // The wizard's own grid keeps the coarse-pointer sizing it already had.
+  expect(coarse.wizardBoxWidth).toBe(2);
+  expect(coarse.wizardBoxesGap).toBe(0.5);
+  await context.close();
+});

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1245,26 +1245,6 @@ a.dropdown-item:hover {
   cursor: default;
   transition: transform 80ms ease, background 80ms ease, border-color 80ms ease;
 }
-/* Touch devices: the 1.4rem pips are far too small to tap reliably. Adjacent
-   pips can't each be a full 44px without overlapping their neighbours, so we
-   enlarge the box and the gap to give a much bigger hit area on coarse
-   pointers while leaving the dense desktop layout untouched. */
-@media (pointer: coarse) {
-  .wizard-stat-box {
-    width: 2rem;
-    height: 2rem;
-  }
-  /* Both containers, not just the wizard's. .stat-blocks is the interactive
-     control that replaced the stat number inputs on the stats editor, the
-     level-up modal, the character form, and the class form; matching only
-     .wizard-stat-boxes here left those four with 0.3rem gaps between 2rem
-     targets -- a smaller tap area than the full-width <input type="number">
-     they replaced. */
-  .wizard-stat-boxes,
-  .stat-blocks {
-    gap: 0.5rem;
-  }
-}
 .wizard-stat-box.is-class {
   background: var(--wizard-stat-class);
   border-color: var(--wizard-stat-class);
@@ -1356,6 +1336,36 @@ a.dropdown-item:hover {
   margin-left: 0.15rem;
 }
 .stat-blocks.is-readonly .wizard-stat-box { cursor: default; }
+/* Touch devices: the 1.4rem pips are far too small to tap reliably. Adjacent
+   pips can't each be a full 44px without overlapping their neighbours, so we
+   enlarge the box and the gap to give a much bigger hit area on coarse
+   pointers while leaving the dense desktop layout untouched.
+ *
+ * SOURCE ORDER, do not move this block up: it MUST stay below all three of
+ * the rules it overrides -- `.wizard-stat-boxes` (gap), `.wizard-stat-box`
+ * (width/height), and `.stat-blocks` (gap). A media query adds NO
+ * specificity and NO priority; `@media (pointer: coarse) { .stat-blocks }`
+ * and a plain `.stat-blocks` are both (0,1,0), so the later one in the file
+ * simply wins. This block used to sit between `.wizard-stat-box` and
+ * `.stat-blocks`, which made the .wizard-* half work and the .stat-blocks
+ * gap silently dead -- 2rem blocks with 0.3rem between them, the exact
+ * touch-target defect this block exists to prevent, hidden behind a rule
+ * that looked like the fix. Keeping every base rule above this one is what
+ * makes it apply. Same equal-specificity-plus-source-order mechanism the
+ * `.is-preview` rules above depend on. */
+@media (pointer: coarse) {
+  .wizard-stat-box {
+    width: 2rem;
+    height: 2rem;
+  }
+  /* Both containers, not just the wizard's. .stat-blocks is the interactive
+     control that replaced the stat number inputs on the stats editor, the
+     level-up modal, the character form, and the class form. */
+  .wizard-stat-boxes,
+  .stat-blocks {
+    gap: 0.5rem;
+  }
+}
 /* Coming-soon / disabled mode buttons in the character-new selector. */
 .is-disabled-mode {
   opacity: 0.55;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -12,6 +12,7 @@
   --wizard-stat-user-edge: #404040;
   --wizard-stat-empty: #f0f0f0;
   --wizard-stat-empty-hover: #e0e0e0;
+  --wizard-stat-preview: #a8a8a8;
 
   /* Elevation scale — shared drop-shadow tokens. Prefer these over ad-hoc
      box-shadow recipes so raised surfaces stay visually consistent.
@@ -1283,6 +1284,53 @@ a.dropdown-item:hover {
   cursor: not-allowed;
   opacity: 0.5;
 }
+/* Interactive stat block control (views/partials/stat-blocks.handlebars).
+   Shares .wizard-stat-box with the wizard's grid so the two read as one
+   control. States:
+     .is-set      a committed point
+     .is-empty    an unfilled slot
+     .is-preview  what a click on the hovered block would produce -- used in
+                  BOTH directions, so hovering below the current value shows
+                  the drop rather than pretending nothing would change */
+.stat-blocks {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+.wizard-stat-box.is-set {
+  background: var(--wizard-stat-user);
+  border-color: var(--wizard-stat-user-edge);
+  cursor: pointer;
+}
+.wizard-stat-box.is-empty {
+  background: var(--wizard-stat-empty);
+  border-color: var(--wizard-stat-user);
+  cursor: pointer;
+}
+.wizard-stat-box.is-empty:hover {
+  background: var(--wizard-stat-empty-hover);
+}
+.wizard-stat-box.is-preview {
+  background: var(--wizard-stat-preview);
+  border-color: var(--wizard-stat-user-edge);
+  cursor: pointer;
+}
+/* Roving tabindex means only one block per stat is in the tab order; that
+   block must show where focus is or keyboard users are navigating blind. */
+.stat-blocks [role="radio"]:focus-visible {
+  outline: 2px solid var(--bulma-link, #2e63b8);
+  outline-offset: 2px;
+}
+/* The numeral shown beside a full row when a stat exceeds its block count. */
+.stat-blocks-over {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--bulma-text, #4a4a4a);
+  margin-left: 0.15rem;
+}
+.stat-blocks.is-readonly .wizard-stat-box { cursor: default; }
 /* Coming-soon / disabled mode buttons in the character-new selector. */
 .is-disabled-mode {
   opacity: 0.55;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1317,6 +1317,11 @@ a.dropdown-item:hover {
   border-color: var(--wizard-stat-user-edge);
   cursor: pointer;
 }
+/* A point the hovered click would give BACK. Dimming it (rather than
+   emptying it) keeps the row's shape stable while the pointer moves. */
+.wizard-stat-box.is-preview-off {
+  opacity: 0.4;
+}
 /* Roving tabindex means only one block per stat is in the tab order; that
    block must show where focus is or keyboard users are navigating blind. */
 .stat-blocks [role="radio"]:focus-visible {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -6,13 +6,12 @@
 :root {
   color-scheme: light;
 
-  /* Character wizard stat icon gray ramp (see .wizard-stat-box states). */
-  --wizard-stat-class: #6b6b6b;
+  /* Character wizard stat-box gray ramp (see .wizard-stat-box states). */
+  --wizard-stat-class: #1a1a1a;
   --wizard-stat-user: #595959;
   --wizard-stat-user-edge: #404040;
   --wizard-stat-empty: #f0f0f0;
   --wizard-stat-empty-hover: #e0e0e0;
-  --wizard-stat-locked: #d2d2d2;
 
   /* Elevation scale — shared drop-shadow tokens. Prefer these over ad-hoc
      box-shadow recipes so raised surfaces stay visually consistent.
@@ -1195,13 +1194,12 @@ a.dropdown-item:hover {
    - .wizard-stat-grid is a 4×3 grid (12 stats). Each cell is one stat.
    - .wizard-stat-row stacks the stat's name, boxes, and labels vertically
      so the cell reads top-to-bottom inside the grid.
-   - .wizard-stat-box represents a single point slot. The square-plus icon
-     carries the point state. The four visual
+   - .wizard-stat-box represents a single point slot. The four visual
      states match the spec:
-       .is-class       medium gray icon (class/personality assigned, not clickable)
-       .is-user        dark gray icon (user assigned, click to remove)
-       .is-assignable  outlined gray icon (click to add)
-       .is-locked      outlined muted icon (above the per-stat max, not clickable) */
+       .is-class       filled black (class/personality assigned, not clickable)
+       .is-user        dark gray    (user assigned, click to remove)
+       .is-assignable  light gray w/ dark border (click to add)
+       .is-locked      dashed border (above the per-stat max, not clickable) */
 .wizard-stat-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -1240,16 +1238,11 @@ a.dropdown-item:hover {
 .wizard-stat-box {
   width: 1.4rem;
   height: 1.4rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--wizard-stat-empty);
+  border: 2.5px solid var(--bulma-border, #1a1a1a);
+  border-radius: 3px;
+  background: var(--wizard-stat-empty);
   cursor: default;
-  line-height: 1;
-  transition: transform 80ms ease, color 80ms ease;
-}
-.wizard-stat-box .fa-square-plus {
-  font-size: 1.35rem;
+  transition: transform 80ms ease, background 80ms ease, border-color 80ms ease;
 }
 /* Touch devices: the 1.4rem pips are far too small to tap reliably. Adjacent
    pips can't each be a full 44px without overlapping their neighbours, so we
@@ -1265,26 +1258,30 @@ a.dropdown-item:hover {
   }
 }
 .wizard-stat-box.is-class {
-  color: var(--wizard-stat-class);
+  background: var(--wizard-stat-class);
+  border-color: var(--wizard-stat-class);
   cursor: default;
 }
 .wizard-stat-box.is-user {
-  color: var(--wizard-stat-user);
+  background: var(--wizard-stat-user);
+  border-color: var(--wizard-stat-user-edge);
   cursor: pointer;
 }
-.wizard-stat-box.is-user:hover { color: var(--wizard-stat-user-edge); }
+.wizard-stat-box.is-user:hover { background: var(--wizard-stat-user-edge); }
 .wizard-stat-box.is-assignable {
-  color: var(--wizard-stat-user);
+  background: var(--wizard-stat-empty);
+  border-color: var(--wizard-stat-user);
   cursor: pointer;
 }
 .wizard-stat-box.is-assignable:hover {
-  color: var(--wizard-stat-user-edge);
+  background: var(--wizard-stat-empty-hover);
   transform: translateY(-1px);
 }
 .wizard-stat-box.is-locked {
-  color: var(--wizard-stat-locked);
+  background: transparent;
+  border: 2.5px dashed var(--bulma-border, #1a1a1a);
   cursor: not-allowed;
-  opacity: 0.8;
+  opacity: 0.5;
 }
 /* Coming-soon / disabled mode buttons in the character-new selector. */
 .is-disabled-mode {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1254,7 +1254,14 @@ a.dropdown-item:hover {
     width: 2rem;
     height: 2rem;
   }
-  .wizard-stat-boxes {
+  /* Both containers, not just the wizard's. .stat-blocks is the interactive
+     control that replaced the stat number inputs on the stats editor, the
+     level-up modal, the character form, and the class form; matching only
+     .wizard-stat-boxes here left those four with 0.3rem gaps between 2rem
+     targets -- a smaller tap area than the full-width <input type="number">
+     they replaced. */
+  .wizard-stat-boxes,
+  .stat-blocks {
     gap: 0.5rem;
   }
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1312,7 +1312,20 @@ a.dropdown-item:hover {
 .wizard-stat-box.is-empty:hover {
   background: var(--wizard-stat-empty-hover);
 }
-.wizard-stat-box.is-preview {
+/* SPECIFICITY, do not reorder: the wizard's grid keeps .is-assignable /
+   .is-user on a box and LAYERS .is-preview on top, so the block under the
+   pointer matches a :hover rule and this one at the same time. The three
+   :hover rules above are (0,3,0); a bare `.wizard-stat-box.is-preview` is
+   (0,2,0) and loses, which paints the hovered block as empty and previews
+   N-1 filled instead of N -- an off-by-one in the exact gesture the preview
+   exists for. Matching :hover here makes that case (0,3,0) too, and this
+   block sits BELOW the :hover rules so the tie resolves in its favour. Same
+   equal-specificity-plus-source-order mechanism .is-preview already uses to
+   beat `.wizard-stat-box.is-assignable` (0,2,0) at :1272 for the blocks that
+   are NOT under the pointer. Moving this above the :hover rules, or dropping
+   the :hover selector, reintroduces the bug. */
+.wizard-stat-box.is-preview,
+.wizard-stat-box.is-preview:hover {
   background: var(--wizard-stat-preview);
   border-color: var(--wizard-stat-user-edge);
   cursor: pointer;

--- a/public/js/alpine-components.js
+++ b/public/js/alpine-components.js
@@ -102,9 +102,9 @@ document.addEventListener('alpine:init', () => {
       // Capture the x-data root here, not inside edit(). $el is bound to
       // whichever element invoked the current method — inside edit() that
       // is the Edit <button> itself (called via @click="edit()"), which has
-      // no .stats-input descendants, so querySelector off $el there always
+      // no .stat-blocks descendants, so querySelector off $el there always
       // returns null and focus silently never moves. init() runs with $el
-      // bound to the x-data root, which does contain the inputs.
+      // bound to the x-data root, which does contain the blocks.
       this.root = this.$el;
     },
 
@@ -117,7 +117,14 @@ document.addEventListener('alpine:init', () => {
       this.error = '';
       this.editing = true;
       this.$nextTick(() => {
-        const first = this.root.querySelector('.stats-input');
+        // The blocks use a roving tabindex, so the one tabbable block per
+        // stat is the right landing spot; the fallback covers the tick
+        // before Alpine has evaluated :tabindex on a freshly-revealed
+        // editor. Still scoped to this.root, not $el, for the reason in
+        // init() above: $el inside edit() is the Edit button, which
+        // contains no blocks at all.
+        const first = this.root.querySelector('.stat-blocks [role="radio"][tabindex="0"]')
+          || this.root.querySelector('.stat-blocks [role="radio"]');
         if (first) first.focus();
       });
     },

--- a/public/js/alpine-components.js
+++ b/public/js/alpine-components.js
@@ -53,7 +53,33 @@ const resolveStatTarget = ({ slot, current, floor = 0, ceiling }) => {
   return Math.max(floor, Math.min(target, ceiling));
 };
 
-window.StatBlocks = { resolveStatTarget };
+// The wizard's half of the same rule. Its grid is imperative and its boxes
+// carry a 0-BASED `data-slot`, and its floor and ceiling are functions of
+// class points, personality points, the per-stat cap, and what is left of
+// the point budget. Building those four arguments is exactly where an
+// off-by-one can hide -- `slot + 1` in particular -- so the construction
+// lives here, next to the rule and inside the tested unit, rather than in
+// public/js/character-wizard.js, which has no unit tests and cannot be
+// mounted under jsdom. character-wizard.js gathers the state; this decides
+// what a click means.
+//
+// Takes the raw 0-based data-slot; returns the stat's new TOTAL (class +
+// personality + user points), which is what the caller subtracts its class
+// and personality points from to get the user portion.
+const resolveWizardTarget = ({ slot, cp = 0, pp = 0, up = 0, remaining = 0, cap }) =>
+  resolveStatTarget({
+    // data-slot is 0-based; resolveStatTarget speaks 1-based positions.
+    slot: slot + 1,
+    current: cp + pp + up,
+    // Class- and personality-assigned points are the floor: no click can
+    // take the stat below them.
+    floor: cp + pp,
+    // Whichever binds first -- the per-stat cap for this level, or what the
+    // remaining budget can actually pay for.
+    ceiling: Math.min(cap, cp + pp + up + remaining)
+  });
+
+window.StatBlocks = { resolveStatTarget, resolveWizardTarget };
 
 document.addEventListener('alpine:init', () => {
   // Title -> slug sync for the page editor. Stops as soon as the slug is
@@ -207,10 +233,21 @@ document.addEventListener('alpine:init', () => {
       });
     },
 
+    // Returns an OBJECT, not a class string, because the partial's blocks
+    // are server-rendered and already carry `is-set`/`is-empty` in the
+    // markup Alpine finds. Alpine's string form only tracks the classes it
+    // added itself and can remove only those, so a served `is-set` could
+    // never be taken off again -- a block restored from an hx-boost history
+    // snapshot would be stuck filled. The object form adds and removes by
+    // truthiness regardless of who put the class there.
     boxClass(i) {
       const shown = this.previewValue;
-      if (shown !== null) return i <= shown ? 'is-preview' : 'is-empty';
-      return i <= this.value ? 'is-set' : 'is-empty';
+      const previewing = shown !== null;
+      return {
+        'is-preview': previewing && i <= shown,
+        'is-set': !previewing && i <= this.value,
+        'is-empty': previewing ? i > shown : i > this.value
+      };
     },
 
     tabIndex(i) {

--- a/public/js/alpine-components.js
+++ b/public/js/alpine-components.js
@@ -233,7 +233,15 @@ document.addEventListener('alpine:init', () => {
       this.value = clamped;
       // Surfaces without Alpine state (the level-up modal) read the hidden
       // input, which fires no native `input` event when set programmatically.
-      this.$dispatch('stat-change', { stat: this.stat, value: this.value });
+      // Deferred to $nextTick: Alpine's own :value effect on that hidden
+      // input hasn't flushed to the DOM yet at the point `value` is
+      // assigned, so a listener that (like the level-up modal's) re-reads
+      // every hidden input synchronously would sum the stale value for
+      // whichever stat just changed -- one interaction behind -- if the
+      // event went out before the DOM write it's reporting.
+      this.$nextTick(() => {
+        this.$dispatch('stat-change', { stat: this.stat, value: this.value });
+      });
     },
 
     focusBlock(n) {

--- a/public/js/alpine-components.js
+++ b/public/js/alpine-components.js
@@ -31,6 +31,30 @@ const slugify = (value) => (value || '')
   .replace(/-+/g, '-')
   .replace(/^-+|-+$/g, '');
 
+// The one rule every stat block control obeys: clicking the block at
+// 1-based position `slot` sets the stat to `slot`, EXCEPT that clicking the
+// block you are already on steps DOWN by one -- that is how a stat reaches
+// zero, and it matches what the wizard's grid already did when you clicked
+// a point you had assigned.
+//
+// `floor` is the number of points the click may not take the stat below
+// (class + personality points in the wizard; 0 everywhere else). `ceiling`
+// is the highest total the click may produce (the per-stat cap, or the
+// remaining point budget, whichever binds first).
+//
+// Exported on `window` rather than closed over because
+// public/js/character-wizard.js renders its own imperative grid and has to
+// apply the identical rule. Two copies of this arithmetic is exactly how
+// the wizard and the editor would drift apart. alpine-components.js is a
+// deferred <head> script and character-wizard.js a deferred body script, so
+// deferred-script document order guarantees this is defined first.
+const resolveStatTarget = ({ slot, current, floor = 0, ceiling }) => {
+  const target = slot === current ? slot - 1 : slot;
+  return Math.max(floor, Math.min(target, ceiling));
+};
+
+window.StatBlocks = { resolveStatTarget };
+
 document.addEventListener('alpine:init', () => {
   // Title -> slug sync for the page editor. Stops as soon as the slug is
   // edited by hand. On load, a slug that still matches its title is
@@ -137,6 +161,101 @@ document.addEventListener('alpine:init', () => {
       }).finally(() => {
         this.saving = false;
       });
+    }
+  }));
+
+  // Star-rating stat selector. Backs every stat-editing surface: the inline
+  // stats editor, the level-up modal, the character form, and the class
+  // form. Replaces the number inputs all four used to render.
+  //
+  // `value` is the committed points, `preview` the block the pointer is
+  // currently over (or null). `previewValue` deliberately runs the hovered
+  // block through the same resolveStatTarget the click uses, so the preview
+  // shows what will HAPPEN, not merely what is under the cursor -- hovering
+  // the block you are already on previews one lower, because that is what
+  // clicking it does.
+  //
+  // Keyboard commits immediately rather than previewing: arrowing IS the
+  // preview, and a focus-driven preview would fight the click preview for
+  // the same `preview` slot every time focusBlock() moved focus after a
+  // click.
+  Alpine.data('statBlocks', (initial, max, stat) => ({
+    value: parseInt(initial, 10) || 0,
+    preview: null,
+    max: max,
+    stat: stat,
+
+    // A stat already above `max` (the editor historically allowed 0-20) can
+    // step DOWN through the blocks but must never be raised by them, so the
+    // ceiling floats up to the current value and ratchets back down as the
+    // value falls.
+    get ceiling() {
+      return Math.max(this.max, this.value);
+    },
+
+    get previewValue() {
+      if (this.preview === null) return null;
+      return resolveStatTarget({
+        slot: this.preview, current: this.value, floor: 0, ceiling: this.ceiling
+      });
+    },
+
+    boxClass(i) {
+      const shown = this.previewValue;
+      if (shown !== null) return i <= shown ? 'is-preview' : 'is-empty';
+      return i <= this.value ? 'is-set' : 'is-empty';
+    },
+
+    tabIndex(i) {
+      // Roving tabindex: the grid costs one tab stop per stat, exactly what
+      // the 12 number inputs it replaces cost.
+      return i === Math.max(1, Math.min(this.value, this.max)) ? 0 : -1;
+    },
+
+    set(i) {
+      this.commit(resolveStatTarget({
+        slot: i, current: this.value, floor: 0, ceiling: this.ceiling
+      }));
+      this.focusBlock(this.value);
+    },
+
+    commit(next) {
+      const clamped = Math.max(0, Math.min(next, this.ceiling));
+      this.preview = null;
+      if (clamped === this.value) return;
+      this.value = clamped;
+      // Surfaces without Alpine state (the level-up modal) read the hidden
+      // input, which fires no native `input` event when set programmatically.
+      this.$dispatch('stat-change', { stat: this.stat, value: this.value });
+    },
+
+    focusBlock(n) {
+      const idx = Math.max(1, Math.min(n, this.max));
+      this.$nextTick(() => {
+        const el = this.$root.querySelectorAll('[role="radio"]')[idx - 1];
+        if (el) el.focus();
+      });
+    },
+
+    key(e) {
+      if (e.key === ' ' || e.key === 'Enter') {
+        const all = Array.prototype.slice.call(this.$root.querySelectorAll('[role="radio"]'));
+        const idx = all.indexOf(e.target);
+        if (idx === -1) return;
+        e.preventDefault();
+        this.set(idx + 1);
+        return;
+      }
+      let next;
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = this.value - 1;
+      else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = this.value + 1;
+      else if (e.key === 'Home') next = 0;
+      else if (e.key === 'End') next = this.max;
+      else return;
+      // Otherwise arrows scroll the page out from under the control.
+      e.preventDefault();
+      this.commit(next);
+      this.focusBlock(this.value);
     }
   }));
 

--- a/public/js/character-level-up.js
+++ b/public/js/character-level-up.js
@@ -211,10 +211,13 @@ window.CharacterLevelUp = (function () {
       renderInitialMissingMissions(missing);
     }
 
-    // Wire stat input live total.
-    document.querySelectorAll('.level-up-stat').forEach((el) => {
-      el.addEventListener('input', updateStatTotal);
-    });
+    // Wire the live stat total. One delegated listener on the grid, not one
+    // per field: the blocks write through a hidden input, and a hidden
+    // input set programmatically fires no native `input` event, so the old
+    // per-field 'input' listener would never fire again and #levelUpTotal
+    // would sit frozen at its seeded value.
+    const statGrid = document.getElementById('levelUpStatGrid');
+    if (statGrid) statGrid.addEventListener('stat-change', updateStatTotal);
     updateStatTotal();
 
     // Wire "Add perk" buttons.

--- a/public/js/character-wizard.js
+++ b/public/js/character-wizard.js
@@ -902,7 +902,33 @@ window.CharacterWizard = (function () {
     }
   };
 
-  // Click handler for stat boxes: add or remove a user-assigned point.
+  // Resolve what a click or hover on `slot` (0-based DOM index) should make
+  // this stat's TOTAL. Shared by the click handler and the hover preview so
+  // the preview cannot promise something the click won't deliver.
+  const resolveWizardTotal = (stat, slot) => {
+    const classPts = getClassPoints();
+    const persPts = getPersonalityPoints();
+    const cp = classPts[stat] || 0;
+    const pp = persPts[stat] || 0;
+    const up = state.userStats[stat] || 0;
+    const remaining = Math.max(0, getTotalPoints()
+      - sumPoints(classPts) - sumPoints(persPts) - getUserPointsTotal());
+    return window.StatBlocks.resolveStatTarget({
+      slot: slot + 1,
+      current: cp + pp + up,
+      // Class- and personality-assigned points are the floor: no click can
+      // take the stat below them.
+      floor: cp + pp,
+      // Whichever binds first -- the per-stat cap for this level, or what
+      // the remaining budget can actually pay for.
+      ceiling: Math.min(getMaxAssignable(), cp + pp + up + remaining)
+    });
+  };
+
+  // Click handler for stat boxes. Star-rating semantics, matching the
+  // statBlocks component every other surface uses: clicking the Nth block
+  // sets the stat to N, except that clicking the block you are already on
+  // steps down by one.
   const onStatBoxClick = (e) => {
     const box = e.target.closest('.wizard-stat-box');
     if (!box || !box.hasAttribute('data-clickable')) return;
@@ -912,24 +938,47 @@ window.CharacterWizard = (function () {
     const persPts = getPersonalityPoints();
     const cp = classPts[stat] || 0;
     const pp = persPts[stat] || 0;
-    const up = state.userStats[stat] || 0;
-    const total = cp + pp + up;
-    const remaining = Math.max(0, getTotalPoints() - sumPoints(classPts) - sumPoints(persPts) - getUserPointsTotal());
 
-    if (slot >= cp + pp && slot < total) {
-      // User-assigned box: remove a point.
-      state.userStats[stat] = up - 1;
-      if (state.userStats[stat] <= 0) delete state.userStats[stat];
-    } else if (slot >= total && remaining > 0) {
-      // Assignable box: add a point (if budget remains).
-      state.userStats[stat] = up + 1;
-    } else {
-      return;
-    }
+    const userTarget = Math.max(0, resolveWizardTotal(stat, slot) - cp - pp);
+    if (userTarget === (state.userStats[stat] || 0)) return;
+
+    if (userTarget <= 0) delete state.userStats[stat];
+    else state.userStats[stat] = userTarget;
 
     renderStatGrid();
     updateStatsDisplay();
     renderSummary();
+  };
+
+  // Hover preview. Shows the total a click would produce -- in both
+  // directions, so hovering below the current value previews the drop
+  // rather than pretending nothing would change.
+  const clearStatPreview = () => {
+    if (!statGrid) return;
+    Array.prototype.forEach.call(
+      statGrid.querySelectorAll('.is-preview, .is-preview-off'),
+      (el) => el.classList.remove('is-preview', 'is-preview-off')
+    );
+  };
+
+  const onStatBoxHover = (e) => {
+    const box = e.target.closest && e.target.closest('.wizard-stat-box');
+    clearStatPreview();
+    if (!box || !box.hasAttribute('data-clickable')) return;
+    const stat = box.getAttribute('data-stat');
+    const slot = parseInt(box.getAttribute('data-slot'), 10);
+    const row = box.closest('.wizard-stat-row');
+    if (!row) return;
+    const classPts = getClassPoints();
+    const persPts = getPersonalityPoints();
+    const floor = (classPts[stat] || 0) + (persPts[stat] || 0);
+    const total = resolveWizardTotal(stat, slot);
+
+    Array.prototype.forEach.call(row.querySelectorAll('.wizard-stat-box'), (b, i) => {
+      if (i < floor) return;                          // class/personality: never previewed
+      if (i < total) b.classList.add('is-preview');    // would be filled
+      else if (b.classList.contains('is-user')) b.classList.add('is-preview-off'); // would be given back
+    });
   };
 
   const onTraitChange = (idx) => {
@@ -991,7 +1040,15 @@ window.CharacterWizard = (function () {
   if (trait2Select) trait2Select.addEventListener('change', onTraitChange(1));
   if (trait3Select) trait3Select.addEventListener('change', onTraitChange(2));
   if (levelInput) levelInput.addEventListener('input', onLevelChange);
-  if (statGrid) statGrid.addEventListener('click', onStatBoxClick);
+  if (statGrid) {
+    statGrid.addEventListener('click', onStatBoxClick);
+    // mouseover, not mouseenter: this is delegated to the grid and has to
+    // fire as the pointer crosses between individual boxes, which mouseenter
+    // on the container does not do. mouseleave on the container is still the
+    // right clear signal -- it fires once, when the pointer leaves the grid.
+    statGrid.addEventListener('mouseover', onStatBoxHover);
+    statGrid.addEventListener('mouseleave', clearStatPreview);
+  }
   // "Of which successful" input in the summary aside. Capped at the total
   // mission count for the current level (handled in renderSummaryMeta).
   if (summarySuccessfulInput) {

--- a/public/js/character-wizard.js
+++ b/public/js/character-wizard.js
@@ -905,23 +905,25 @@ window.CharacterWizard = (function () {
   // Resolve what a click or hover on `slot` (0-based DOM index) should make
   // this stat's TOTAL. Shared by the click handler and the hover preview so
   // the preview cannot promise something the click won't deliver.
+  //
+  // This function only GATHERS state. The arithmetic -- the 0-based to
+  // 1-based slot conversion, the class+personality floor, and the
+  // cap-vs-budget ceiling -- lives in StatBlocks.resolveWizardTarget, which
+  // has unit tests; this module has none and cannot be mounted under jsdom.
+  // Rebuilding those arguments here would put the one place an off-by-one
+  // can live back on the untested side of the line.
   const resolveWizardTotal = (stat, slot) => {
     const classPts = getClassPoints();
     const persPts = getPersonalityPoints();
-    const cp = classPts[stat] || 0;
-    const pp = persPts[stat] || 0;
-    const up = state.userStats[stat] || 0;
     const remaining = Math.max(0, getTotalPoints()
       - sumPoints(classPts) - sumPoints(persPts) - getUserPointsTotal());
-    return window.StatBlocks.resolveStatTarget({
-      slot: slot + 1,
-      current: cp + pp + up,
-      // Class- and personality-assigned points are the floor: no click can
-      // take the stat below them.
-      floor: cp + pp,
-      // Whichever binds first -- the per-stat cap for this level, or what
-      // the remaining budget can actually pay for.
-      ceiling: Math.min(getMaxAssignable(), cp + pp + up + remaining)
+    return window.StatBlocks.resolveWizardTarget({
+      slot: slot,
+      cp: classPts[stat] || 0,
+      pp: persPts[stat] || 0,
+      up: state.userStats[stat] || 0,
+      remaining: remaining,
+      cap: getMaxAssignable()
     });
   };
 

--- a/public/js/character-wizard.js
+++ b/public/js/character-wizard.js
@@ -850,7 +850,7 @@ window.CharacterWizard = (function () {
           title = 'Above the per-stat maximum at this level';
         }
         const clickAttr = clickable ? ' data-clickable="1"' : '';
-        boxes += '<div class="wizard-stat-box ' + cls + '" data-stat="' + stat + '" data-slot="' + i + '" title="' + title + '"' + clickAttr + '><i class="fa-regular fa-square-plus" aria-hidden="true"></i></div>';
+        boxes += '<div class="wizard-stat-box ' + cls + '" data-stat="' + stat + '" data-slot="' + i + '" title="' + title + '"' + clickAttr + '></div>';
       }
       let labels = '';
       if (cp || pp || up) {

--- a/views/character-form.handlebars
+++ b/views/character-form.handlebars
@@ -193,8 +193,7 @@
         <div class="field">
           <label class="label">{{capitalize this}}</label>
           <div class="control">
-            <input class="input" type="number" name="{{this}}"
-              value="{{#if (lookup ../character this)}}{{lookup ../character this}}{{else}}0{{/if}}" required>
+            {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5}}
           </div>
         </div>
       </div>

--- a/views/character-form.handlebars
+++ b/views/character-form.handlebars
@@ -191,7 +191,11 @@
       {{#each statList}}
       <div class="column is-one-third">
         <div class="field">
-          <label class="label">{{capitalize this}}</label>
+          {{!-- A <div>, not a <label>: the stat is now a radiogroup of
+                blocks, not a single labellable control, so a <label> here
+                would have no `for` target and clicking it would move focus
+                nowhere. The group carries its own aria-label. --}}
+          <div class="label">{{capitalize this}}</div>
           <div class="control">
             {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5}}
           </div>

--- a/views/character-form.test.js
+++ b/views/character-form.test.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('bun:test');
+const { test, expect, beforeAll } = require('bun:test');
 const fs = require('fs');
 const path = require('path');
 
@@ -35,6 +35,12 @@ test('deceased-modal carries all four modal bindings on the real template', () =
 });
 
 const { setupAlpine, render, tick } = require('../test/helpers/alpine-dom');
+
+beforeAll(async () => {
+  await setupAlpine();
+  require('../public/js/alpine-components.js');
+  document.dispatchEvent(new window.CustomEvent('alpine:init'));
+});
 
 const CONFIRM = `
   <div x-data="{ typed: '', required: 'Vex Kalloway' }">
@@ -109,4 +115,59 @@ test('deceased submit button has no bare disabled attribute', () => {
   const buttonTag = buttonMatch[0];
   // Match ' disabled' not followed by '-' or '=' (avoids matching ':disabled=')
   expect(buttonTag).not.toMatch(/\sdisabled(?![-=])/);
+});
+
+// --- stat blocks ----------------------------------------------------------
+//
+// This form is a plain native POST -- no fetch, no Alpine state carrying the
+// values -- so the hidden input inside each control is the ONLY thing that
+// makes a stat reach the server. A test that only checked the blocks render
+// would pass on a form that silently posts no stats at all.
+
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../util/handlebars');
+const { statList } = require('../util/enclave-consts');
+
+const FORM_SRC = fs.readFileSync(path.join(__dirname, 'character-form.handlebars'), 'utf8');
+
+test('character-form renders stat blocks instead of number inputs', () => {
+  expect(FORM_SRC).toContain('{{> stat-blocks stat=this name=this');
+  // The old field had `type="number" name="{{this}}" ... required`.
+  expect(FORM_SRC).not.toMatch(/type="number"\s+name="\{\{this\}\}"/);
+});
+
+test('the stat fields are no longer `required`', () => {
+  // A hidden input always has a value and 0 is a legitimate stat, so a
+  // `required` here could only ever be a false gate.
+  const statsSection = FORM_SRC.slice(
+    FORM_SRC.indexOf('<label class="label">Stats</label>'),
+    FORM_SRC.indexOf('Signature Gear')
+  );
+  expect(statsSection).not.toContain('required');
+});
+
+test('every stat POSTs its own name from a hidden input', async () => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  hb.registerPartial('stat-blocks', fs.readFileSync(
+    path.join(__dirname, 'partials', 'stat-blocks.handlebars'), 'utf8'
+  ));
+
+  const statsSection = FORM_SRC.slice(
+    FORM_SRC.indexOf('<label class="label">Stats</label>'),
+    FORM_SRC.indexOf('Signature Gear')
+  );
+  const character = Object.fromEntries(statList.map((s, i) => [s, i % 6]));
+  await render(hb.compile(statsSection)({ statList, character }));
+  await tick();
+
+  const posted = Array.from(document.querySelectorAll('input[type="hidden"]'))
+    .map((el) => el.name);
+  expect(posted.sort()).toEqual([...statList].sort());
+  expect(document.querySelector('input[name="might"]').value)
+    .toBe(String(character.might));
 });

--- a/views/character.handlebars
+++ b/views/character.handlebars
@@ -219,16 +219,12 @@
       </div>
       <div id="statsReadOnly" class="wizard-stat-grid" x-show="!editing">
         {{#each statList}}
-        <div class="wizard-stat-row" data-stat="{{this}}" data-value="{{lookup ../character this}}">
+        <div class="wizard-stat-row" data-stat="{{this}}">
           <div class="wizard-stat-name">{{capitalize this}}</div>
-          <div class="wizard-stat-boxes">
-            {{#range 0 (lookup ../character this)}}
-            <div class="wizard-stat-box is-class" title="{{capitalize ../this}}: point"></div>
-            {{/range}}
-            {{#range (lookup ../character this) 5}}
-            <div class="wizard-stat-box is-locked" title="{{capitalize ../this}}: locked"></div>
-            {{/range}}
-          </div>
+          {{> stat-blocks-readonly value=(lookup ../character this) max=5}}
+          {{#if (gt (lookup ../character this) 5)}}
+          <span class="stat-blocks-over">{{lookup ../character this}} points</span>
+          {{/if}}
         </div>
         {{/each}}
       </div>

--- a/views/character.handlebars
+++ b/views/character.handlebars
@@ -223,14 +223,10 @@
           <div class="wizard-stat-name">{{capitalize this}}</div>
           <div class="wizard-stat-boxes">
             {{#range 0 (lookup ../character this)}}
-            <div class="wizard-stat-box is-class" title="{{capitalize ../this}}: point">
-              <i class="fa-regular fa-square-plus" aria-hidden="true"></i>
-            </div>
+            <div class="wizard-stat-box is-class" title="{{capitalize ../this}}: point"></div>
             {{/range}}
             {{#range (lookup ../character this) 5}}
-            <div class="wizard-stat-box is-locked" title="{{capitalize ../this}}: locked">
-              <i class="fa-regular fa-square-plus" aria-hidden="true"></i>
-            </div>
+            <div class="wizard-stat-box is-locked" title="{{capitalize ../this}}: locked"></div>
             {{/range}}
           </div>
         </div>

--- a/views/class-form.handlebars
+++ b/views/class-form.handlebars
@@ -101,7 +101,12 @@
     <div class="columns is-multiline is-mobile">
       {{#each statList}}
       <div class="column is-2-tablet is-4-mobile">
-        <label class="label is-small is-capitalized">{{this}}</label>
+        {{!-- A <div>, not a <label>: the stat is now a radiogroup of blocks,
+              not a single labellable control, so a <label> here would have
+              no `for` target and clicking it would move focus nowhere. The
+              group carries its own aria-label. Bulma classes kept as-is --
+              they carry this column's layout. --}}
+        <div class="label is-small is-capitalized">{{this}}</div>
         <div class="control">
           {{> stat-blocks stat=this name=(concat "stat_spread[" this "]") value=(lookup ../class.stat_spread this) max=3}}
         </div>

--- a/views/class-form.handlebars
+++ b/views/class-form.handlebars
@@ -101,9 +101,9 @@
     <div class="columns is-multiline is-mobile">
       {{#each statList}}
       <div class="column is-2-tablet is-4-mobile">
-        <label class="label is-small is-capitalized" for="stat-{{this}}">{{this}}</label>
+        <label class="label is-small is-capitalized">{{this}}</label>
         <div class="control">
-          <input class="input" type="number" min="0" max="3" step="1" id="stat-{{this}}" name="stat_spread[{{this}}]" value="{{lookup ../class.stat_spread this}}">
+          {{> stat-blocks stat=this name=(concat "stat_spread[" this "]") value=(lookup ../class.stat_spread this) max=3}}
         </div>
       </div>
       {{/each}}

--- a/views/class-form.test.js
+++ b/views/class-form.test.js
@@ -1,0 +1,70 @@
+// The class form's stat spread is a native POST using bracket notation
+// (stat_spread[might]=2), parsed by parseStatSpread in routes/classes.js.
+// Swapping the number inputs for blocks must not disturb those names --
+// parseStatSpread reads body['stat_spread[<stat>]'] literally, so a renamed
+// field silently yields an empty spread and the class ships with no stats.
+const { test, expect, beforeAll } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../util/handlebars');
+const { statList } = require('../util/enclave-consts');
+const { setupAlpine, render, tick } = require('../test/helpers/alpine-dom');
+
+beforeAll(async () => {
+  await setupAlpine();
+  require('../public/js/alpine-components.js');
+  document.dispatchEvent(new window.CustomEvent('alpine:init'));
+});
+
+const SRC = fs.readFileSync(path.join(__dirname, 'class-form.handlebars'), 'utf8');
+
+const renderSpread = async (statSpread) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  hb.registerPartial('stat-blocks', fs.readFileSync(
+    path.join(__dirname, 'partials', 'stat-blocks.handlebars'), 'utf8'
+  ));
+  const section = SRC.slice(
+    SRC.indexOf('<label class="label">Class Stats</label>'),
+    SRC.indexOf('<label class="label" for="class-image">')
+  );
+  await render(hb.compile(section)({ statList, class: { stat_spread: statSpread } }));
+  await tick();
+};
+
+test('class-form renders stat blocks instead of number inputs', () => {
+  expect(SRC).toContain('{{> stat-blocks');
+  expect(SRC).not.toMatch(/name="stat_spread\[\{\{this\}\}\]"\s*value=/);
+  expect(SRC).not.toContain('type="number"');
+});
+
+test('every stat posts under its bracket-notation name', async () => {
+  await renderSpread({ might: 2, resilience: 1 });
+  const posted = Array.from(document.querySelectorAll('input[type="hidden"]'))
+    .map((el) => el.name);
+  expect(posted.sort()).toEqual(statList.map((s) => `stat_spread[${s}]`).sort());
+});
+
+test('a class spread renders three blocks per stat, not five', async () => {
+  await renderSpread({ might: 2 });
+  const might = document.querySelector('.stat-blocks[data-stat="might"]');
+  expect(might.querySelectorAll('[role="radio"]').length).toBe(3);
+});
+
+test('seeded points fill and unseeded stats start empty', async () => {
+  await renderSpread({ might: 2 });
+  expect(document.querySelector('input[name="stat_spread[might]"]').value).toBe('2');
+  expect(document.querySelector('input[name="stat_spread[luck]"]').value).toBe('0');
+});
+
+test('clicking a block updates the value that would post', async () => {
+  await renderSpread({ might: 2 });
+  document.querySelectorAll('.stat-blocks[data-stat="might"] [role="radio"]')[2].click();
+  await tick();
+  expect(document.querySelector('input[name="stat_spread[might]"]').value).toBe('3');
+});

--- a/views/lfg-post.handlebars
+++ b/views/lfg-post.handlebars
@@ -112,9 +112,8 @@
                     <div class="columns is-multiline">
                       {{#each ../statList}}
                       <div class="column is-6">
-                        <p><strong>{{capitalize this}}:</strong>
-                          {{#range 0 (lookup ../this.character this)}}+ {{/range}}
-                        </p>
+                        <p class="mb-1"><strong>{{capitalize this}}</strong></p>
+                        {{> stat-blocks-readonly value=(lookup ../this.character this) max=5}}
                       </div>
                       {{/each}}
                     </div>
@@ -178,12 +177,8 @@
     <div class="columns is-multiline">
       {{#each statList}}
       <div class="column is-3">
-        <p><strong>{{capitalize this}}:</strong>
-          {{#range 0 (lookup ../partyStats this)}}
-          +
-          {{/range}}
-          ({{lookup ../partyStats this}})
-        </p>
+        <p class="mb-1"><strong>{{capitalize this}}</strong> ({{lookup ../partyStats this}})</p>
+        {{> stat-blocks-readonly value=(lookup ../partyStats this) max=5}}
       </div>
       {{/each}}
     </div>

--- a/views/lfg-post.test.js
+++ b/views/lfg-post.test.js
@@ -1,0 +1,71 @@
+// The LFG post page showed stats as literal '+' characters. It predates the
+// square-plus commit but is the same "stats as pluses" look, so it converts
+// with the rest.
+const { test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../util/handlebars');
+
+const READONLY_SRC = fs.readFileSync(
+  path.join(__dirname, 'partials', 'stat-blocks-readonly.handlebars'), 'utf8'
+);
+const LFG_SRC = fs.readFileSync(path.join(__dirname, 'lfg-post.handlebars'), 'utf8');
+
+const renderReadonly = (context) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(READONLY_SRC)(context);
+};
+
+const count = (html, cls) => (html.match(new RegExp(cls, 'g')) || []).length;
+
+test('renders one filled block per point and dims the rest to max', () => {
+  const html = renderReadonly({ value: 2, max: 5 });
+  expect(count(html, 'is-set')).toBe(2);
+  expect(count(html, 'is-empty')).toBe(3);
+});
+
+test('a value at max fills every block and dims none', () => {
+  const html = renderReadonly({ value: 5, max: 5 });
+  expect(count(html, 'is-set')).toBe(5);
+  expect(count(html, 'is-empty')).toBe(0);
+});
+
+test('a value above max fills every block without overflowing the row', () => {
+  // Party totals routinely exceed 5; the row must cap rather than render 14
+  // blocks. The caller shows the real number alongside.
+  const html = renderReadonly({ value: 14, max: 5 });
+  expect(count(html, 'is-set')).toBe(5);
+  expect(count(html, 'is-empty')).toBe(0);
+});
+
+test('a zero or missing value renders an all-dim row', () => {
+  expect(count(renderReadonly({ value: 0, max: 5 }), 'is-empty')).toBe(5);
+  expect(count(renderReadonly({ max: 5 }), 'is-empty')).toBe(5);
+});
+
+test('the read-only control carries no interactive affordances', () => {
+  const html = renderReadonly({ value: 3, max: 5 });
+  expect(html).toContain('is-readonly');
+  expect(html).not.toContain('role="radio"');
+  expect(html).not.toContain('x-data');
+  expect(html).not.toContain('@click');
+  expect(html).not.toContain('tabindex');
+});
+
+test('lfg-post renders blocks and no longer prints plus characters', () => {
+  expect(LFG_SRC).toContain('{{> stat-blocks-readonly');
+  // Both {{#range}} loops that printed a bare '+' per point are gone.
+  expect(LFG_SRC).not.toMatch(/\{\{#range 0 \(lookup [^)]*\)\}\}\+/);
+  expect(LFG_SRC).not.toMatch(/\{\{#range 0 \(lookup [^)]*\)\}\}\s*\n\s*\+/);
+});
+
+test('party stats keep their numeral, since totals routinely exceed five', () => {
+  const partySection = LFG_SRC.slice(LFG_SRC.indexOf('Party Stats'));
+  expect(partySection).toContain('({{lookup ../partyStats this}})');
+});

--- a/views/partials/character-level-up.handlebars
+++ b/views/partials/character-level-up.handlebars
@@ -54,20 +54,8 @@
       <div class="wizard-stat-grid" id="levelUpStatGrid">
         {{#each statList}}
         <div class="wizard-stat-row" data-stat="{{this}}">
-          <label class="wizard-stat-name" for="level-up-{{this}}">{{capitalize this}}</label>
-          <div class="wizard-stat-boxes">
-            <input
-              class="input is-small level-up-stat"
-              id="level-up-{{this}}"
-              name="{{this}}"
-              type="number"
-              min="0"
-              max="20"
-              step="1"
-              value="{{lookup ../character this}}"
-              data-stat="{{this}}"
-            >
-          </div>
+          <div class="wizard-stat-name">{{capitalize this}}</div>
+          {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5 inputClass="level-up-stat"}}
         </div>
         {{/each}}
       </div>

--- a/views/partials/character-level-up.test.js
+++ b/views/partials/character-level-up.test.js
@@ -117,3 +117,80 @@ test('an open-modal event for a different name does not open the level-up modal'
   await tick();
   expect(document.getElementById('levelUpModal').classList.contains('is-active')).toBe(false);
 });
+
+// --- stat blocks in the modal --------------------------------------------
+
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../../util/handlebars');
+
+const renderStatBlocks = (stat, value) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(read('stat-blocks.handlebars'))({
+    stat, name: stat, value, max: 5, inputClass: 'level-up-stat'
+  });
+};
+
+test('character-level-up.handlebars renders stat blocks, not number inputs', () => {
+  const src = read('character-level-up.handlebars');
+  expect(src).toContain('{{> stat-blocks');
+  expect(src).toContain('inputClass="level-up-stat"');
+  expect(src).not.toContain('type="number"');
+  expect(src).not.toContain('class="input is-small level-up-stat"');
+});
+
+test('the hidden inputs keep the class and data-stat the save payload reads', async () => {
+  await render(`<div id="levelUpStatGrid">${renderStatBlocks('might', 2)}</div>`);
+  await tick();
+  const input = document.querySelector('.level-up-stat');
+  expect(input.getAttribute('data-stat')).toBe('might');
+  expect(input.value).toBe('2');
+});
+
+test('clicking a block updates the value the save payload would read', async () => {
+  await render(`<div id="levelUpStatGrid">${renderStatBlocks('might', 2)}</div>`);
+  await tick();
+  document.querySelectorAll('[role="radio"]')[3].click();
+  await tick();
+  expect(document.querySelector('.level-up-stat').value).toBe('4');
+});
+
+test('character-level-up.js recomputes the total from stat-change, not input', () => {
+  const src = read('../../public/js/character-level-up.js');
+  // A hidden input set programmatically fires no native `input` event, so
+  // the old per-field 'input' listener would leave #levelUpTotal frozen at
+  // its seeded value for the whole session.
+  expect(src).toContain("addEventListener('stat-change', updateStatTotal)");
+  expect(src).not.toContain("el.addEventListener('input', updateStatTotal)");
+});
+
+test('a stat-change bubbling out of the grid drives the live total', async () => {
+  await render(`
+    <div id="levelUpStatGrid">
+      ${renderStatBlocks('might', 2)}
+      ${renderStatBlocks('vitality', 3)}
+    </div>
+    <strong id="levelUpTotal">0</strong>
+  `);
+  await tick();
+
+  // Mirrors the wiring in character-level-up.js:215 exactly: one delegated
+  // listener on the grid, summing every .level-up-stat.
+  const updateStatTotal = () => {
+    const sum = Array.from(document.querySelectorAll('.level-up-stat'))
+      .reduce((s, el) => s + (parseInt(el.value, 10) || 0), 0);
+    document.getElementById('levelUpTotal').textContent = sum;
+  };
+  document.getElementById('levelUpStatGrid')
+    .addEventListener('stat-change', updateStatTotal);
+  updateStatTotal();
+  expect(document.getElementById('levelUpTotal').textContent).toBe('5');
+
+  document.querySelectorAll('[data-stat="might"] [role="radio"]')[4].click();
+  await tick();
+  expect(document.getElementById('levelUpTotal').textContent).toBe('8');
+});

--- a/views/partials/character-stats-editor.handlebars
+++ b/views/partials/character-stats-editor.handlebars
@@ -5,21 +5,8 @@
   <div class="wizard-stat-grid">
     {{#each statList}}
     <div class="wizard-stat-row" data-stat="{{this}}">
-      <label class="wizard-stat-name" for="stat-input-{{this}}">{{capitalize this}}</label>
-      <div class="wizard-stat-boxes">
-        <input
-          class="input is-small stats-input"
-          id="stat-input-{{this}}"
-          name="{{this}}"
-          type="number"
-          min="0"
-          max="20"
-          step="1"
-          value="{{lookup ../character this}}"
-          data-stat="{{this}}"
-          x-model.number="stats.{{this}}"
-        >
-      </div>
+      <div class="wizard-stat-name">{{capitalize this}}</div>
+      {{> stat-blocks stat=this name=this value=(lookup ../character this) max=5 model=(concat "stats." this)}}
     </div>
     {{/each}}
   </div>

--- a/views/partials/character-stats-editor.test.js
+++ b/views/partials/character-stats-editor.test.js
@@ -6,6 +6,26 @@ const customHelpers = require('../../util/handlebars');
 const { statList } = require('../../util/enclave-consts');
 const { setupAlpine, render, tick, settle } = require('../../test/helpers/alpine-dom');
 
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+
+const STAT_BLOCKS_SRC = fs.readFileSync(
+  path.join(__dirname, 'stat-blocks.handlebars'), 'utf8'
+);
+
+// Renders the REAL stat-blocks partial into the fixture rather than a
+// hand-copied stand-in, so a regression in the shipped partial fails here
+// too instead of only in stat-blocks.test.js.
+const statBlocks = (stat, value) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(STAT_BLOCKS_SRC)({
+    stat, name: stat, value, max: 5, model: `stats.${stat}`
+  });
+};
+
 const STATS = { vitality: 3, might: 2, resilience: 1 };
 
 // The x-data attribute is single-quote delimited (not double) because
@@ -19,9 +39,9 @@ const mount = (stats) => render(`
     <button id="edit" x-show="!editing" @click="edit()"></button>
     <div id="readonly" x-show="!editing"></div>
     <form id="editor" x-show="editing" @submit.prevent="save()">
-      <input class="stats-input" type="number" x-model.number="stats.vitality">
-      <input class="stats-input" type="number" x-model.number="stats.might">
-      <input class="stats-input" type="number" x-model.number="stats.resilience">
+      ${statBlocks('vitality', stats.vitality)}
+      ${statBlocks('might', stats.might)}
+      ${statBlocks('resilience', stats.resilience)}
       <strong id="statsTotalSum" x-text="total"></strong>
       <button id="cancel" type="button" @click="cancel()"></button>
       <button id="save" type="submit" :disabled="saving"></button>
@@ -51,11 +71,16 @@ test('Edit reveals the editor and hides the read-only grid', async () => {
   expect(document.getElementById('readonly').style.display).toBe('none');
 });
 
-test('Edit moves focus to the first stats input', async () => {
+test('Edit moves focus to the first stat block', async () => {
   await mount(STATS);
   document.getElementById('edit').click();
   await settle();
-  const first = document.querySelector('.stats-input');
+  // Not a truthy-only assertion: statList starts with 'vitality', and both
+  // #statsReadOnly and #statsEditor iterate it, so the first .stat-blocks in
+  // DOM order is vitality's. Focus landing on the wrong stat's control must
+  // fail here, which a bare "something is focused" check would not catch.
+  const first = document.querySelector('.stat-blocks[data-stat="vitality"] [role="radio"][tabindex="0"]');
+  expect(first).not.toBe(null);
   expect(document.activeElement).toBe(first);
 });
 
@@ -64,25 +89,23 @@ test('total sums the seeded stats', async () => {
   expect(document.getElementById('statsTotalSum').textContent).toBe('6');
 });
 
-test('total recomputes as inputs change', async () => {
+test('total recomputes as blocks are clicked', async () => {
   await mount(STATS);
   document.getElementById('edit').click();
   await tick();
-  const input = document.querySelector('.stats-input');
-  input.value = '10';
-  input.dispatchEvent(new window.Event('input', { bubbles: true }));
+  // vitality 3 -> 5, so 3+2+1 = 6 becomes 5+2+1 = 8.
+  document.querySelectorAll('.stat-blocks[data-stat="vitality"] [role="radio"]')[4].click();
   await tick();
-  expect(document.getElementById('statsTotalSum').textContent).toBe('13');
+  expect(document.getElementById('statsTotalSum').textContent).toBe('8');
 });
 
 test('Cancel restores the original values and exits edit mode', async () => {
   await mount(STATS);
   document.getElementById('edit').click();
   await tick();
-  const input = document.querySelector('.stats-input');
-  input.value = '19';
-  input.dispatchEvent(new window.Event('input', { bubbles: true }));
+  document.querySelectorAll('.stat-blocks[data-stat="vitality"] [role="radio"]')[4].click();
   await tick();
+  expect(document.getElementById('statsTotalSum').textContent).toBe('8');
 
   document.getElementById('cancel').click();
   await settle();
@@ -119,9 +142,7 @@ test('save PATCHes clamped integers to the stats endpoint', async () => {
   try {
     document.getElementById('edit').click();
     await tick();
-    const input = document.querySelector('.stats-input');
-    input.value = '99';                       // above the 0-20 range
-    input.dispatchEvent(new window.Event('input', { bubbles: true }));
+    document.querySelectorAll('.stat-blocks[data-stat="vitality"] [role="radio"]')[4].click();
     await tick();
 
     document.getElementById('editor').dispatchEvent(
@@ -135,7 +156,7 @@ test('save PATCHes clamped integers to the stats endpoint', async () => {
 
   expect(captured.url).toBe('/characters/char-1/stats');
   expect(captured.options.method).toBe('PATCH');
-  expect(JSON.parse(captured.options.body).vitality).toBe(20);
+  expect(JSON.parse(captured.options.body).vitality).toBe(5);
   expect(reloaded).toBe(true);
 });
 
@@ -187,7 +208,8 @@ test('character-stats-editor.handlebars carries the Alpine bindings', () => {
   );
 
   expect(src).toContain('x-text="total"');
-  expect(src).toContain('x-model.number="stats.{{this}}"');
+  expect(src).toContain('{{> stat-blocks');
+  expect(src).toContain('model=(concat "stats." this)');
   expect(src).toContain('@submit.prevent="save()"');
   expect(src).toContain('@click="cancel()"');
   expect(src).toContain(':disabled="saving"');
@@ -196,6 +218,9 @@ test('character-stats-editor.handlebars carries the Alpine bindings', () => {
   expect(src).toContain(":class=\"{ 'is-loading': saving }\"");
   expect(src).toContain('x-show="error" x-text="error"');
 
+  // The number inputs this replaced must be gone, not merely hidden.
+  expect(src).not.toContain('stats-input');
+  expect(src).not.toContain('type="number"');
   expect(src).not.toContain('character-stats.js');
   expect(src).not.toContain('CharacterStats');
 });

--- a/views/partials/character-stats-editor.test.js
+++ b/views/partials/character-stats-editor.test.js
@@ -340,3 +340,112 @@ test('the real #statsBox x-data seed survives a missing (undefined) stat', async
   await tick();
   expect(document.getElementById('statsTotalSum').textContent).toBe('19');
 });
+
+// --- unify-readonly-grid ------------------------------------------------
+//
+// #statsReadOnly used to hand-roll its own boxes with the WIZARD's
+// vocabulary (.is-class filled / .is-locked dashed), while #statsEditor
+// (revealed by the very same Edit click) used the stat-blocks control's
+// vocabulary (.is-set / .is-empty), and /lfg/:id used a third rendering via
+// stat-blocks-readonly. Same stat, three different looks. This extracts the
+// REAL #statsReadOnly markup out of character.handlebars (still containing
+// its Handlebars syntax, Handlebars source and all) and compiles it with the
+// app's real helpers plus the real stat-blocks-readonly partial -- mirroring
+// extractStatsXData above -- so a regression in the shipped template fails
+// here, not just in a hand-copied stand-in.
+const extractStatsReadOnlyBlock = () => {
+  const startMarker = '<div id="statsReadOnly"';
+  const endMarker = '<div id="statsEditor"';
+  const startIdx = CHARACTER_SRC.indexOf(startMarker);
+  if (startIdx === -1) throw new Error('#statsReadOnly not found in character.handlebars');
+  const endIdx = CHARACTER_SRC.indexOf(endMarker, startIdx);
+  if (endIdx === -1) throw new Error('#statsEditor not found after #statsReadOnly');
+  return CHARACTER_SRC.slice(startIdx, endIdx);
+};
+
+const renderStatsReadOnly = (character) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  hb.registerPartial('stat-blocks-readonly', fs.readFileSync(
+    path.join(__dirname, 'stat-blocks-readonly.handlebars'), 'utf8'
+  ));
+  return hb.compile(extractStatsReadOnlyBlock())({ character, statList });
+};
+
+const count = (html, cls) => (html.match(new RegExp(cls, 'g')) || []).length;
+
+// Isolates one stat's row out of the rendered grid by slicing from its
+// data-stat marker to the next one (or end of string for the last stat).
+// The sliced tail carries a few harmless characters of the next row's own
+// opening tag, but nothing in that prefix can match is-set/is-empty/points,
+// so it never contaminates the count.
+const statRowHtml = (html, stat) => {
+  const start = html.indexOf(`data-stat="${stat}"`);
+  if (start === -1) throw new Error(`data-stat="${stat}" not found in rendered grid`);
+  const nextStart = html.indexOf('data-stat="', start + 1);
+  return html.slice(start, nextStart === -1 ? html.length : nextStart);
+};
+
+const ZERO_STATS = Object.fromEntries(statList.map((stat) => [stat, 0]));
+
+test('the read-only grid uses is-set/is-empty and no longer emits the wizard vocabulary', () => {
+  const html = renderStatsReadOnly({ ...ZERO_STATS, might: 3 });
+  expect(html).toContain('is-set');
+  expect(html).toContain('is-empty');
+  expect(html).not.toContain('is-class');
+  expect(html).not.toContain('is-locked');
+});
+
+test('a stat of 3 renders 3 filled and 2 empty blocks', () => {
+  const html = renderStatsReadOnly({ ...ZERO_STATS, might: 3 });
+  const row = statRowHtml(html, 'might');
+  expect(count(row, 'is-set')).toBe(3);
+  expect(count(row, 'is-empty')).toBe(2);
+});
+
+test('a stat of 0 renders an all-empty row', () => {
+  const html = renderStatsReadOnly(ZERO_STATS);
+  const row = statRowHtml(html, 'vitality');
+  expect(count(row, 'is-set')).toBe(0);
+  expect(count(row, 'is-empty')).toBe(5);
+});
+
+test('a stat above 5 caps the row at 5 blocks and surfaces the real number', () => {
+  // Today {{#range 0 7}} renders seven boxes and spills the grid cell.
+  // stat-blocks-readonly caps at max, but a capped row alone would silently
+  // read as "5" for a stat of 7 -- the numeral alongside the row is what
+  // keeps that legible, same as the LFG party-stats caller and the editable
+  // control's "N points" text.
+  const html = renderStatsReadOnly({ ...ZERO_STATS, might: 7 });
+  const row = statRowHtml(html, 'might');
+  expect(count(row, 'is-set')).toBe(5);
+  expect(count(row, 'is-empty')).toBe(0);
+  expect(row).toContain('7 points');
+});
+
+test('a stat within range shows no overflow numeral', () => {
+  const html = renderStatsReadOnly({ ...ZERO_STATS, might: 3 });
+  const row = statRowHtml(html, 'might');
+  expect(row).not.toContain('points');
+});
+
+test('the read-only row keeps data-stat as a live selector hook', () => {
+  const html = renderStatsReadOnly({ ...ZERO_STATS, might: 3 });
+  expect(html).toContain('data-stat="might"');
+});
+
+test('the dead data-value attribute is gone from character.handlebars', () => {
+  expect(CHARACTER_SRC).not.toContain('data-value=');
+});
+
+test('the lost title tooltips are gone from the read-only row', () => {
+  const html = renderStatsReadOnly({ ...ZERO_STATS, might: 3 });
+  const row = statRowHtml(html, 'might');
+  expect(row).not.toContain('title=');
+});
+
+test('the #statsReadOnly container line is unchanged by the conversion', () => {
+  expect(CHARACTER_SRC).toContain('id="statsReadOnly" class="wizard-stat-grid" x-show="!editing"');
+});

--- a/views/partials/character-stats-editor.test.js
+++ b/views/partials/character-stats-editor.test.js
@@ -113,7 +113,7 @@ test('Cancel restores the original values and exits edit mode', async () => {
   expect(document.getElementById('statsTotalSum').textContent).toBe('6');
 });
 
-test('save PATCHes clamped integers to the stats endpoint', async () => {
+test('save PATCHes the block-set value to the stats endpoint', async () => {
   await mount(STATS);
   let captured = null;
   globalThis.fetch = async (url, options) => {
@@ -158,6 +158,50 @@ test('save PATCHes clamped integers to the stats endpoint', async () => {
   expect(captured.options.method).toBe('PATCH');
   expect(JSON.parse(captured.options.body).vitality).toBe(5);
   expect(reloaded).toBe(true);
+});
+
+// The blocks can only ever produce 0..max, so clicking them can never reach
+// save()'s 0-20 clamp or its NaN/negative floor. Those two lines still guard
+// everything the control does NOT produce: a legacy value stored above 20, a
+// negative, or a null column that parseInt turns into NaN. Seed that state
+// directly -- the clamp is unreachable from the UI, which is exactly why a
+// click-driven test cannot pin it. (Deleting both lines leaves every other
+// test in this file green.)
+const submitAndCapturePayload = async () => {
+  let captured = null;
+  globalThis.fetch = async (url, options) => {
+    captured = { url, options };
+    return { ok: true, json: async () => ({ character: {} }) };
+  };
+  // Same jsdom-location workaround as the test above; see its comment.
+  const realWindow = window;
+  const locationStub = { reload: () => {} };
+  globalThis.window = new Proxy(realWindow, {
+    get(target, prop, receiver) {
+      if (prop === 'location') return locationStub;
+      return Reflect.get(target, prop, receiver);
+    }
+  });
+  try {
+    document.getElementById('editor').dispatchEvent(
+      new realWindow.Event('submit', { bubbles: true, cancelable: true })
+    );
+    await tick();
+    await tick();
+  } finally {
+    globalThis.window = realWindow;
+  }
+  return JSON.parse(captured.options.body);
+};
+
+test('save clamps stored values the blocks cannot produce', async () => {
+  await mount({ vitality: 25, might: -3, resilience: 1 });
+  expect(await submitAndCapturePayload()).toEqual({ vitality: 20, might: 0, resilience: 1 });
+});
+
+test('save coerces a null stat to zero rather than PATCHing NaN', async () => {
+  await mount({ vitality: null, might: 2, resilience: 1 });
+  expect(await submitAndCapturePayload()).toEqual({ vitality: 0, might: 2, resilience: 1 });
 });
 
 test('save surfaces a server error and re-enables the button', async () => {

--- a/views/partials/stat-blocks-readonly.handlebars
+++ b/views/partials/stat-blocks-readonly.handlebars
@@ -1,0 +1,20 @@
+{{!-- Display-only stat blocks. No Alpine, no ARIA group, no interaction --
+      this is the same visual vocabulary as views/partials/stat-blocks.handlebars
+      for surfaces that only report a value.
+
+      Params:
+        value  the points to show (null/missing renders an empty row)
+        max    how many blocks the row holds
+
+      A value above max fills every block and stops there rather than
+      spilling a 14-block row across the layout; callers that can exceed
+      max (party totals) print the real number alongside. There is no `min`
+      helper registered, hence the branch. --}}
+<span class="stat-blocks is-readonly">
+  {{#if (gt value max)}}
+  {{#range 0 max}}<span class="wizard-stat-box is-set"></span>{{/range}}
+  {{else}}
+  {{#range 0 value}}<span class="wizard-stat-box is-set"></span>{{/range}}
+  {{#range value max}}<span class="wizard-stat-box is-empty"></span>{{/range}}
+  {{/if}}
+</span>

--- a/views/partials/stat-blocks.handlebars
+++ b/views/partials/stat-blocks.handlebars
@@ -22,7 +22,32 @@
       `value` goes through {{json}} rather than being interpolated bare: a
       null stat renders as nothing at all under {{lookup}}, producing
       `statBlocks(, 5, "luck")` -- a SyntaxError that takes the whole
-      component down. --}}
+      component down.
+
+      THE BLOCKS ARE SERVER-RENDERED, NOT `<template x-for>`. This is
+      load-bearing, not a style preference. views/layouts/main.handlebars
+      puts hx-boost="true" on <body>, and htmx snapshots the LIVE DOM into
+      its history cache -- including anything x-for generated. On Back the
+      snapshot is restored WITH those generated spans and Alpine's x-for
+      appends a second full set, so every stat doubles its blocks, the stale
+      half throws "i is not defined" on every binding (`i` lives only in the
+      x-for scope), and clicking one throws instead of setting the stat.
+      Real elements in the served HTML restore as themselves. Keep it that
+      way.
+
+      {{#range}} iterates [start, end), and the statBlocks component's API is
+      1-BASED (block 1 is the first block, and clicking it sets the stat to
+      1). So this iterates 1..max inclusive -- `{{#range 1 (add max 1)}}` --
+      and `{{this}}` IS the 1-based block position everywhere below, with no
+      +1 hiding in an expression. Inside the range block the partial's own
+      params are one frame up, hence `../value` and `../stat`.
+
+      :class uses the OBJECT form. The string form only ever ADDS: Alpine
+      tracks the classes it added itself and can remove only those, so on a
+      restored history snapshot where `is-set` is already in the served
+      markup Alpine would never be able to take it off and the block would
+      be stuck filled. The object form adds and removes by truthiness
+      regardless of who put the class there. --}}
 <div class="stat-blocks" role="radiogroup" aria-label="{{capitalize stat}}"
      data-stat="{{stat}}"
      x-data="statBlocks({{json value}}, {{max}}, {{json stat}})"
@@ -32,14 +57,28 @@
   <input type="hidden" name="{{name}}" :value="value"
          class="stat-blocks-value{{#if inputClass}} {{inputClass}}{{/if}}"
          data-stat="{{stat}}">
-  <template x-for="i in max" :key="i">
-    <span class="wizard-stat-box" role="radio"
-          :class="boxClass(i)"
-          :aria-checked="i === value"
-          :aria-label="`{{capitalize stat}}: ${i}`"
-          :tabindex="tabIndex(i)"
-          @click="set(i)"
-          @mouseenter="preview = i"></span>
-  </template>
-  <span class="stat-blocks-over" x-show="value > max" x-cloak x-text="value"></span>
+  {{#range 1 (add max 1)}}
+  <span class="wizard-stat-box {{#if (gte ../value this)}}is-set{{else}}is-empty{{/if}}"
+        role="radio"
+        aria-label="{{capitalize ../stat}}: {{this}}"
+        :class="boxClass({{this}})"
+        :aria-checked="value === {{this}}"
+        :tabindex="tabIndex({{this}})"
+        @click="set({{this}})"
+        @mouseenter="preview = {{this}}"></span>
+  {{/range}}
+  {{!-- A stat above the block count. The blocks cannot express it -- every
+        one of them reads aria-checked="false" -- so this indicator is the
+        only place the real value exists, and a bare numeral read out as
+        "7" next to twelve other bare numerals tells a screen-reader user
+        nothing. It carries the unit in its own text instead.
+
+        Deliberately NOT done by growing the radiogroup's aria-label: an
+        accessible name that mutates while the user is inside the control is
+        its own bug. Also deliberately not aria-describedby: that needs an
+        id, and the character page renders this partial twice for the same
+        stat (inline editor + level-up modal), so any id derived from `stat`
+        or `name` would be duplicated. --}}
+  <span class="stat-blocks-over" x-show="value > max" x-cloak
+        x-text="value + ' points'"></span>
 </div>

--- a/views/partials/stat-blocks.handlebars
+++ b/views/partials/stat-blocks.handlebars
@@ -1,0 +1,45 @@
+{{!-- Star-rating stat selector. One control per stat. Replaces the number
+      inputs the stats editor, level-up modal, character form, and class
+      form used to render.
+
+      Params:
+        stat        the stat key ("might"). Accessible name + data-stat.
+        name        the hidden input's name -- what actually POSTs.
+        value       seeded points. null/undefined becomes 0.
+        max         how many blocks render (5 for character stats, 3 for a
+                    class stat spread).
+        model       optional expression ("stats.might"); when present the
+                    control two-way binds into the surrounding x-data.
+        inputClass  optional extra class on the hidden input, for surfaces
+                    that query it by class (the level-up modal).
+
+      The hidden input is what makes this work on native form POSTs: it
+      carries the same `name` the number input it replaced carried, so no
+      route or payload changes. A value ABOVE max is preserved -- every
+      block fills and the real number shows beside them -- and only drops
+      when the user clicks a block. Nothing clamps silently.
+
+      `value` goes through {{json}} rather than being interpolated bare: a
+      null stat renders as nothing at all under {{lookup}}, producing
+      `statBlocks(, 5, "luck")` -- a SyntaxError that takes the whole
+      component down. --}}
+<div class="stat-blocks" role="radiogroup" aria-label="{{capitalize stat}}"
+     data-stat="{{stat}}"
+     x-data="statBlocks({{json value}}, {{max}}, {{json stat}})"
+     {{#if model}}x-modelable="value" x-model="{{model}}"{{/if}}
+     @mouseleave="preview = null"
+     @keydown="key($event)">
+  <input type="hidden" name="{{name}}" :value="value"
+         class="stat-blocks-value{{#if inputClass}} {{inputClass}}{{/if}}"
+         data-stat="{{stat}}">
+  <template x-for="i in max" :key="i">
+    <span class="wizard-stat-box" role="radio"
+          :class="boxClass(i)"
+          :aria-checked="i === value"
+          :aria-label="`{{capitalize stat}}: ${i}`"
+          :tabindex="tabIndex(i)"
+          @click="set(i)"
+          @mouseenter="preview = i"></span>
+  </template>
+  <span class="stat-blocks-over" x-show="value > max" x-cloak x-text="value"></span>
+</div>

--- a/views/partials/stat-blocks.test.js
+++ b/views/partials/stat-blocks.test.js
@@ -232,3 +232,88 @@ test('a keypress that changes nothing dispatches nothing', async () => {
   expect(count).toBe(0);
   expect(hidden().value).toBe('5');
 });
+
+// --- the real partial -----------------------------------------------------
+//
+// Everything above mounts a hand-written fixture. These compile the actual
+// template with the app's real helper set and mount THAT, so the fixture
+// and the shipped partial cannot quietly drift apart.
+
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const hbsHelpers = require('handlebars-helpers')();
+const rangeHelper = require('handlebars-helper-range');
+const customHelpers = require('../../util/handlebars');
+
+const PARTIAL_SRC = fs.readFileSync(path.join(__dirname, 'stat-blocks.handlebars'), 'utf8');
+
+const renderPartial = (context) => {
+  const hb = Handlebars.create();
+  hb.registerHelper(hbsHelpers);
+  hb.registerHelper(customHelpers);
+  hb.registerHelper('range', rangeHelper);
+  return hb.compile(PARTIAL_SRC)(context);
+};
+
+test('the partial renders a labelled radiogroup with a POSTable hidden input', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 3, max: 5 }));
+  await tick();
+  const group = document.querySelector('.stat-blocks');
+  expect(group.getAttribute('role')).toBe('radiogroup');
+  expect(group.getAttribute('aria-label')).toBe('Might');
+  expect(document.querySelector('input[type="hidden"]').name).toBe('might');
+  expect(document.querySelectorAll('[role="radio"]').length).toBe(5);
+});
+
+test('the real partial mounts and clicks through to the right value', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 1, max: 5 }));
+  await tick();
+  document.querySelectorAll('[role="radio"]')[3].click();
+  await tick();
+  expect(document.querySelector('input[type="hidden"]').value).toBe('4');
+});
+
+test('a null value seeds zero rather than breaking the x-data expression', async () => {
+  // {{json v}} emits `null` for a missing stat; a bare {{lookup}} would emit
+  // nothing at all and produce `statBlocks(, 5, "luck")` -- a SyntaxError
+  // that takes the whole component down, which is the exact defect
+  // character-stats-editor.test.js documents for the #statsBox seed.
+  await render(renderPartial({ stat: 'luck', name: 'luck', value: null, max: 5 }));
+  await tick();
+  expect(document.querySelector('input[type="hidden"]').value).toBe('0');
+  expect(document.querySelectorAll('.is-empty').length).toBe(5);
+});
+
+test('max drives the block count, so a class spread renders three', async () => {
+  await render(renderPartial({ stat: 'might', name: 'stat_spread[might]', value: 2, max: 3 }));
+  await tick();
+  expect(document.querySelectorAll('[role="radio"]').length).toBe(3);
+  expect(document.querySelector('input[type="hidden"]').name).toBe('stat_spread[might]');
+});
+
+test('inputClass lands on the hidden input for surfaces that query it', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 0, max: 5, inputClass: 'level-up-stat' }));
+  await tick();
+  const input = document.querySelector('input[type="hidden"]');
+  expect(input.classList.contains('level-up-stat')).toBe(true);
+  expect(input.getAttribute('data-stat')).toBe('might');
+});
+
+test('model wires x-modelable so a parent x-data sees every change', async () => {
+  const inner = renderPartial({ stat: 'might', name: 'might', value: 1, max: 5, model: 'stats.might' });
+  await render(`<div x-data="{ stats: { might: 1 } }"><span id="mirror" x-text="stats.might"></span>${inner}</div>`);
+  await tick();
+  document.querySelectorAll('[role="radio"]')[3].click();
+  await tick();
+  expect(document.getElementById('mirror').textContent).toBe('4');
+});
+
+test('the partial omits the model bindings entirely when no model is passed', () => {
+  // x-modelable is emitted only alongside x-model. On its own it has no
+  // parent binding to attach to, and leaving it on every surface would be a
+  // directive that silently does nothing on three of the four.
+  const html = renderPartial({ stat: 'might', name: 'might', value: 1, max: 5 });
+  expect(html).not.toMatch(/\sx-model="/);
+  expect(html).not.toMatch(/\sx-modelable="/);
+});

--- a/views/partials/stat-blocks.test.js
+++ b/views/partials/stat-blocks.test.js
@@ -47,21 +47,26 @@ test('a value above the block count can step down but the rule never invents one
 // --- the Alpine component -------------------------------------------------
 //
 // This fixture mirrors views/partials/stat-blocks.handlebars by hand so the
-// component's behaviour is pinned independently of the template. Task 3
-// adds tests that mount the REAL partial, which is what catches the two
+// component's behaviour is pinned independently of the template. The tests
+// further down mount the REAL partial, which is what catches the two
 // drifting apart.
+//
+// The blocks are written out one element each rather than looped by
+// `<template x-for>` for the same reason the partial does not use x-for:
+// hx-boost snapshots the live DOM, so x-for's generated children come back
+// on a Back navigation and x-for appends a second set on top of them. See
+// the history-restore tests at the bottom of this file.
 
 const mount = (value, max) => render(`
   <div class="stat-blocks" role="radiogroup" aria-label="Might"
        x-data="statBlocks(${value}, ${max}, 'might')"
        @mouseleave="preview = null" @keydown="key($event)">
     <input type="hidden" name="might" :value="value" class="stat-blocks-value" data-stat="might">
-    <template x-for="i in max" :key="i">
-      <span class="wizard-stat-box" role="radio"
-            :class="boxClass(i)" :aria-checked="i === value" :tabindex="tabIndex(i)"
-            @click="set(i)" @mouseenter="preview = i"></span>
-    </template>
-    <span class="stat-blocks-over" x-show="value > max" x-text="value"></span>
+    ${Array.from({ length: max }, (_, k) => k + 1).map((i) => `
+    <span class="wizard-stat-box ${i <= value ? 'is-set' : 'is-empty'}" role="radio"
+          :class="boxClass(${i})" :aria-checked="value === ${i}" :tabindex="tabIndex(${i})"
+          @click="set(${i})" @mouseenter="preview = ${i}"></span>`).join('')}
+    <span class="stat-blocks-over" x-show="value > max" x-text="value + ' points'"></span>
   </div>
 `);
 
@@ -187,7 +192,10 @@ test('a value above max fills every block, shows the number, and does not clamp'
   await tick();
   expect(classesOf().every((c) => c === 'is-set')).toBe(true);
   expect(hidden().value).toBe('7');
-  expect(document.querySelector('.stat-blocks-over').textContent).toBe('7');
+  // Carries the unit, not a bare numeral: for a stat above the block count
+  // every block reads aria-checked="false", so this indicator is the only
+  // place a screen-reader user can get the real value.
+  expect(document.querySelector('.stat-blocks-over').textContent).toBe('7 points');
 });
 
 test('an over-max value drops to the clicked block, and cannot grow again', async () => {
@@ -322,54 +330,171 @@ test('the partial omits the model bindings entirely when no model is passed', ()
 //
 // public/js/character-wizard.js is a 1698-line IIFE that returns immediately
 // without a #wizard-data element and touches localStorage, Math.random, and
-// rAF at init, so mounting it under jsdom is its own project. Instead the
-// arithmetic it needs lives in resolveStatTarget and is pinned here with the
-// wizard's own numbers, and a source assertion proves the wizard calls it
-// rather than growing a second copy.
+// rAF at init, so mounting it under jsdom is its own project. So the
+// wizard's side of the rule -- INCLUDING the construction of its arguments,
+// which is where an off-by-one can actually live -- is exported as
+// StatBlocks.resolveWizardTarget and exercised directly here. The wizard
+// only gathers state and calls it.
+//
+// These tests call the real exported function rather than a local rebuild
+// of the wizard's call. A hand-rebuilt copy passes no matter what the
+// wizard actually passes: flipping `slot + 1` to `slot` is invisible to a
+// copy that already takes a 1-based slot, and that one character makes
+// every wizard click assign a point too few.
 
-// Mirrors the call the wizard makes: floor is the class + personality
-// points the user may not remove, ceiling is whichever binds first -- the
-// per-stat cap, or what the remaining budget can pay for.
-const wizardTarget = ({ slot, cp, pp, up, remaining, cap }) =>
-  window.StatBlocks.resolveStatTarget({
-    slot,
-    current: cp + pp + up,
-    floor: cp + pp,
-    ceiling: Math.min(cap, cp + pp + up + remaining)
-  }) - cp - pp;
+// resolveWizardTarget takes the raw 0-based data-slot and returns the new
+// TOTAL. The user portion -- what the wizard stores -- is that minus the
+// class and personality points, which are not the user's to give back.
+const wizardTotal = (args) => window.StatBlocks.resolveWizardTarget(args);
+const wizardUserPoints = (args) => wizardTotal(args) - (args.cp || 0) - (args.pp || 0);
+
+test('wizard: data-slot is 0-based, so the first block means one point, not zero', () => {
+  // This is the conversion the old hand-rebuilt helper could not see.
+  expect(wizardTotal({ slot: 0, cp: 0, pp: 0, up: 0, remaining: 6, cap: 5 })).toBe(1);
+  expect(wizardTotal({ slot: 3, cp: 0, pp: 0, up: 0, remaining: 6, cap: 5 })).toBe(4);
+});
 
 test('wizard: clicking the 4th block assigns the whole jump when the budget covers it', () => {
   // Level 2+: cap 5. One class point, nothing user-assigned, 4 points left.
-  expect(wizardTarget({ slot: 4, cp: 1, pp: 0, up: 0, remaining: 4, cap: 5 })).toBe(3);
+  // The 4th block is data-slot 3.
+  const args = { slot: 3, cp: 1, pp: 0, up: 0, remaining: 4, cap: 5 };
+  expect(wizardTotal(args)).toBe(4);
+  expect(wizardUserPoints(args)).toBe(3);
 });
 
 test('wizard: a short budget assigns only what remains', () => {
-  expect(wizardTarget({ slot: 5, cp: 1, pp: 0, up: 0, remaining: 2, cap: 5 })).toBe(2);
+  const args = { slot: 4, cp: 1, pp: 0, up: 0, remaining: 2, cap: 5 };
+  expect(wizardTotal(args)).toBe(3);
+  expect(wizardUserPoints(args)).toBe(2);
 });
 
 test('wizard: the per-stat cap binds before the budget at level 1', () => {
-  // Level 1: cap 3. Clicking the 5th block can only reach 3 total.
-  expect(wizardTarget({ slot: 5, cp: 1, pp: 0, up: 0, remaining: 5, cap: 3 })).toBe(2);
+  // Level 1: cap 3. Clicking the 5th block (data-slot 4) reaches 3 total.
+  const args = { slot: 4, cp: 1, pp: 0, up: 0, remaining: 5, cap: 3 };
+  expect(wizardTotal(args)).toBe(3);
+  expect(wizardUserPoints(args)).toBe(2);
 });
 
 test('wizard: clicking the topmost user-assigned block removes one point', () => {
-  // 1 class + 2 user = 3. Clicking the 3rd block steps down to 2 total.
-  expect(wizardTarget({ slot: 3, cp: 1, pp: 0, up: 2, remaining: 3, cap: 5 })).toBe(1);
+  // 1 class + 2 user = 3. Clicking the 3rd block (data-slot 2) steps down.
+  const args = { slot: 2, cp: 1, pp: 0, up: 2, remaining: 3, cap: 5 };
+  expect(wizardTotal(args)).toBe(2);
+  expect(wizardUserPoints(args)).toBe(1);
 });
 
 test('wizard: a click can never take a stat below its class and personality points', () => {
-  // 1 class + 1 personality + 2 user. Clicking the 1st block floors at 2.
-  expect(wizardTarget({ slot: 1, cp: 1, pp: 1, up: 2, remaining: 2, cap: 5 })).toBe(0);
+  // 1 class + 1 personality + 2 user. Clicking the 1st block (data-slot 0)
+  // floors at 2.
+  const args = { slot: 0, cp: 1, pp: 1, up: 2, remaining: 2, cap: 5 };
+  expect(wizardTotal(args)).toBe(2);
+  expect(wizardUserPoints(args)).toBe(0);
 });
 
 test('character-wizard.js applies the shared rule instead of its own arithmetic', () => {
   const src = fs.readFileSync(
     path.join(__dirname, '..', '..', 'public', 'js', 'character-wizard.js'), 'utf8'
   );
-  expect(src).toContain('StatBlocks.resolveStatTarget');
+  expect(src).toContain('StatBlocks.resolveWizardTarget');
+  // Rebuilding the arguments in the wizard is what put the slot conversion
+  // and the floor/ceiling on the untested side of the line. It must not
+  // come back.
+  expect(src).not.toContain('slot: slot + 1');
+  expect(src).not.toContain('floor: cp + pp');
   // The old one-point-at-a-time branches must be gone, not left beside it.
   expect(src).not.toContain('state.userStats[stat] = up + 1');
   expect(src).not.toContain('state.userStats[stat] = up - 1');
+});
+
+// --- surviving an hx-boost history restore --------------------------------
+//
+// views/layouts/main.handlebars puts hx-boost="true" on <body> and nothing
+// configures htmx's history cache or hooks htmx:beforeHistorySave, so htmx
+// snapshots the LIVE DOM -- Alpine's output included -- and restores that
+// snapshot verbatim on Back. render() replaces document.body.innerHTML and
+// lets Alpine's MutationObserver re-initialize it, which is exactly the
+// shape of that swap (see the note on render() in test/helpers/alpine-dom).
+//
+// Under `<template x-for>` this was measured at 5 blocks -> 10: the restored
+// snapshot already contains the five spans x-for generated, and x-for
+// appends five more. The stale five throw "i is not defined" on every
+// binding, because `i` exists only in the x-for scope, so clicking one
+// throws instead of setting the stat.
+
+const snapshotAndRestore = async () => {
+  // What htmx caches is the live DOM, not the response body.
+  const snapshot = document.body.innerHTML;
+  await render(snapshot);
+  await tick();
+};
+
+test('a history snapshot round trip does not duplicate the blocks', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 3, max: 5 }));
+  await tick();
+  expect(blocks().length).toBe(5);
+
+  await snapshotAndRestore();
+
+  expect(blocks().length).toBe(5);
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-set', 'is-empty', 'is-empty']);
+  expect(blocks().filter((b) => b.getAttribute('tabindex') === '0').length).toBe(1);
+  expect(blocks().map((b) => b.getAttribute('aria-checked')))
+    .toEqual(['false', 'false', 'true', 'false', 'false']);
+});
+
+test('a restored block re-derives its class from the seed rather than keeping the snapshot state', async () => {
+  // The string form of :class can only ADD: Alpine tracks the classes it
+  // added itself and removes only those, so an `is-set` that arrived in the
+  // served markup (which is what a restored snapshot is) could never come
+  // off, and the block would be stuck filled. Raise the value, snapshot the
+  // filled row, restore, and the seed of 3 must win.
+  await render(renderPartial({ stat: 'might', name: 'might', value: 3, max: 5 }));
+  await tick();
+  blocks()[4].click();
+  await tick();
+  expect(classesOf().every((c) => c === 'is-set')).toBe(true);
+
+  await snapshotAndRestore();
+
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-set', 'is-empty', 'is-empty']);
+  expect(hidden().value).toBe('3');
+});
+
+test('a restored block is still live, not a stale copy that throws on click', async () => {
+  await render(renderPartial({ stat: 'might', name: 'might', value: 2, max: 5 }));
+  await tick();
+
+  await snapshotAndRestore();
+
+  blocks()[3].click();
+  await tick();
+  expect(hidden().value).toBe('4');
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-set', 'is-set', 'is-empty']);
+});
+
+test('the partial ships real elements, not an x-for template', () => {
+  // Asserted against the RENDERED output, not the source: Handlebars strips
+  // {{!-- --}} comments, and the partial's comment explains at length why
+  // x-for is not used here, which a source-level substring check would trip
+  // over.
+  const html = renderPartial({ stat: 'might', name: 'might', value: 3, max: 5 });
+  expect(html).not.toContain('<template');
+  expect(html).not.toContain('x-for');
+  expect((html.match(/role="radio"/g) || []).length).toBe(5);
+  // And the class binding is the object form, which is the half of the fix
+  // that is easy to lose in a later edit.
+  expect(html).toContain(':class="boxClass(');
+});
+
+test('boxClass returns an object, not a class string', async () => {
+  // Alpine's string form only removes classes it added itself; the object
+  // form toggles by truthiness whoever added them. Asserted directly as
+  // well as through the restore tests above, because "it returns a string
+  // again" is a one-line regression with a non-obvious symptom.
+  await render(renderPartial({ stat: 'might', name: 'might', value: 2, max: 5 }));
+  await tick();
+  const data = Alpine.$data(document.querySelector('.stat-blocks'));
+  expect(data.boxClass(1)).toEqual({ 'is-preview': false, 'is-set': true, 'is-empty': false });
+  expect(data.boxClass(4)).toEqual({ 'is-preview': false, 'is-set': false, 'is-empty': true });
 });
 
 test('character-wizard.js wires the hover preview', () => {

--- a/views/partials/stat-blocks.test.js
+++ b/views/partials/stat-blocks.test.js
@@ -1,0 +1,234 @@
+const { test, expect, beforeAll } = require('bun:test');
+const { setupAlpine, render, tick } = require('../../test/helpers/alpine-dom');
+
+beforeAll(async () => {
+  await setupAlpine();
+  require('../../public/js/alpine-components.js');
+  document.dispatchEvent(new window.CustomEvent('alpine:init'));
+});
+
+// --- the shared rule ------------------------------------------------------
+//
+// resolveStatTarget is the single source of truth for "what does clicking
+// this block do". It is exported on window rather than closed over because
+// public/js/character-wizard.js drives its own imperative grid and must
+// apply the identical rule; two copies of this arithmetic is exactly how
+// the wizard and the editor would drift apart.
+
+const resolve = (args) => window.StatBlocks.resolveStatTarget(args);
+
+test('clicking the Nth block targets N', () => {
+  expect(resolve({ slot: 3, current: 0, floor: 0, ceiling: 5 })).toBe(3);
+});
+
+test('clicking the block you are already on steps down by one', () => {
+  expect(resolve({ slot: 3, current: 3, floor: 0, ceiling: 5 })).toBe(2);
+});
+
+test('clicking the first block at value 1 reaches zero', () => {
+  expect(resolve({ slot: 1, current: 1, floor: 0, ceiling: 5 })).toBe(0);
+});
+
+test('the ceiling caps the target', () => {
+  // The wizard's short-budget case: 1 class point, 2 points left in the
+  // budget, user clicks the 5th block. The most it can reach is 3.
+  expect(resolve({ slot: 5, current: 1, floor: 1, ceiling: 3 })).toBe(3);
+});
+
+test('the floor keeps class- and personality-assigned points untouchable', () => {
+  expect(resolve({ slot: 1, current: 4, floor: 2, ceiling: 5 })).toBe(2);
+});
+
+test('a value above the block count can step down but the rule never invents one', () => {
+  // 7 points, 5 blocks: clicking the 3rd block drops it to 3, not to 5.
+  expect(resolve({ slot: 3, current: 7, floor: 0, ceiling: 7 })).toBe(3);
+});
+
+// --- the Alpine component -------------------------------------------------
+//
+// This fixture mirrors views/partials/stat-blocks.handlebars by hand so the
+// component's behaviour is pinned independently of the template. Task 3
+// adds tests that mount the REAL partial, which is what catches the two
+// drifting apart.
+
+const mount = (value, max) => render(`
+  <div class="stat-blocks" role="radiogroup" aria-label="Might"
+       x-data="statBlocks(${value}, ${max}, 'might')"
+       @mouseleave="preview = null" @keydown="key($event)">
+    <input type="hidden" name="might" :value="value" class="stat-blocks-value" data-stat="might">
+    <template x-for="i in max" :key="i">
+      <span class="wizard-stat-box" role="radio"
+            :class="boxClass(i)" :aria-checked="i === value" :tabindex="tabIndex(i)"
+            @click="set(i)" @mouseenter="preview = i"></span>
+    </template>
+    <span class="stat-blocks-over" x-show="value > max" x-text="value"></span>
+  </div>
+`);
+
+const blocks = () => Array.from(document.querySelectorAll('[role="radio"]'));
+const classesOf = () => blocks().map((b) => b.className.replace('wizard-stat-box ', ''));
+const hidden = () => document.querySelector('.stat-blocks-value');
+
+test('renders max blocks, filled up to the seeded value', async () => {
+  await mount(2, 5);
+  await tick();
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+test('clicking the Nth block sets the value and updates the hidden input', async () => {
+  await mount(2, 5);
+  await tick();
+  blocks()[3].click();
+  await tick();
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-set', 'is-set', 'is-empty']);
+  expect(hidden().value).toBe('4');
+});
+
+test('clicking the active block drops to N-1', async () => {
+  await mount(3, 5);
+  await tick();
+  blocks()[2].click();
+  await tick();
+  expect(hidden().value).toBe('2');
+});
+
+test('clicking the first block at value 1 reaches zero', async () => {
+  await mount(1, 5);
+  await tick();
+  blocks()[0].click();
+  await tick();
+  expect(hidden().value).toBe('0');
+  expect(classesOf().every((c) => c === 'is-empty')).toBe(true);
+});
+
+test('hovering above the value previews the blocks a click would fill', async () => {
+  await mount(2, 5);
+  await tick();
+  blocks()[3].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  expect(classesOf()).toEqual(['is-preview', 'is-preview', 'is-preview', 'is-preview', 'is-empty']);
+  // The committed value is untouched until a click.
+  expect(hidden().value).toBe('2');
+});
+
+test('hovering below the value previews the drop, not just a fill', async () => {
+  await mount(5, 5);
+  await tick();
+  blocks()[1].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  expect(classesOf()).toEqual(['is-preview', 'is-preview', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+test('hovering the active block previews N-1, matching what the click does', async () => {
+  await mount(3, 5);
+  await tick();
+  blocks()[2].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  expect(classesOf()).toEqual(['is-preview', 'is-preview', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+test('mouseleave restores the committed state', async () => {
+  await mount(2, 5);
+  await tick();
+  blocks()[4].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  document.querySelector('.stat-blocks').dispatchEvent(new window.Event('mouseleave'));
+  await tick();
+  expect(classesOf()).toEqual(['is-set', 'is-set', 'is-empty', 'is-empty', 'is-empty']);
+});
+
+const press = async (key) => {
+  document.querySelector('.stat-blocks').dispatchEvent(
+    new window.KeyboardEvent('keydown', { key, bubbles: true })
+  );
+  await tick();
+};
+
+test('arrow keys adjust by one and clamp at both ends', async () => {
+  await mount(2, 5);
+  await tick();
+  await press('ArrowRight');
+  expect(hidden().value).toBe('3');
+  await press('ArrowLeft');
+  await press('ArrowLeft');
+  await press('ArrowLeft');
+  await press('ArrowLeft');
+  expect(hidden().value).toBe('0');
+  await press('ArrowUp');
+  expect(hidden().value).toBe('1');
+});
+
+test('Home and End jump to the ends', async () => {
+  await mount(2, 5);
+  await tick();
+  await press('End');
+  expect(hidden().value).toBe('5');
+  await press('Home');
+  expect(hidden().value).toBe('0');
+});
+
+test('exactly one block is tabbable and aria-checked tracks the value', async () => {
+  await mount(3, 5);
+  await tick();
+  expect(blocks().filter((b) => b.getAttribute('tabindex') === '0').length).toBe(1);
+  expect(blocks()[2].getAttribute('tabindex')).toBe('0');
+  expect(blocks().map((b) => b.getAttribute('aria-checked')))
+    .toEqual(['false', 'false', 'true', 'false', 'false']);
+});
+
+test('at value 0 the first block is the tabbable one', async () => {
+  await mount(0, 5);
+  await tick();
+  expect(blocks()[0].getAttribute('tabindex')).toBe('0');
+});
+
+test('a value above max fills every block, shows the number, and does not clamp', async () => {
+  await mount(7, 5);
+  await tick();
+  expect(classesOf().every((c) => c === 'is-set')).toBe(true);
+  expect(hidden().value).toBe('7');
+  expect(document.querySelector('.stat-blocks-over').textContent).toBe('7');
+});
+
+test('an over-max value drops to the clicked block, and cannot grow again', async () => {
+  await mount(7, 5);
+  await tick();
+  await press('ArrowRight');
+  expect(hidden().value).toBe('7');   // no-op: blocks cannot invent a 6th
+  blocks()[2].click();
+  await tick();
+  expect(hidden().value).toBe('3');
+});
+
+test('committing dispatches a bubbling stat-change with the stat and value', async () => {
+  await mount(2, 5);
+  await tick();
+  let seen = null;
+  document.body.addEventListener('stat-change', (e) => { seen = e.detail; });
+  blocks()[3].click();
+  await tick();
+  expect(seen).toEqual({ stat: 'might', value: 4 });
+});
+
+test('hovering alone never commits, so it dispatches nothing', async () => {
+  await mount(2, 5);
+  await tick();
+  let count = 0;
+  document.body.addEventListener('stat-change', () => { count += 1; });
+  blocks()[4].dispatchEvent(new window.Event('mouseenter', { bubbles: false }));
+  await tick();
+  document.querySelector('.stat-blocks').dispatchEvent(new window.Event('mouseleave'));
+  await tick();
+  expect(count).toBe(0);
+});
+
+test('a keypress that changes nothing dispatches nothing', async () => {
+  await mount(5, 5);
+  await tick();
+  let count = 0;
+  document.body.addEventListener('stat-change', () => { count += 1; });
+  await press('ArrowRight');   // already at max
+  await press('End');          // already at max
+  expect(count).toBe(0);
+  expect(hidden().value).toBe('5');
+});

--- a/views/partials/stat-blocks.test.js
+++ b/views/partials/stat-blocks.test.js
@@ -317,3 +317,65 @@ test('the partial omits the model bindings entirely when no model is passed', ()
   expect(html).not.toMatch(/\sx-model="/);
   expect(html).not.toMatch(/\sx-modelable="/);
 });
+
+// --- the wizard's use of the shared rule ----------------------------------
+//
+// public/js/character-wizard.js is a 1698-line IIFE that returns immediately
+// without a #wizard-data element and touches localStorage, Math.random, and
+// rAF at init, so mounting it under jsdom is its own project. Instead the
+// arithmetic it needs lives in resolveStatTarget and is pinned here with the
+// wizard's own numbers, and a source assertion proves the wizard calls it
+// rather than growing a second copy.
+
+// Mirrors the call the wizard makes: floor is the class + personality
+// points the user may not remove, ceiling is whichever binds first -- the
+// per-stat cap, or what the remaining budget can pay for.
+const wizardTarget = ({ slot, cp, pp, up, remaining, cap }) =>
+  window.StatBlocks.resolveStatTarget({
+    slot,
+    current: cp + pp + up,
+    floor: cp + pp,
+    ceiling: Math.min(cap, cp + pp + up + remaining)
+  }) - cp - pp;
+
+test('wizard: clicking the 4th block assigns the whole jump when the budget covers it', () => {
+  // Level 2+: cap 5. One class point, nothing user-assigned, 4 points left.
+  expect(wizardTarget({ slot: 4, cp: 1, pp: 0, up: 0, remaining: 4, cap: 5 })).toBe(3);
+});
+
+test('wizard: a short budget assigns only what remains', () => {
+  expect(wizardTarget({ slot: 5, cp: 1, pp: 0, up: 0, remaining: 2, cap: 5 })).toBe(2);
+});
+
+test('wizard: the per-stat cap binds before the budget at level 1', () => {
+  // Level 1: cap 3. Clicking the 5th block can only reach 3 total.
+  expect(wizardTarget({ slot: 5, cp: 1, pp: 0, up: 0, remaining: 5, cap: 3 })).toBe(2);
+});
+
+test('wizard: clicking the topmost user-assigned block removes one point', () => {
+  // 1 class + 2 user = 3. Clicking the 3rd block steps down to 2 total.
+  expect(wizardTarget({ slot: 3, cp: 1, pp: 0, up: 2, remaining: 3, cap: 5 })).toBe(1);
+});
+
+test('wizard: a click can never take a stat below its class and personality points', () => {
+  // 1 class + 1 personality + 2 user. Clicking the 1st block floors at 2.
+  expect(wizardTarget({ slot: 1, cp: 1, pp: 1, up: 2, remaining: 2, cap: 5 })).toBe(0);
+});
+
+test('character-wizard.js applies the shared rule instead of its own arithmetic', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'js', 'character-wizard.js'), 'utf8'
+  );
+  expect(src).toContain('StatBlocks.resolveStatTarget');
+  // The old one-point-at-a-time branches must be gone, not left beside it.
+  expect(src).not.toContain('state.userStats[stat] = up + 1');
+  expect(src).not.toContain('state.userStats[stat] = up - 1');
+});
+
+test('character-wizard.js wires the hover preview', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'js', 'character-wizard.js'), 'utf8'
+  );
+  expect(src).toContain("addEventListener('mouseover', onStatBoxHover)");
+  expect(src).toContain("addEventListener('mouseleave', clearStatPreview)");
+});


### PR DESCRIPTION
## Summary

Stats are blocks everywhere, and every stat text box is gone. Click the Nth block to set a stat to N; unset blocks stay visible but dimmed; hovering previews what a click would produce, in both directions.

Stacked on `fix-alpine-frozen-class-and-pages-rls` — please merge that first.

| Surface | Change |
|---|---|
| Inline stats editor | 12 number inputs → block selectors |
| Level-up modal | 12 number inputs → block selectors |
| Character form | 12 number inputs → blocks over hidden inputs (native POST unchanged) |
| Class form | 12 number inputs → blocks, 3 per stat |
| Wizard step 2 | one-point-per-click → jump-to-N, plus hover preview |
| Character page read-only grid | unified onto the same partial `/lfg/:id` uses |
| LFG post page | literal `+` characters → read-only blocks |
| Everywhere | plus icons reverted to blocks (reverts e13cbd3) |

One pure function, `StatBlocks.resolveStatTarget`, holds the click rule: clicking the Nth block sets the stat to N, except that clicking the block you are already on steps down by one — which is how a stat reaches zero. `character-wizard.js` renders its own imperative grid but calls the same function through `resolveWizardTarget`, so the two surfaces cannot drift. No route, payload, or server-side validation changed.

Accessibility is preserved rather than approximated: `role="radiogroup"` with a roving tabindex, so the grid still costs 12 tab stops — exactly what the 12 number inputs cost. Arrows, Home/End, and Space/Enter all work, `aria-checked` tracks the value, and blocks have a real focus outline.

### Three defects found and fixed along the way

- **`stat-change` fired before Alpine's DOM write flushed**, so the level-up total would have lagged one click behind in production. Proven by reverting just that hunk and reproducing the failure.
- **The partial originally used `<template x-for>`** — the only one in `views/`. With `hx-boost` on `<body>`, htmx snapshots the live DOM, so pressing Back doubled every block: 60 → 120, half of them dead and throwing on click. Now server-rendered with `{{#range}}`, and `:class` uses the object form so a served class can actually be cleared. There is a test that simulates the swap.
- **The coarse-pointer tap-target rule was cascade-dead** on the first attempt — added, commented as a fix, doing nothing, because an equal-specificity rule came later in the file. Fixed by ordering, with the invariant documented and `e2e/specs/16-stat-block-touch-targets.spec.js` asserting size and gap separately.

### Notes for review

- A stat above 5 is preserved, never silently clamped. Five blocks fill and the real number shows beside them ("7 points"); it only drops when someone clicks a block. The 0–20 clamp in `save()` stays, now with direct coverage.
- The read-only grid previously spilled its row for a stat above 5 (`{{#range 0 7}}` rendered seven boxes). That is fixed by the unification.
- Removed `data-value` from `.wizard-stat-row` — written on every row, read by nothing. One line to restore.
- `.is-class` / `.is-user` / `.is-assignable` / `.is-locked` remain live with one consumer, the wizard, where they mean different things (class-assigned vs personality-assigned vs assignable vs above-cap).

Design and plan: `docs/superpowers/specs/2026-08-05-stat-block-selector-design.md`, `docs/superpowers/plans/2026-08-05-stat-block-selector.md`.

## Validation

- [x] `bun run check`
- [x] `bun run test` — 805 pass, 0 fail
- [x] `bun run test:http` — 27 pass, 0 fail (no routes changed; run as a regression check)
- [ ] `bun run test:integration` — not applicable, no database writes or migrations

E2E: 81 pass / 2 fail. Both failures are the pre-existing `DELIBERATELY RED` specs (`03b-class-reassignment`, `13-page-slug`) documented in the e2e findings report. This branch touches only specs 04, 05, and the new 16.

## Database and risk

- [x] No migration required
- [ ] Migration added and local rollback/repair considerations documented
- [x] Authorization, sensitive data, and compatibility impacts reviewed

No authorization or data-access paths changed. The character and class forms still POST the same field names from hidden inputs, so `parseStatSpread` and `normalizeStatsPayload` are untouched and server-side clamping is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ2ByG25JsMuwiN8gJzRWw
