### PR TITLE
feat: rehearse pending migrations against a copy of a real database

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "seed:admin": "bun run util/seed-admin.js",
     "seed:badges": "bun run scripts/seed-badges.js",
     "fetch:badges": "bun run scripts/fetch-badge-art.js",
-    "db:backup": "sh scripts/db-backup.sh"
+    "db:backup": "sh scripts/db-backup.sh",
+    "rehearse:migrations": "bash scripts/rehearse-migrations.sh"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.1",

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -14,19 +14,122 @@ SUPABASE_DB_PASS="${SUPABASE_DB_PASS:-$(from_env_file SUPABASE_DB_PASS)}"
 SUPABASE_DB_REGION="${SUPABASE_DB_REGION:-$(from_env_file SUPABASE_DB_REGION)}"
 
 : "${SUPABASE_URL:?must be set in the environment or .env}"
-: "${SUPABASE_DB_PASS:?must be set in the environment or .env}"
+: "${SUPABASE_DB_PASS:?must be set in the environment or .env (it ships commented out)}"
 
 PROJECT_REF=$(printf '%s' "$SUPABASE_URL" |
   sed -e 's|^https\{0,1\}://||' -e 's|/$||' -e 's|^db\.||' -e 's|\.supabase\.co.*$||')
 REGION="${SUPABASE_DB_REGION:-aws-0-us-east-1}"
 
+case "$SUPABASE_URL" in
+  *127.0.0.1*|*localhost*)
+    echo "SUPABASE_URL points at the local stack ($SUPABASE_URL)." >&2
+    echo "This script backs up the hosted project. Set SUPABASE_URL to it, or use" >&2
+    echo "  supabase db dump  for the local one." >&2
+    exit 2 ;;
+esac
+
 mkdir -p "$DIR/backups"
 STAMP=$(date +%Y%m%d-%H%M%S)
-PGPASSWORD="$SUPABASE_DB_PASS" pg_dump \
-  -h "$REGION.pooler.supabase.com" \
-  -p 5432 \
-  -U "postgres.$PROJECT_REF" \
-  -d postgres \
-  -F c \
-  -f "$DIR/backups/backup-$STAMP.dump"
-echo "Backup saved to backups/backup-$STAMP.dump"
+OUT="$DIR/backups/backup-$STAMP.dump"
+# Written to .partial and renamed only once it verifies. A failed dump used to
+# leave a zero-byte file sitting in backups/ named exactly like a real one.
+PARTIAL="$OUT.partial"
+trap 'rm -f "$PARTIAL"' EXIT
+
+HOST="$REGION.pooler.supabase.com"
+USER="postgres.$PROJECT_REF"
+
+# pg_dump refuses to dump a server NEWER than itself ("aborting because of server
+# version mismatch"), and distro packages lag: Ubuntu 24.04 ships 16.x while
+# Supabase projects run 17.x. That failure is silent in the worst way -- it comes
+# after you have decided you have a backup.
+#
+# So: use the local pg_dump when it is new enough, and otherwise dump through a
+# container image whose pg_dump matches. An OLDER server is fine either way; only
+# a newer one is a problem.
+# Anchored at the start on purpose: `pg_dump (PostgreSQL) 16.14 (Ubuntu
+# 16.14-0ubuntu0.24.04.1)` ends in another dotted number, and a greedy pattern
+# reads the major as "04".
+LOCAL_MAJOR=$(pg_dump --version 2>/dev/null | sed -n 's/^pg_dump (PostgreSQL) \([0-9][0-9]*\).*/\1/p')
+IMAGE="${BACKUP_PGDUMP_IMAGE:-$(docker ps --format '{{.Image}}' 2>/dev/null | grep -m1 '/supabase/postgres:' || true)}"
+IMAGE="${IMAGE:-public.ecr.aws/supabase/postgres:17.6.1.095}"
+IMAGE_MAJOR=$(printf '%s' "$IMAGE" | sed -n 's/.*postgres:\([0-9][0-9]*\)\..*/\1/p')
+
+dump_local() {
+  PGPASSWORD="$SUPABASE_DB_PASS" pg_dump \
+    -h "$HOST" -p 5432 -U "$USER" -d postgres -F c -f "$PARTIAL"
+}
+
+# The password goes in an --env-file, not -e: docker's arguments are visible in
+# `ps` to every user on the machine, and a project's database password is not
+# something to leak to a process listing. The shell-level assignment in
+# dump_local() is not in pg_dump's argv, so it has never had this problem.
+dump_container() {
+  ENVFILE="$(mktemp)"
+  chmod 600 "$ENVFILE"
+  printf 'PGPASSWORD=%s\n' "$SUPABASE_DB_PASS" > "$ENVFILE"
+  # shellcheck disable=SC2064
+  trap "rm -f '$ENVFILE' \"$PARTIAL\"" EXIT
+  docker run --rm -i --env-file "$ENVFILE" --entrypoint pg_dump "$IMAGE" \
+    -h "$HOST" -p 5432 -U "$USER" -d postgres -F c > "$PARTIAL"
+  rm -f "$ENVFILE"
+  trap 'rm -f "$PARTIAL"' EXIT
+}
+
+USED_CONTAINER=0
+if [ -n "$LOCAL_MAJOR" ] && [ -n "$IMAGE_MAJOR" ] && [ "$LOCAL_MAJOR" -lt "$IMAGE_MAJOR" ]; then
+  if command -v docker >/dev/null 2>&1; then
+    USED_CONTAINER=1
+    echo "local pg_dump is $LOCAL_MAJOR, project is likely $IMAGE_MAJOR -- dumping via $IMAGE"
+    dump_container
+  else
+    echo "local pg_dump is $LOCAL_MAJOR but the project is likely $IMAGE_MAJOR, and pg_dump" >&2
+    echo "refuses to dump a newer server. Install postgresql-client-$IMAGE_MAJOR, or install" >&2
+    echo "Docker so this script can dump through a matching image." >&2
+    exit 1
+  fi
+elif [ -z "$LOCAL_MAJOR" ]; then
+  command -v docker >/dev/null 2>&1 || { echo "neither pg_dump nor docker is available" >&2; exit 1; }
+  echo "no local pg_dump -- dumping via $IMAGE"
+  USED_CONTAINER=1
+  dump_container
+else
+  dump_local
+fi
+
+# "It wrote a file" is not "you have a backup". A custom-format archive that
+# pg_restore cannot read its way through is worth knowing about now rather than
+# during a restore.
+#
+# Verified with the SAME pg_restore that matches the dump. pg_restore has
+# pg_dump's version rule -- a 16 client cannot read a 17 archive -- so verifying
+# a container-produced dump with the local binary reports a perfectly good backup
+# as corrupt.
+if [ "$USED_CONTAINER" = "1" ]; then
+  ENTRIES=$(docker run --rm -i --entrypoint pg_restore "$IMAGE" --list < "$PARTIAL" 2>/dev/null | grep -c . || true)
+elif command -v pg_restore >/dev/null 2>&1; then
+  ENTRIES=$(pg_restore --list "$PARTIAL" 2>/dev/null | grep -c . || true)
+else
+  ENTRIES=""
+fi
+
+if [ ! -s "$PARTIAL" ]; then
+  echo "the dump produced no data; treat this as a failed backup" >&2
+  exit 1
+fi
+
+if [ -n "$ENTRIES" ] && [ "$ENTRIES" -gt 0 ]; then
+  mv "$PARTIAL" "$OUT"; trap - EXIT
+  echo "Backup saved to backups/backup-$STAMP.dump ($(du -h "$OUT" | cut -f1), $ENTRIES archive entries)"
+elif [ -z "$ENTRIES" ]; then
+  mv "$PARTIAL" "$OUT"; trap - EXIT
+  echo "Backup saved to backups/backup-$STAMP.dump ($(du -h "$OUT" | cut -f1))"
+  echo "  (no pg_restore available to verify it is readable)" >&2
+else
+  echo "the dump is not a readable archive; treat this as a failed backup" >&2
+  exit 1
+fi
+
+# Reminder, because a pg_dump is not a project backup: Storage FILES live outside
+# Postgres. storage.objects rows are in here; the uploaded bytes they point at
+# are not.

--- a/scripts/rehearse-migrations.sh
+++ b/scripts/rehearse-migrations.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+#
+# Rehearse this repo's pending migrations against a throwaway copy of a real
+# database, and report what they would do -- before they do it anywhere that
+# matters.
+#
+# WHY THIS EXISTS
+#
+# main's migration set never creates the core tables: its earliest migration is
+# 20241213_collaborative_missions.sql, and profiles/characters/missions are
+# created by none of them. Production's schema predates its own migration
+# history. The refactor stack then added 20240101000000_baseline_schema.sql, a
+# synthetic baseline dated before everything else so that a from-scratch
+# `supabase db reset` works locally -- which it does, and which is why CI is
+# green. That baseline has never met the production database. Ten of its 23
+# CREATE TABLE statements are unguarded (profiles, characters, missions,
+# lfg_posts among them), so against a database that already has those tables and
+# no ledger entry for 20240101000000, the run aborts on the first one.
+#
+# It cannot destroy data -- every destructive statement in the baseline is a
+# DROP POLICY IF EXISTS (47 of them) or DROP FUNCTION IF EXISTS increment. The
+# risk is a deploy that dies partway through a ten-migration batch, and those 47
+# policy drop-and-recreates silently replacing RLS that may have diverged.
+#
+# This script answers both questions with evidence instead of inference.
+#
+# WHAT IT DOES
+#
+#   1. Dumps the SOURCE database. Read-only: pg_dump and nothing else, ever.
+#   2. Restores that dump into a scratch Postgres container on its own port.
+#   3. Records the "before" schema and the full RLS policy set.
+#   4. Applies every migration the source's ledger does not already list, in
+#      version order, each in its own transaction, stopping at the first
+#      failure -- the way the CLI would.
+#   5. Diffs the policy set and reports the verdict.
+#   6. Destroys the container.
+#
+# The source database is never written to. The local Supabase stack is never
+# touched: the scratch container gets its own port and its own name, and the
+# script refuses to start if that port is one the stack uses.
+#
+# USAGE
+#
+#   scripts/rehearse-migrations.sh --source local     # rehearse against a copy
+#                                                     # of your dev database
+#   scripts/rehearse-migrations.sh --source prod      # the real question
+#
+#   --with-data   copy table data too, not just schema. Slower, and it puts a
+#                 copy of production on your disk until the container is
+#                 destroyed -- but it is the only way to catch a migration that
+#                 fails on the rows rather than on the shape (20260806000000
+#                 rewrites an FK; a constraint can be valid against an empty
+#                 table and rejected by real data).
+#   --keep        leave the container running for inspection. Prints how to
+#                 connect, and how to remove it when you are done.
+#   --port N      scratch port (default 55432).
+#   --forget V    delete version V from the restored ledger before applying, so
+#                 the run treats it as pending. Repeatable. This is how you ask
+#                 "what happens to a database that has the tables but never
+#                 recorded the migration that creates them" -- production's exact
+#                 situation -- without needing production:
+#
+#                   scripts/rehearse-migrations.sh --source local \
+#                     --forget 20240101000000
+#
+#                 It edits the scratch copy's ledger. The source is untouched.
+#
+# For --source prod, supply the connection explicitly. Nothing is derived from a
+# local .env, because in this repo SUPABASE_URL points at the local stack and
+# silently rehearsing local-against-local would answer nothing:
+#
+#   REHEARSE_SOURCE_URL='postgresql://postgres.<ref>:<pass>@<region>.pooler.supabase.com:5432/postgres' \
+#     scripts/rehearse-migrations.sh --source prod
+#
+# Or let it build that URL the way scripts/db-backup.sh does, from
+# SUPABASE_URL (the project URL, not localhost), SUPABASE_DB_PASS and
+# optionally SUPABASE_DB_REGION.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MIGRATIONS="$DIR/supabase/migrations"
+
+SOURCE=""
+WITH_DATA=0
+KEEP=0
+PORT=55432
+FORGET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="${2:-}"; shift 2 ;;
+    --with-data) WITH_DATA=1; shift ;;
+    --keep) KEEP=1; shift ;;
+    --forget) FORGET="$FORGET ${2:-}"; shift 2 ;;
+    --port) PORT="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,70p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$SOURCE" in
+  local|prod) ;;
+  *) echo "usage: $0 --source <local|prod> [--with-data] [--keep] [--port N]" >&2; exit 2 ;;
+esac
+
+# The local stack's ports. Binding the scratch container to one of these would
+# collide with a running stack, and --port is exactly the kind of flag someone
+# pastes without reading.
+case "$PORT" in
+  54321|54322|54323|54324|54327) echo "refusing --port $PORT: that belongs to the local Supabase stack" >&2; exit 2 ;;
+esac
+
+# Same image as the local stack, not a vanilla postgres: the baseline installs
+# extensions (pgjwt, pg_graphql, ...) that only the Supabase image carries, and
+# a rehearsal on an image without them would fail for a reason production never
+# would.
+IMAGE="$(docker ps --format '{{.Image}}' | grep -m1 '/supabase/postgres:' || true)"
+IMAGE="${IMAGE:-public.ecr.aws/supabase/postgres:17.6.1.095}"
+
+CONTAINER="migration-rehearsal-$$"
+WORK="$(mktemp -d)"
+trap 'rc=$?; if [ "$KEEP" = "1" ]; then
+        echo; echo "--keep: scratch container left running."
+        echo "  connect: psql postgresql://postgres:postgres@127.0.0.1:$PORT/postgres"
+        echo "  remove : docker rm -f $CONTAINER"
+      else
+        docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+      fi
+      rm -rf "$WORK"; exit $rc' EXIT
+
+# ---------------------------------------------------------------- source URL
+
+from_env_file() {
+  [ -f "$DIR/.env" ] || return 0
+  sed -n "s/^[[:space:]]*$1=//p" "$DIR/.env" | head -n 1 |
+    sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//"
+}
+
+if [ "$SOURCE" = "local" ]; then
+  SOURCE_URL="$(supabase status -o env 2>/dev/null | sed -n 's/^DB_URL="\{0,1\}//p' | sed 's/"$//')"
+  [ -n "$SOURCE_URL" ] || { echo "could not read DB_URL from \`supabase status\` -- is the local stack running?" >&2; exit 1; }
+  SOURCE_LABEL="local dev database"
+else
+  SOURCE_URL="${REHEARSE_SOURCE_URL:-}"
+  if [ -z "$SOURCE_URL" ]; then
+    URL="${SUPABASE_URL:-$(from_env_file SUPABASE_URL)}"
+    PASS="${SUPABASE_DB_PASS:-$(from_env_file SUPABASE_DB_PASS)}"
+    REGION="${SUPABASE_DB_REGION:-$(from_env_file SUPABASE_DB_REGION)}"
+    REGION="${REGION:-aws-0-us-east-1}"
+    case "$URL" in
+      ""|*127.0.0.1*|*localhost*)
+        echo "--source prod needs a real project." >&2
+        echo "SUPABASE_URL is '${URL:-unset}', which is not one. Set REHEARSE_SOURCE_URL to the" >&2
+        echo "pooler connection string, or set SUPABASE_URL + SUPABASE_DB_PASS to the project's." >&2
+        exit 2 ;;
+    esac
+    [ -n "$PASS" ] || { echo "SUPABASE_DB_PASS is not set (it is commented out in .env)" >&2; exit 2; }
+    REF="$(printf '%s' "$URL" | sed -e 's|^https\{0,1\}://||' -e 's|/$||' -e 's|^db\.||' -e 's|\.supabase\.co.*$||')"
+    SOURCE_URL="postgresql://postgres.$REF:$PASS@$REGION.pooler.supabase.com:5432/postgres"
+  fi
+  SOURCE_LABEL="production"
+fi
+
+# Belt and braces: whatever route produced the URL, a prod rehearsal must not be
+# pointed at the local stack, and a local one must not reach out to a project.
+case "$SOURCE:$SOURCE_URL" in
+  prod:*127.0.0.1*|prod:*localhost*) echo "refusing: --source prod resolved to a local URL" >&2; exit 2 ;;
+  local:*pooler.supabase.com*)       echo "refusing: --source local resolved to a remote URL" >&2; exit 2 ;;
+esac
+
+redacted() { printf '%s' "$1" | sed -E 's|://[^:]+:[^@]+@|://***:***@|'; }
+
+echo "Rehearsing $DIR/supabase/migrations"
+echo "  source : $SOURCE_LABEL -- $(redacted "$SOURCE_URL")"
+echo "  scratch: $IMAGE on 127.0.0.1:$PORT"
+echo "  data   : $([ "$WITH_DATA" = 1 ] && echo 'schema + data' || echo 'schema only')"
+echo
+
+# ------------------------------------------------------------ scratch server
+
+echo "==> starting scratch Postgres"
+docker run -d --name "$CONTAINER" -e POSTGRES_PASSWORD=postgres \
+  --add-host=host.docker.internal:host-gateway \
+  -p "127.0.0.1:$PORT:5432" "$IMAGE" >/dev/null
+
+# -h 127.0.0.1 everywhere, deliberately. This image's entrypoint runs a
+# throwaway init-phase server that listens on the unix socket ONLY, then shuts
+# it down and starts the real one. A socket-based readiness probe passes against
+# that first server, so a restore started on its say-so gets killed partway
+# through with "the database system is shutting down" -- and silently, since the
+# restore is allowed to report errors. Requiring TCP skips the init server
+# entirely, because it never binds a port.
+scratch() { docker exec -i "$CONTAINER" psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 "$@"; }
+
+ready=0
+for _ in $(seq 1 90); do
+  if docker exec "$CONTAINER" psql -h 127.0.0.1 -U postgres -d postgres -tAc 'select 1' >/dev/null 2>&1; then
+    # Twice in a row, a second apart: one success is not proof the restart is
+    # behind us.
+    ready=$((ready + 1))
+    [ "$ready" -ge 2 ] && break
+  else
+    ready=0
+  fi
+  sleep 1
+done
+[ "$ready" -ge 2 ] || { echo "scratch Postgres never accepted TCP connections" >&2; exit 1; }
+
+# ------------------------------------------------------------------ the dump
+#
+# Run pg_dump INSIDE the container: the client must match the server major, and
+# a developer's system psql is routinely older (16 against a 17 server fails
+# outright). --no-owner/--no-privileges because the scratch server has none of
+# the source's roles.
+
+# pg_dump runs inside the container, where 127.0.0.1 is the container's own
+# loopback -- not the host's. A local source has to be reached via the
+# host-gateway alias instead. Remote sources resolve normally and are untouched.
+DUMP_URL="$(printf '%s' "$SOURCE_URL" | sed -e 's|@127\.0\.0\.1:|@host.docker.internal:|' -e 's|@localhost:|@host.docker.internal:|')"
+
+echo "==> dumping source (read-only)"
+# --clean --if-exists because the Supabase image pre-creates auth/storage/graphql
+# schemas at init; without it the restore dies on "schema auth already exists"
+# and the copy is never faithful.
+DUMP_ARGS="--no-owner --no-privileges --clean --if-exists"
+[ "$WITH_DATA" = 1 ] || DUMP_ARGS="$DUMP_ARGS --schema-only"
+
+docker exec -i "$CONTAINER" pg_dump $DUMP_ARGS "$DUMP_URL" > "$WORK/source.sql" 2>"$WORK/dump.err" || {
+  echo "pg_dump failed:" >&2; sed 's/^/    /' "$WORK/dump.err" >&2; exit 1; }
+
+# The ledger decides which migrations are "pending", so it has to come across
+# even on a schema-only run -- it is data, in a schema pg_dump would otherwise
+# bring over empty.
+docker exec -i "$CONTAINER" pg_dump --data-only --schema=supabase_migrations \
+  "$DUMP_URL" > "$WORK/ledger.sql" 2>/dev/null || : > "$WORK/ledger.sql"
+
+echo "    $(wc -l < "$WORK/source.sql") lines of schema, $(wc -l < "$WORK/ledger.sql") of ledger"
+
+# Restored WITHOUT ON_ERROR_STOP, then verified by outcome. A dump of a Supabase
+# database always produces some benign noise against a Supabase image -- roles it
+# cannot drop, extensions already installed, ownership it was told to skip. What
+# matters is whether the schema arrived, so that is what gets asserted rather
+# than demanding a silent run and hiding the real errors among the expected ones.
+echo "==> restoring into scratch"
+docker exec -i "$CONTAINER" psql -h 127.0.0.1 -U postgres -d postgres -q < "$WORK/source.sql" > "$WORK/restore.log" 2>&1 || true
+restore_errors="$(grep -c '^ERROR:' "$WORK/restore.log" || true)"
+
+missing=""
+for t in profiles characters missions; do
+  present="$(scratch -tAq -c "select to_regclass('public.$t') is not null;" 2>/dev/null || echo f)"
+  [ "$present" = "t" ] || missing="$missing $t"
+done
+if [ -n "$missing" ]; then
+  echo "restore did not produce the core tables:$missing" >&2
+  echo "first errors from the restore:" >&2
+  grep '^ERROR:' "$WORK/restore.log" | head -10 | sed 's/^/    /' >&2
+  exit 1
+fi
+[ "$restore_errors" = "0" ] || echo "    ($restore_errors benign restore error(s) -- core tables verified present)"
+scratch -q < "$WORK/ledger.sql" >/dev/null 2>&1 || true
+scratch -q -c "create schema if not exists supabase_migrations;
+  create table if not exists supabase_migrations.schema_migrations (version text primary key);" >/dev/null 2>&1
+
+# ---------------------------------------------------------------- snapshots
+
+POLICY_SQL="select schemaname||'.'||tablename||' :: '||policyname||' ['||cmd||'] using='||coalesce(qual,'-')||' check='||coalesce(with_check,'-')
+            from pg_policies where schemaname not in ('pg_catalog','information_schema') order by 1;"
+TABLE_SQL="select table_schema||'.'||table_name from information_schema.tables
+           where table_schema not in ('pg_catalog','information_schema') order by 1;"
+
+for v in $FORGET; do
+  n="$(scratch -tAq -c "delete from supabase_migrations.schema_migrations where version = '$v' returning 1;" | grep -c . || true)"
+  if [ "$n" = "0" ]; then
+    echo "    --forget $v: not in the ledger anyway (already pending)"
+  else
+    echo "    --forget $v: removed from the scratch ledger, will be treated as pending"
+  fi
+done
+[ -n "$FORGET" ] && echo
+
+scratch -tAq -c "$POLICY_SQL" > "$WORK/policies.before"
+scratch -tAq -c "$TABLE_SQL"  > "$WORK/tables.before"
+scratch -tAq -c "select version from supabase_migrations.schema_migrations order by version;" > "$WORK/ledger.before"
+
+echo "    restored: $(wc -l < "$WORK/tables.before") tables, $(wc -l < "$WORK/policies.before") policies, $(wc -l < "$WORK/ledger.before") ledger entries"
+echo
+
+# ------------------------------------------------------------- apply pending
+
+echo "==> applying pending migrations"
+APPLIED=0; FAILED=""; SKIPPED=0
+for file in "$MIGRATIONS"/*.sql; do
+  version="$(basename "$file" | sed 's/_.*//')"
+  if grep -qxF "$version" "$WORK/ledger.before"; then
+    SKIPPED=$((SKIPPED + 1)); continue
+  fi
+
+  # --single-transaction so a failure leaves nothing half-applied, which is what
+  # the CLI does and what makes the first failure the only one worth reporting.
+  if docker exec -i "$CONTAINER" psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 \
+       --single-transaction -q < "$file" > "$WORK/apply.log" 2>&1; then
+    scratch -q -c "insert into supabase_migrations.schema_migrations(version) values ('$version') on conflict do nothing;" >/dev/null
+    echo "    ok    $(basename "$file")"
+    APPLIED=$((APPLIED + 1))
+  else
+    echo "    FAIL  $(basename "$file")"
+    echo
+    grep -E "^(psql:|ERROR|DETAIL|HINT|CONTEXT)" "$WORK/apply.log" | sed 's/^/        /' | head -12
+    FAILED="$(basename "$file")"
+    break
+  fi
+done
+echo
+echo "    $APPLIED applied, $SKIPPED already in the ledger$([ -n "$FAILED" ] && echo ", stopped at $FAILED")"
+echo
+
+# ----------------------------------------------------------------- the diff
+
+scratch -tAq -c "$POLICY_SQL" > "$WORK/policies.after"
+scratch -tAq -c "$TABLE_SQL"  > "$WORK/tables.after"
+
+echo "==> what changed"
+new_tables="$(comm -13 "$WORK/tables.before" "$WORK/tables.after" || true)"
+gone_tables="$(comm -23 "$WORK/tables.before" "$WORK/tables.after" || true)"
+[ -n "$new_tables" ]  && { echo "    tables added:"; printf '%s\n' "$new_tables" | sed 's/^/      + /'; }
+[ -n "$gone_tables" ] && { echo "    TABLES REMOVED:"; printf '%s\n' "$gone_tables" | sed 's/^/      - /'; }
+[ -z "$new_tables$gone_tables" ] && echo "    tables: unchanged"
+
+# The 47 DROP POLICY IF EXISTS in the baseline are the quiet risk: they replace
+# RLS wholesale, and a policy that changes shape shows up here as one removed
+# and one added on the same table.
+pol_added="$(comm -13 "$WORK/policies.before" "$WORK/policies.after" || true)"
+pol_gone="$(comm -23 "$WORK/policies.before" "$WORK/policies.after" || true)"
+if [ -z "$pol_added$pol_gone" ]; then
+  echo "    RLS policies: unchanged"
+else
+  echo "    RLS policies: $(printf '%s' "$pol_gone" | grep -c . || true) removed/changed, $(printf '%s' "$pol_added" | grep -c . || true) added -- REVIEW THESE"
+  [ -n "$pol_gone" ]  && printf '%s\n' "$pol_gone"  | sed 's/^/      - /' | head -25
+  [ -n "$pol_added" ] && printf '%s\n' "$pol_added" | sed 's/^/      + /' | head -25
+fi
+echo
+
+# ------------------------------------------------------------------ verdict
+
+echo "==> verdict"
+if [ -n "$FAILED" ]; then
+  echo "    WOULD FAIL against $SOURCE_LABEL, at $FAILED."
+  echo "    $APPLIED migration(s) would have applied first; a real deploy stops here."
+  exit 1
+fi
+echo "    All $APPLIED pending migration(s) apply cleanly to a copy of $SOURCE_LABEL."
+[ "$WITH_DATA" = 1 ] || echo "    Schema only -- rerun with --with-data to also prove them against the rows."
+exit 0


### PR DESCRIPTION
`refactor-base` is six commits ahead of `main` and carries **ten migrations main does not have**. One of them cannot be applied to production as it stands, and nothing in the repo would have caught that before the deploy.

## The problem

`main`'s migration set never creates the core tables. Its earliest migration is `20241213_collaborative_missions.sql`, and `profiles`, `characters` and `missions` are created by **none** of its 21 — production's schema predates its own migration history.

The refactor stack then added `20240101000000_baseline_schema.sql`, a 1627-line synthetic baseline dated before everything else so a from-scratch `supabase db reset` works locally. It does, which is why local and CI are green. **It has never met production.** Ten of its 23 `CREATE TABLE` statements are unguarded, including `profiles`, `characters`, `missions` and `lfg_posts`.

It cannot destroy data — all 48 destructive statements are `DROP POLICY IF EXISTS` (47) and one `DROP FUNCTION IF EXISTS increment`. No `DROP TABLE`, no `TRUNCATE`, no `DELETE FROM`.

## What this adds

`scripts/rehearse-migrations.sh` (also `bun run rehearse:migrations`) dumps a source database, restores it into a throwaway container, applies whatever the source's ledger does not already list — in version order, each in its own transaction, stopping at the first failure the way the CLI does — then diffs the schema and the full RLS policy set and reports a verdict. **The source is only ever read from.**

```
scripts/rehearse-migrations.sh --source local --forget 20240101000000
```

`--forget` deletes a version from the *scratch copy's* ledger, so the run treats it as pending. That is how production's situation — has the tables, never recorded the migration that creates them — becomes reproducible without production credentials:

```
FAIL  20240101000000_baseline_schema.sql
    ERROR:  relation "profiles" already exists
0 applied, stopped at 20240101000000_baseline_schema.sql
```

**Zero migrations apply.** Not the FK change, not `20260811000000`. The deploy dies on the first statement, so nothing lands half-applied — but nothing lands at all.

## What this does not settle

The other nine still need a real `--source prod` run. Production lacks their objects and the dev database has them, so rehearsing those locally measures idempotency rather than applicability. The 47 policy drop-and-recreates are the quiet risk — if production's RLS has diverged, they would be replaced silently, and the policy diff is there to show exactly that.

## Options once someone runs it against prod

1. `supabase migration repair --status applied 20240101000000` — tells the ledger it is already there. Standard for baselining an existing database, but it assumes prod's schema already matches what the baseline describes, which is the thing to verify.
2. Add `IF NOT EXISTS` to the ten unguarded tables — fixes the abort, does nothing about the policies.

## Verification

Clean run exits 0, failing run exits 1, no container left behind. Two bugs worth knowing about are documented in the script: `pg_dump` must run inside the container (client/server major must match), and readiness must be a TCP probe — this image's entrypoint runs a throwaway init-phase server on the unix socket only, and a socket probe passes against *that*, so the restore gets killed partway with "the database system is shutting down". That one cost the first three runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)