### PR TITLE
Add sitemap.xml generation and robots.txt for SEO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ SUPABASE_DB_PASS=DUMMY_PASSWORD
 # Pooler region; only set if your project is not in us-east-1.
 SUPABASE_DB_REGION=aws-0-us-east-1
 
+# Canonical public origin, used for the absolute <loc> URLs in /sitemap.xml.
+# Optional: when unset the sitemap falls back to the request's own scheme and
+# Host, which is what local development wants. Set it in production, where the
+# app sits behind a TLS-terminating proxy and req.protocol reads as http.
+SITE_URL=https://agent-resources.vip
+
 # OpenAI API key. Parsing user provided text into game classes,
 # characters, and missions will not work without a key.
 OPENAI_API_KEY=sk-proj-DUMMYKEY

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,8 @@ SUPABASE_DB_PASS=DUMMY_PASSWORD
 SUPABASE_DB_REGION=aws-0-us-east-1
 
 # Canonical public origin, used for the absolute <loc> URLs in /sitemap.xml.
-# Optional: when unset the sitemap falls back to the request's own scheme and
-# Host, which is what local development wants. Set it in production, where the
-# app sits behind a TLS-terminating proxy and req.protocol reads as http.
+# Optional: unset, the sitemap falls back to the request's own scheme and Host.
+# Set it in production, where TLS terminates at a proxy and the app sees http.
 SITE_URL=https://agent-resources.vip
 
 # OpenAI API key. Parsing user provided text into game classes,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ and `bun run setup` handles the full DB bootstrap.
      **Project Settings → General**. Only needed if your project is not in
      `us-east-1`. `bun run scripts/probe-region.mjs` detects it.
 
-   Optional: `OPENAI_API_KEY` and any `SYSTEM_MESSAGE_*` settings.
+   Optional: `OPENAI_API_KEY`, `SITE_URL`, and any `SYSTEM_MESSAGE_*`
+   settings. `SITE_URL` is the canonical public origin (e.g.
+   `https://agent-resources.vip`) used for the absolute URLs in
+   `/sitemap.xml`; leave it unset in development and the sitemap uses the
+   request's own scheme and host.
 
 3. Run the setup script. It installs dependencies, applies all migrations
    in `supabase/migrations/`, and seeds the navigation table — safe to

--- a/app.js
+++ b/app.js
@@ -72,8 +72,8 @@ const createApp = () => {
     next();
   });
 
-  // Mounted before loadNavItems: the sitemap renders no layout, so it has no
-  // use for nav items and no reason to pay for the query.
+  // Before loadNavItems: the sitemap renders no layout, so it has no use for
+  // nav items and no reason to pay for the query.
   app.use('/', sitemapRoutes);
 
   app.use(loadNavItems);

--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ const badgesRoutes = require('./routes/badges');
 const pagesRoutes = require('./routes/pages');
 const navRoutes = require('./routes/nav');
 const agentRoutes = require('./routes/agent');
+const sitemapRoutes = require('./routes/sitemap');
 const botLinkRoutes = require('./routes/bot-link');
 const { loadNavItems } = require('./util/nav-loader');
 
@@ -70,6 +71,10 @@ const createApp = () => {
     res.locals.supabaseKey = process.env.SUPABASE_PUBLISHABLE_KEY;
     next();
   });
+
+  // Mounted before loadNavItems: the sitemap renders no layout, so it has no
+  // use for nav items and no reason to pay for the query.
+  app.use('/', sitemapRoutes);
 
   app.use(loadNavItems);
   app.use('/', homeRoutes);

--- a/models/sitemap.js
+++ b/models/sitemap.js
@@ -1,0 +1,82 @@
+const { supabase } = require('./_base');
+
+// Sitemap listings. Every query here runs on the anon singleton on purpose:
+// the sitemap is a public document, so the rows it can see should be exactly
+// the rows a signed-out visitor can see. The explicit is_public/is_published
+// filters below are belt-and-braces on top of RLS, and they double as the
+// definition of "crawlable" for anything RLS leaves readable but the routes
+// still gate (see canViewPage / canViewClass).
+
+// PostgREST caps a single response at 1000 rows, so every listing pages with
+// .range() until it runs dry or hits its cap. Ordering is by `id` rather than
+// recency: range pagination over a table that is being written to needs a
+// stable sort, or rows shift between pages and get skipped or duplicated.
+const PAGE_SIZE = 1000;
+
+const fetchAllRows = async (buildQuery, limit) => {
+  const rows = [];
+
+  for (let offset = 0; offset < limit; offset += PAGE_SIZE) {
+    const size = Math.min(PAGE_SIZE, limit - offset);
+    const { data, error } = await buildQuery().range(offset, offset + size - 1);
+    if (error) {
+      console.error(error);
+      return { data: null, error };
+    }
+    rows.push(...(data || []));
+    // A short page means the table is exhausted -- stop before spending a
+    // round trip on a range we know is empty.
+    if (!data || data.length < size) break;
+  }
+
+  return { data: rows, error: null };
+};
+
+// hide_from_search is honored here for the same reason models/character.js
+// honors it on the homepage feed and in search: opting a character out of
+// discovery has to mean opting it out of the sitemap too, which is the most
+// literal discovery surface there is.
+const listPublicCharacters = ({ limit }, client = supabase) => fetchAllRows(() => client
+  .from('characters')
+  .select('id, name, updated_at')
+  .eq('is_public', true)
+  .eq('hide_from_search', false)
+  .order('id', { ascending: true }), limit);
+
+const listPublicMissions = ({ limit }, client = supabase) => fetchAllRows(() => client
+  .from('missions')
+  .select('id, updated_at')
+  .eq('is_public', true)
+  .order('id', { ascending: true }), limit);
+
+const listPublicClasses = ({ limit }, client = supabase) => fetchAllRows(() => client
+  .from('classes')
+  .select('id, name, updated_at')
+  .eq('is_public', true)
+  .order('id', { ascending: true }), limit);
+
+// access_level 'authenticated' and 'admin' pages are excluded even though they
+// exist and are published: routes/pages.js gates them, so a crawler following
+// the URL would only ever get an error page.
+const listPublicPages = ({ limit }, client = supabase) => fetchAllRows(() => client
+  .from('pages')
+  .select('slug, updated_at')
+  .eq('is_published', true)
+  .eq('access_level', 'public')
+  .order('id', { ascending: true }), limit);
+
+// profiles has no updated_at column, so these entries carry no lastmod.
+const listPublicProfiles = ({ limit }, client = supabase) => fetchAllRows(() => client
+  .from('profiles')
+  .select('name')
+  .eq('is_public', true)
+  .order('id', { ascending: true }), limit);
+
+module.exports = {
+  PAGE_SIZE,
+  listPublicCharacters,
+  listPublicMissions,
+  listPublicClasses,
+  listPublicPages,
+  listPublicProfiles
+};

--- a/models/sitemap.js
+++ b/models/sitemap.js
@@ -1,16 +1,13 @@
 const { supabase } = require('./_base');
 
-// Sitemap listings. Every query here runs on the anon singleton on purpose:
-// the sitemap is a public document, so the rows it can see should be exactly
-// the rows a signed-out visitor can see. The explicit is_public/is_published
-// filters below are belt-and-braces on top of RLS, and they double as the
-// definition of "crawlable" for anything RLS leaves readable but the routes
-// still gate (see canViewPage / canViewClass).
+// Every query runs on the anon singleton on purpose: the sitemap is a public
+// document, so the rows it sees should be exactly the rows a signed-out visitor
+// sees. The explicit is_public/is_published filters are belt-and-braces on top
+// of RLS.
 
-// PostgREST caps a single response at 1000 rows, so every listing pages with
-// .range() until it runs dry or hits its cap. Ordering is by `id` rather than
-// recency: range pagination over a table that is being written to needs a
-// stable sort, or rows shift between pages and get skipped or duplicated.
+// PostgREST caps a response at 1000 rows, so listings page with .range().
+// Ordered by `id`, not recency: range pagination over a table being written to
+// needs a stable sort, or rows shift between pages and get skipped.
 const PAGE_SIZE = 1000;
 
 const fetchAllRows = async (buildQuery, limit) => {
@@ -24,18 +21,16 @@ const fetchAllRows = async (buildQuery, limit) => {
       return { data: null, error };
     }
     rows.push(...(data || []));
-    // A short page means the table is exhausted -- stop before spending a
-    // round trip on a range we know is empty.
+    // A short page means the table is exhausted.
     if (!data || data.length < size) break;
   }
 
   return { data: rows, error: null };
 };
 
-// hide_from_search is honored here for the same reason models/character.js
-// honors it on the homepage feed and in search: opting a character out of
-// discovery has to mean opting it out of the sitemap too, which is the most
-// literal discovery surface there is.
+// hide_from_search is honored for the same reason models/character.js honors it
+// in search and the homepage feed: opting out of discovery has to mean opting
+// out of the sitemap too.
 const listPublicCharacters = ({ limit }, client = supabase) => fetchAllRows(() => client
   .from('characters')
   .select('id, name, updated_at')
@@ -55,9 +50,8 @@ const listPublicClasses = ({ limit }, client = supabase) => fetchAllRows(() => c
   .eq('is_public', true)
   .order('id', { ascending: true }), limit);
 
-// access_level 'authenticated' and 'admin' pages are excluded even though they
-// exist and are published: routes/pages.js gates them, so a crawler following
-// the URL would only ever get an error page.
+// Published 'authenticated'/'admin' pages are excluded: routes/pages.js gates
+// them, so a crawler following the URL only gets an error page.
 const listPublicPages = ({ limit }, client = supabase) => fetchAllRows(() => client
   .from('pages')
   .select('slug, updated_at')

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,6 +12,12 @@
 #   * an HTMX fragment -- partial HTML with no layout, meaningless as a
 #     standalone search result.
 
+# Absolute by spec -- a Sitemap line cannot be relative. Hard-coded to the
+# canonical host because this file is static; the sitemap itself derives its
+# own <loc> origin from SITE_URL (see routes/sitemap.js), so a non-production
+# deployment still generates correct URLs for its own host.
+Sitemap: https://agent-resources.vip/sitemap.xml
+
 User-agent: *
 
 # Auth flow and machine endpoints.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,21 +1,8 @@
-# Agent Resources
-#
-# Public game content is welcome to be crawled: the home page, news, static
-# pages, classes, missions, character sheets, player profiles, LFG posts and
-# the rules library all render standalone for signed-out visitors.
-#
-# Everything disallowed below is one of:
-#   * sign-in gated (an anonymous crawler only ever gets a redirect to
-#     /auth/check, so crawling it is pure waste),
-#   * an admin screen,
-#   * a machine endpoint (/api/agent/*, exports), or
-#   * an HTMX fragment -- partial HTML with no layout, meaningless as a
-#     standalone search result.
+# Public game content is crawlable. Everything disallowed below is sign-in
+# gated, an admin screen, a machine endpoint, or an HTMX fragment.
 
-# Absolute by spec -- a Sitemap line cannot be relative. Hard-coded to the
-# canonical host because this file is static; the sitemap itself derives its
-# own <loc> origin from SITE_URL (see routes/sitemap.js), so a non-production
-# deployment still generates correct URLs for its own host.
+# Must be absolute; hard-coded because this file is static. The sitemap itself
+# derives its own origin per request (SITE_URL, see routes/sitemap.js).
 Sitemap: https://agent-resources.vip/sitemap.xml
 
 User-agent: *
@@ -25,8 +12,8 @@ Disallow: /auth/
 Disallow: /api/
 Disallow: /link/bot
 
-# Sign-in gated index pages. The detail pages beneath them stay crawlable
-# (e.g. /characters/:id, /missions/:id), so these are anchored with $.
+# Gated index pages, anchored with $ so their public detail pages
+# (/characters/:id, /missions/:id, /lfg/:id) stay crawlable.
 Disallow: /characters$
 Disallow: /missions$
 Disallow: /lfg$
@@ -46,7 +33,7 @@ Disallow: /pages/manage
 Disallow: /library/manage
 Disallow: /library/unlocks
 
-# Create/edit/import forms and destructive actions.
+# Forms and destructive actions.
 Disallow: /*/new
 Disallow: /*/edit
 Disallow: /*/import

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,68 @@
+# Agent Resources
+#
+# Public game content is welcome to be crawled: the home page, news, static
+# pages, classes, missions, character sheets, player profiles, LFG posts and
+# the rules library all render standalone for signed-out visitors.
+#
+# Everything disallowed below is one of:
+#   * sign-in gated (an anonymous crawler only ever gets a redirect to
+#     /auth/check, so crawling it is pure waste),
+#   * an admin screen,
+#   * a machine endpoint (/api/agent/*, exports), or
+#   * an HTMX fragment -- partial HTML with no layout, meaningless as a
+#     standalone search result.
+
+User-agent: *
+
+# Auth flow and machine endpoints.
+Disallow: /auth/
+Disallow: /api/
+Disallow: /link/bot
+
+# Sign-in gated index pages. The detail pages beneath them stay crawlable
+# (e.g. /characters/:id, /missions/:id), so these are anchored with $.
+Disallow: /characters$
+Disallow: /missions$
+Disallow: /lfg$
+Disallow: /profile$
+Disallow: /classes/my
+
+# Per-user areas. /profile/view/:name is the public player profile.
+Disallow: /profile/
+Allow: /profile/view/
+Disallow: /lfg/tab/
+Disallow: /lfg/events/
+
+# Admin screens.
+Disallow: /badges/
+Disallow: /nav/
+Disallow: /pages/manage
+Disallow: /library/manage
+Disallow: /library/unlocks
+
+# Create/edit/import forms and destructive actions.
+Disallow: /*/new
+Disallow: /*/edit
+Disallow: /*/import
+Disallow: /*/export
+Disallow: /*/join
+Disallow: /*/requests
+Disallow: /characters/wizard
+Disallow: /classes/redeem
+
+# Search endpoints and HTMX fragments.
+Disallow: /*/search
+Disallow: /*/s$
+Disallow: /*/similar
+Disallow: /party/panel
+Disallow: /characters/class-gear
+Disallow: /characters/class-abilities
+Disallow: /characters/common-item
+Disallow: /characters/quirk
+Disallow: /characters/accessory
+Disallow: /characters/ability-perk
+Disallow: /characters/version-fields
+Disallow: /characters/*/auto-calc-fields
+Disallow: /characters/*/details
+Disallow: /missions/*/editors
+Disallow: /missions/*/merge

--- a/routes/sitemap.js
+++ b/routes/sitemap.js
@@ -3,11 +3,9 @@ const router = express.Router();
 const { asyncHandler } = require('../util/async-handler');
 const { getSitemapXml } = require('../services/sitemap/build');
 
-// <loc> has to be an absolute URL, so the document needs to know its own
-// origin. SITE_URL is authoritative when set (the Host header is client
-// controlled, and behind a TLS-terminating proxy req.protocol reads as http);
-// the request-derived fallback is what makes this work in local dev, where
-// nobody has a SITE_URL configured.
+// <loc> must be absolute, so the document needs its own origin. SITE_URL wins
+// when set (Host is client controlled, and behind a TLS-terminating proxy
+// req.protocol reads as http); the fallback is what makes local dev work.
 const resolveBaseUrl = (req) => {
   const configured = (process.env.SITE_URL || '').trim();
   if (configured) return configured.replace(/\/+$/, '');
@@ -20,8 +18,8 @@ router.get('/sitemap.xml', asyncHandler(async (req, res) => {
   const { xml, failures } = await getSitemapXml({ baseUrl: resolveBaseUrl(req) });
 
   res.set('Content-Type', 'application/xml; charset=utf-8');
-  // A degraded document is served but marked short-lived, so crawlers and any
-  // CDN in front of us come back for the complete one soon.
+  // A degraded document is marked short-lived so crawlers and any CDN in front
+  // of us come back for the complete one soon.
   res.set('Cache-Control', failures.length === 0 ? 'public, max-age=900' : 'public, max-age=60');
   return res.send(xml);
 }));

--- a/routes/sitemap.js
+++ b/routes/sitemap.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+const { asyncHandler } = require('../util/async-handler');
+const { getSitemapXml } = require('../services/sitemap/build');
+
+// <loc> has to be an absolute URL, so the document needs to know its own
+// origin. SITE_URL is authoritative when set (the Host header is client
+// controlled, and behind a TLS-terminating proxy req.protocol reads as http);
+// the request-derived fallback is what makes this work in local dev, where
+// nobody has a SITE_URL configured.
+const resolveBaseUrl = (req) => {
+  const configured = (process.env.SITE_URL || '').trim();
+  if (configured) return configured.replace(/\/+$/, '');
+
+  const forwarded = String(req.get('x-forwarded-proto') || '').split(',')[0].trim();
+  return `${forwarded || req.protocol}://${req.get('host')}`;
+};
+
+router.get('/sitemap.xml', asyncHandler(async (req, res) => {
+  const { xml, failures } = await getSitemapXml({ baseUrl: resolveBaseUrl(req) });
+
+  res.set('Content-Type', 'application/xml; charset=utf-8');
+  // A degraded document is served but marked short-lived, so crawlers and any
+  // CDN in front of us come back for the complete one soon.
+  res.set('Cache-Control', failures.length === 0 ? 'public, max-age=900' : 'public, max-age=60');
+  return res.send(xml);
+}));
+
+module.exports = router;

--- a/routes/sitemap.test.js
+++ b/routes/sitemap.test.js
@@ -1,0 +1,128 @@
+// routes/sitemap.test.js
+//
+// Covers the part of the sitemap that lives in the route rather than the
+// builder: how the document learns its own origin, and what it tells caches.
+//
+// Origin matters more than it looks. <loc> must be absolute, and a sitemap
+// whose URLs point at the wrong scheme or host is worse than no sitemap --
+// every URL in it is unreachable or cross-host, and crawlers reject it. In
+// production the app sits behind a TLS-terminating proxy, so req.protocol
+// reads as http and only SITE_URL (or X-Forwarded-Proto) knows better.
+const { test, expect, mock, beforeAll, afterAll, beforeEach } = require('bun:test');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const realSitemapModel = require('../models/sitemap');
+
+// Mutable test state: the route exercises the real service and the real
+// builder, and only the database layer is stubbed.
+let missionRows = [];
+let missionError = null;
+
+mock.module('../models/sitemap', () => ({
+  listPublicCharacters: async () => ({ data: [], error: null }),
+  listPublicMissions: async () => (missionError
+    ? { data: null, error: missionError }
+    : { data: missionRows, error: null }),
+  listPublicClasses: async () => ({ data: [], error: null }),
+  listPublicPages: async () => ({ data: [], error: null }),
+  listPublicProfiles: async () => ({ data: [], error: null })
+}));
+
+const express = require('express');
+const { startHttpServer, stopHttpServer } = require('../test/helpers/http-server');
+
+let server;
+let baseUrl;
+let clearSitemapCache;
+const originalSiteUrl = process.env.SITE_URL;
+
+beforeAll(async () => {
+  delete require.cache[require.resolve('../services/sitemap/build')];
+  delete require.cache[require.resolve('./sitemap')];
+  ({ clearSitemapCache } = require('../services/sitemap/build'));
+
+  const app = express();
+  app.use('/', require('./sitemap'));
+  ({ server, baseUrl } = await startHttpServer(app));
+});
+
+afterAll(async () => {
+  await stopHttpServer(server);
+  mock.module('../models/sitemap', () => realSitemapModel);
+  delete require.cache[require.resolve('../services/sitemap/build')];
+  delete require.cache[require.resolve('./sitemap')];
+  if (originalSiteUrl === undefined) delete process.env.SITE_URL;
+  else process.env.SITE_URL = originalSiteUrl;
+});
+
+beforeEach(() => {
+  clearSitemapCache();
+  delete process.env.SITE_URL;
+  missionRows = [{ id: 'mission-1', updated_at: '2026-05-02T00:00:00.000Z' }];
+  missionError = null;
+});
+
+test('serves an XML sitemap', async () => {
+  const res = await fetch(`${baseUrl}/sitemap.xml`);
+  const body = await res.text();
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toBe('application/xml; charset=utf-8');
+  expect(res.headers.get('cache-control')).toBe('public, max-age=900');
+  expect(body).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+  expect(body).toContain('/missions/mission-1</loc>');
+});
+
+test('falls back to the request scheme and host when SITE_URL is unset', async () => {
+  const res = await fetch(`${baseUrl}/sitemap.xml`);
+  const body = await res.text();
+
+  expect(body).toContain(`<loc>${baseUrl}/</loc>`);
+  expect(body).toContain(`<loc>${baseUrl}/missions/mission-1</loc>`);
+});
+
+test('SITE_URL wins over the request, and its trailing slash is trimmed', async () => {
+  process.env.SITE_URL = 'https://agent-resources.vip/';
+
+  const res = await fetch(`${baseUrl}/sitemap.xml`);
+  const body = await res.text();
+
+  expect(body).toContain('<loc>https://agent-resources.vip/</loc>');
+  expect(body).toContain('<loc>https://agent-resources.vip/missions/mission-1</loc>');
+  expect(body).not.toContain(baseUrl);
+});
+
+// Behind a TLS-terminating proxy the app itself speaks http, so without this
+// every <loc> would advertise http:// for an https-only site.
+test('honors X-Forwarded-Proto when SITE_URL is unset', async () => {
+  const res = await fetch(`${baseUrl}/sitemap.xml`, {
+    headers: { 'X-Forwarded-Proto': 'https, http' }
+  });
+  const body = await res.text();
+
+  expect(body).toContain(`<loc>https://${new URL(baseUrl).host}/</loc>`);
+});
+
+test('a degraded document is still served, but marked short-lived', async () => {
+  missionError = new Error('missions table unreachable');
+
+  const res = await fetch(`${baseUrl}/sitemap.xml`);
+  const body = await res.text();
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('cache-control')).toBe('public, max-age=60');
+  // The sections that worked are still in the document...
+  expect(body).toContain('<loc>');
+  // ...and the failed one contributed nothing.
+  expect(body).not.toContain('/missions/');
+
+  // Nothing partial was cached: once the table recovers, the very next request
+  // serves the complete document rather than waiting out a 15-minute TTL.
+  missionError = null;
+  const recovered = await fetch(`${baseUrl}/sitemap.xml`);
+  expect(recovered.headers.get('cache-control')).toBe('public, max-age=900');
+  expect(await recovered.text()).toContain('/missions/mission-1</loc>');
+});

--- a/routes/sitemap.test.js
+++ b/routes/sitemap.test.js
@@ -1,13 +1,6 @@
-// routes/sitemap.test.js
-//
-// Covers the part of the sitemap that lives in the route rather than the
-// builder: how the document learns its own origin, and what it tells caches.
-//
-// Origin matters more than it looks. <loc> must be absolute, and a sitemap
-// whose URLs point at the wrong scheme or host is worse than no sitemap --
-// every URL in it is unreachable or cross-host, and crawlers reject it. In
-// production the app sits behind a TLS-terminating proxy, so req.protocol
-// reads as http and only SITE_URL (or X-Forwarded-Proto) knows better.
+// Covers what lives in the route rather than the builder: how the document
+// learns its own origin, and what it tells caches. A sitemap whose URLs carry
+// the wrong scheme or host is worse than no sitemap -- crawlers reject it.
 const { test, expect, mock, beforeAll, afterAll, beforeEach } = require('bun:test');
 
 process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
@@ -16,8 +9,7 @@ process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secre
 
 const realSitemapModel = require('../models/sitemap');
 
-// Mutable test state: the route exercises the real service and the real
-// builder, and only the database layer is stubbed.
+// Only the database layer is stubbed; the real route, service, and builder run.
 let missionRows = [];
 let missionError = null;
 
@@ -95,8 +87,8 @@ test('SITE_URL wins over the request, and its trailing slash is trimmed', async 
   expect(body).not.toContain(baseUrl);
 });
 
-// Behind a TLS-terminating proxy the app itself speaks http, so without this
-// every <loc> would advertise http:// for an https-only site.
+// The app itself speaks http behind the proxy, so without this every <loc>
+// would advertise http:// for an https-only site.
 test('honors X-Forwarded-Proto when SITE_URL is unset', async () => {
   const res = await fetch(`${baseUrl}/sitemap.xml`, {
     headers: { 'X-Forwarded-Proto': 'https, http' }
@@ -119,8 +111,8 @@ test('a degraded document is still served, but marked short-lived', async () => 
   // ...and the failed one contributed nothing.
   expect(body).not.toContain('/missions/');
 
-  // Nothing partial was cached: once the table recovers, the very next request
-  // serves the complete document rather than waiting out a 15-minute TTL.
+  // Nothing partial was cached, so recovery is immediate rather than waiting
+  // out the 15-minute TTL.
   missionError = null;
   const recovered = await fetch(`${baseUrl}/sitemap.xml`);
   expect(recovered.headers.get('cache-control')).toBe('public, max-age=900');

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -23,7 +23,8 @@ const httpFiles = new Set([
   'routes/missions.test.js',
   'routes/nav-manage-navbar.test.js',
   'routes/pages.test.js',
-  'routes/party.test.js'
+  'routes/party.test.js',
+  'routes/sitemap.test.js'
 ]);
 const mode = process.argv[2] || 'unit';
 

--- a/services/sitemap/build.js
+++ b/services/sitemap/build.js
@@ -1,0 +1,193 @@
+const {
+  listPublicCharacters,
+  listPublicMissions,
+  listPublicClasses,
+  listPublicPages,
+  listPublicProfiles
+} = require('../../models/sitemap');
+
+// sitemaps.org caps a single sitemap at 50,000 URLs. These per-section caps sum
+// to 40,000, which leaves headroom for the static list and for one section to
+// grow without silently pushing another out of a valid document. A section that
+// hits its cap is logged, never quietly truncated -- if one of these starts
+// firing, the fix is a sitemap index with one child document per section, not a
+// bigger number here.
+const LIMITS = {
+  characters: 10000,
+  missions: 10000,
+  classes: 5000,
+  pages: 5000,
+  profiles: 10000
+};
+
+// Routes that exist regardless of what is in the database. Auth-gated indexes
+// (/characters, /missions, /lfg, /profile) are deliberately absent: a crawler
+// only ever gets a redirect to /auth/check from them, which is also why
+// robots.txt disallows them.
+const STATIC_PATHS = [
+  '/',
+  '/news',
+  '/classes',
+  '/library',
+  '/party',
+  '/privacy',
+  '/terms',
+  '/contact'
+];
+
+const defaultDeps = {
+  listPublicCharacters,
+  listPublicMissions,
+  listPublicClasses,
+  listPublicPages,
+  listPublicProfiles
+};
+
+const escapeXml = (value) => String(value)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&apos;');
+
+// <lastmod> takes a W3C datetime. Anything unparseable is dropped rather than
+// emitted malformed: an entry with no lastmod is valid, one with a broken date
+// invalidates the document.
+const toLastmod = (value) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
+const segment = (value) => encodeURIComponent(String(value));
+
+// The routes accept /characters/:id and /classes/:id with the name segment
+// omitted, so a row with a blank name still gets a working URL.
+const named = (prefix, id, name) => (name && String(name).trim()
+  ? `${prefix}/${segment(id)}/${segment(name)}`
+  : `${prefix}/${segment(id)}`);
+
+const renderSitemap = (entries) => {
+  const urls = entries.map(({ loc, lastmod }) => (lastmod
+    ? `  <url>\n    <loc>${escapeXml(loc)}</loc>\n    <lastmod>${escapeXml(lastmod)}</lastmod>\n  </url>`
+    : `  <url>\n    <loc>${escapeXml(loc)}</loc>\n  </url>`));
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    '</urlset>',
+    ''
+  ].join('\n');
+};
+
+// One sick table should not blank the whole sitemap, so each section is
+// isolated the way the homepage isolates its feeds (services/home/sections.js).
+// The difference: a degraded sitemap is reported back to the caller in
+// `failures` so the route can decline to cache it and retry on the next hit.
+const collect = async (label, run, toEntries, failures) => {
+  try {
+    const { data, error } = await run();
+    if (error) {
+      console.error(`sitemap section "${label}" failed:`, error);
+      failures.push(label);
+      return [];
+    }
+    const rows = data || [];
+    if (rows.length >= LIMITS[label]) {
+      console.warn(`sitemap section "${label}" hit its ${LIMITS[label]}-URL cap; some URLs are omitted`);
+    }
+    return toEntries(rows);
+  } catch (err) {
+    console.error(`sitemap section "${label}" threw:`, err);
+    failures.push(label);
+    return [];
+  }
+};
+
+const buildSitemap = async ({ baseUrl }, deps = defaultDeps) => {
+  const root = String(baseUrl).replace(/\/+$/, '');
+  const url = (path) => `${root}${path}`;
+  const failures = [];
+
+  const [characters, missions, classes, pages, profiles] = await Promise.all([
+    collect('characters', () => deps.listPublicCharacters({ limit: LIMITS.characters }),
+      rows => rows.map(row => ({
+        loc: url(named('/characters', row.id, row.name)),
+        lastmod: toLastmod(row.updated_at)
+      })), failures),
+    collect('missions', () => deps.listPublicMissions({ limit: LIMITS.missions }),
+      rows => rows.map(row => ({
+        loc: url(`/missions/${segment(row.id)}`),
+        lastmod: toLastmod(row.updated_at)
+      })), failures),
+    collect('classes', () => deps.listPublicClasses({ limit: LIMITS.classes }),
+      rows => rows.map(row => ({
+        loc: url(named('/classes', row.id, row.name)),
+        lastmod: toLastmod(row.updated_at)
+      })), failures),
+    collect('pages', () => deps.listPublicPages({ limit: LIMITS.pages }),
+      rows => rows.filter(row => row.slug).map(row => ({
+        loc: url(`/pages/${segment(row.slug)}`),
+        lastmod: toLastmod(row.updated_at)
+      })), failures),
+    collect('profiles', () => deps.listPublicProfiles({ limit: LIMITS.profiles }),
+      // /profile/view/:name is looked up by name, so an unnamed profile has no
+      // reachable URL. profiles carries no updated_at, hence no lastmod.
+      rows => rows.filter(row => row.name).map(row => ({
+        loc: url(`/profile/view/${segment(row.name)}`)
+      })), failures)
+  ]);
+
+  const entries = [
+    ...STATIC_PATHS.map(path => ({ loc: url(path) })),
+    ...pages,
+    ...classes,
+    ...characters,
+    ...missions,
+    ...profiles
+  ];
+
+  return { xml: renderSitemap(entries), entries, failures };
+};
+
+// Building the document is five paginated table scans, and crawlers refetch
+// /sitemap.xml on their own schedule (sometimes several bots at once), so the
+// rendered XML is held briefly in memory. Fifteen minutes is well inside how
+// quickly any crawler acts on a lastmod change.
+//
+// A degraded document (one section's table was unreachable) is still worth
+// serving -- the URLs in it are correct -- but it is deliberately not cached,
+// or a transient blip freezes an incomplete sitemap in front of crawlers for
+// the next quarter hour.
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+let cache = null;
+
+const getSitemapXml = async ({ baseUrl }, deps = defaultDeps) => {
+  const now = Date.now();
+  if (cache && cache.baseUrl === baseUrl && cache.expiresAt > now) {
+    return { xml: cache.xml, failures: [], cached: true };
+  }
+
+  const { xml, failures } = await buildSitemap({ baseUrl }, deps);
+  cache = failures.length === 0 ? { baseUrl, xml, expiresAt: now + CACHE_TTL_MS } : null;
+
+  return { xml, failures, cached: false };
+};
+
+// Exported for tests; also the hook to reach for if content writes ever need
+// to invalidate the sitemap eagerly.
+const clearSitemapCache = () => { cache = null; };
+
+module.exports = {
+  buildSitemap,
+  getSitemapXml,
+  clearSitemapCache,
+  renderSitemap,
+  escapeXml,
+  toLastmod,
+  CACHE_TTL_MS,
+  LIMITS,
+  STATIC_PATHS
+};

--- a/services/sitemap/build.js
+++ b/services/sitemap/build.js
@@ -6,12 +6,9 @@ const {
   listPublicProfiles
 } = require('../../models/sitemap');
 
-// sitemaps.org caps a single sitemap at 50,000 URLs. These per-section caps sum
-// to 40,000, which leaves headroom for the static list and for one section to
-// grow without silently pushing another out of a valid document. A section that
-// hits its cap is logged, never quietly truncated -- if one of these starts
-// firing, the fix is a sitemap index with one child document per section, not a
-// bigger number here.
+// sitemaps.org caps a single sitemap at 50,000 URLs; these sum to 40,000. If a
+// section starts logging that it hit its cap, the fix is a sitemap index with a
+// child document per section, not a bigger number here.
 const LIMITS = {
   characters: 10000,
   missions: 10000,
@@ -20,10 +17,8 @@ const LIMITS = {
   profiles: 10000
 };
 
-// Routes that exist regardless of what is in the database. Auth-gated indexes
-// (/characters, /missions, /lfg, /profile) are deliberately absent: a crawler
-// only ever gets a redirect to /auth/check from them, which is also why
-// robots.txt disallows them.
+// Auth-gated indexes (/characters, /missions, /lfg, /profile) are absent on
+// purpose: a crawler only gets a redirect to /auth/check from them.
 const STATIC_PATHS = [
   '/',
   '/news',
@@ -50,9 +45,8 @@ const escapeXml = (value) => String(value)
   .replace(/"/g, '&quot;')
   .replace(/'/g, '&apos;');
 
-// <lastmod> takes a W3C datetime. Anything unparseable is dropped rather than
-// emitted malformed: an entry with no lastmod is valid, one with a broken date
-// invalidates the document.
+// An entry with no lastmod is valid; one with a malformed date invalidates the
+// whole document, so anything unparseable is dropped.
 const toLastmod = (value) => {
   if (!value) return null;
   const parsed = new Date(value);
@@ -61,8 +55,7 @@ const toLastmod = (value) => {
 
 const segment = (value) => encodeURIComponent(String(value));
 
-// The routes accept /characters/:id and /classes/:id with the name segment
-// omitted, so a row with a blank name still gets a working URL.
+// The name segment is optional in the routes, so a blank name still works.
 const named = (prefix, id, name) => (name && String(name).trim()
   ? `${prefix}/${segment(id)}/${segment(name)}`
   : `${prefix}/${segment(id)}`);
@@ -81,10 +74,9 @@ const renderSitemap = (entries) => {
   ].join('\n');
 };
 
-// One sick table should not blank the whole sitemap, so each section is
-// isolated the way the homepage isolates its feeds (services/home/sections.js).
-// The difference: a degraded sitemap is reported back to the caller in
-// `failures` so the route can decline to cache it and retry on the next hit.
+// Sections are isolated like the homepage feeds (services/home/sections.js), so
+// one sick table cannot blank the sitemap. Failures are reported back so the
+// caller can decline to cache a degraded document.
 const collect = async (label, run, toEntries, failures) => {
   try {
     const { data, error } = await run();
@@ -132,8 +124,8 @@ const buildSitemap = async ({ baseUrl }, deps = defaultDeps) => {
         lastmod: toLastmod(row.updated_at)
       })), failures),
     collect('profiles', () => deps.listPublicProfiles({ limit: LIMITS.profiles }),
-      // /profile/view/:name is looked up by name, so an unnamed profile has no
-      // reachable URL. profiles carries no updated_at, hence no lastmod.
+      // Looked up by name, so an unnamed profile has no reachable URL.
+      // profiles carries no updated_at, hence no lastmod.
       rows => rows.filter(row => row.name).map(row => ({
         loc: url(`/profile/view/${segment(row.name)}`)
       })), failures)
@@ -151,15 +143,10 @@ const buildSitemap = async ({ baseUrl }, deps = defaultDeps) => {
   return { xml: renderSitemap(entries), entries, failures };
 };
 
-// Building the document is five paginated table scans, and crawlers refetch
-// /sitemap.xml on their own schedule (sometimes several bots at once), so the
-// rendered XML is held briefly in memory. Fifteen minutes is well inside how
-// quickly any crawler acts on a lastmod change.
-//
-// A degraded document (one section's table was unreachable) is still worth
-// serving -- the URLs in it are correct -- but it is deliberately not cached,
-// or a transient blip freezes an incomplete sitemap in front of crawlers for
-// the next quarter hour.
+// The document costs five paginated table scans and crawlers refetch it on
+// their own schedule, so it is held briefly in memory. A degraded document is
+// not cached -- a transient blip should not freeze an incomplete sitemap in
+// front of crawlers for a quarter hour.
 const CACHE_TTL_MS = 15 * 60 * 1000;
 
 let cache = null;
@@ -176,8 +163,7 @@ const getSitemapXml = async ({ baseUrl }, deps = defaultDeps) => {
   return { xml, failures, cached: false };
 };
 
-// Exported for tests; also the hook to reach for if content writes ever need
-// to invalidate the sitemap eagerly.
+// Exported for tests, and for eager invalidation if content writes ever need it.
 const clearSitemapCache = () => { cache = null; };
 
 module.exports = {

--- a/services/sitemap/build.test.js
+++ b/services/sitemap/build.test.js
@@ -1,16 +1,7 @@
-// services/sitemap/build.test.js
-//
-// The sitemap is a document nobody on the team ever looks at directly -- a
-// crawler reads it, and a mistake shows up weeks later as pages missing from
-// (or wrongly present in) search results. So the things worth pinning down are
-// the ones with no visible failure mode:
-//
-//   * URLs match the routes the app actually serves (/characters/:id/:name,
-//     /classes/:id/:name, /missions/:id, /pages/:slug, /profile/view/:name).
-//   * Names and slugs are URL-encoded and then XML-escaped -- a character
-//     called "Nadia & Co" must not produce a malformed document.
-//   * A section whose table is unreachable degrades to empty and is reported,
-//     rather than 500ing the whole sitemap or being silently cached.
+// Nobody reads the sitemap directly -- a mistake shows up weeks later as pages
+// missing from search results. Covers the parts with no visible failure mode:
+// URLs matching the routes the app serves, encoding/escaping of user-supplied
+// names, and a failing section degrading rather than breaking the document.
 const { test, expect, beforeEach } = require('bun:test');
 const { JSDOM } = require('jsdom');
 
@@ -44,8 +35,7 @@ const emptyDeps = () => ({
 
 const locs = (xml) => [...xml.matchAll(/<loc>([^<]*)<\/loc>/g)].map(match => match[1]);
 
-// Parse as XML so escaping bugs surface as a parse error rather than as a
-// string comparison that happens to still pass.
+// Parse as XML so escaping bugs surface as a parse error.
 const { DOMParser } = new JSDOM('').window;
 const parse = (xml) => new DOMParser().parseFromString(xml, 'text/xml');
 
@@ -103,8 +93,8 @@ test('names are URL-encoded and XML-escaped', async () => {
   const doc = parse(xml);
   expect(doc.getElementsByTagName('parsererror').length).toBe(0);
 
-  // encodeURIComponent turns & into %26, so the escaped document carries no
-  // raw markup characters from user data at all.
+  // encodeURIComponent turns & into %26, so no raw markup from user data
+  // reaches the document at all.
   expect(xml).toContain(`${BASE}/characters/char-1/Nadia%20%26%20%22Rook%22%20%3Cthe%20Kid%3E`);
   expect(xml).toContain(`${BASE}/profile/view/a%20b%2Fc`);
 });
@@ -112,9 +102,8 @@ test('names are URL-encoded and XML-escaped', async () => {
 test('rows with no usable URL segment are dropped', async () => {
   const { xml } = await buildSitemap({ baseUrl: BASE }, {
     ...emptyDeps(),
-    // A blank name is fine for characters and classes -- the routes make the
-    // name segment optional -- but a page needs its slug and a profile is
-    // looked up by name, so those rows have no reachable URL.
+    // A blank name is fine for characters and classes (optional segment), but
+    // a page needs its slug and a profile is looked up by name.
     listPublicCharacters: ok([{ id: 'char-1', name: '   ', updated_at: null }]),
     listPublicPages: ok([{ slug: null, updated_at: null }, { slug: 'real', updated_at: null }]),
     listPublicProfiles: ok([{ name: '' }])
@@ -180,7 +169,7 @@ test('each section asks for its documented cap', async () => {
   });
 
   expect(asked).toEqual(LIMITS);
-  // The caps have to leave room for a single valid sitemap (50,000 URLs).
+  // Must leave room for a single valid sitemap (50,000 URLs).
   const total = Object.values(LIMITS).reduce((sum, value) => sum + value, 0);
   expect(total + STATIC_PATHS.length).toBeLessThanOrEqual(50000);
 });
@@ -202,7 +191,7 @@ test('a complete document is cached; a degraded one is not', async () => {
   expect(second.cached).toBe(true);
   expect(second.xml).toBe(first.xml);
 
-  // A different origin is a different document and must not reuse the cache.
+  // A different origin is a different document.
   const other = await getSitemapXml({ baseUrl: 'http://localhost:3000' }, counting());
   expect(calls).toBe(2);
   expect(other.cached).toBe(false);

--- a/services/sitemap/build.test.js
+++ b/services/sitemap/build.test.js
@@ -1,0 +1,240 @@
+// services/sitemap/build.test.js
+//
+// The sitemap is a document nobody on the team ever looks at directly -- a
+// crawler reads it, and a mistake shows up weeks later as pages missing from
+// (or wrongly present in) search results. So the things worth pinning down are
+// the ones with no visible failure mode:
+//
+//   * URLs match the routes the app actually serves (/characters/:id/:name,
+//     /classes/:id/:name, /missions/:id, /pages/:slug, /profile/view/:name).
+//   * Names and slugs are URL-encoded and then XML-escaped -- a character
+//     called "Nadia & Co" must not produce a malformed document.
+//   * A section whose table is unreachable degrades to empty and is reported,
+//     rather than 500ing the whole sitemap or being silently cached.
+const { test, expect, beforeEach } = require('bun:test');
+const { JSDOM } = require('jsdom');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || 'test-publishable-key';
+process.env.SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY || 'test-secret-key';
+
+const {
+  buildSitemap,
+  getSitemapXml,
+  clearSitemapCache,
+  renderSitemap,
+  toLastmod,
+  LIMITS,
+  STATIC_PATHS
+} = require('./build');
+
+const BASE = 'https://agent-resources.vip';
+
+const ok = (rows) => async () => ({ data: rows, error: null });
+const fails = (message) => async () => ({ data: null, error: new Error(message) });
+const throws = (message) => async () => { throw new Error(message); };
+
+const emptyDeps = () => ({
+  listPublicCharacters: ok([]),
+  listPublicMissions: ok([]),
+  listPublicClasses: ok([]),
+  listPublicPages: ok([]),
+  listPublicProfiles: ok([])
+});
+
+const locs = (xml) => [...xml.matchAll(/<loc>([^<]*)<\/loc>/g)].map(match => match[1]);
+
+// Parse as XML so escaping bugs surface as a parse error rather than as a
+// string comparison that happens to still pass.
+const { DOMParser } = new JSDOM('').window;
+const parse = (xml) => new DOMParser().parseFromString(xml, 'text/xml');
+
+beforeEach(() => clearSitemapCache());
+
+test('emits a valid urlset containing the static routes', async () => {
+  const { xml } = await buildSitemap({ baseUrl: BASE }, emptyDeps());
+
+  expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n')).toBe(true);
+  expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+
+  const doc = parse(xml);
+  expect(doc.getElementsByTagName('parsererror').length).toBe(0);
+  expect(doc.getElementsByTagName('url').length).toBe(STATIC_PATHS.length);
+
+  for (const path of STATIC_PATHS) {
+    expect(locs(xml)).toContain(`${BASE}${path}`);
+  }
+});
+
+test('builds content URLs in the shapes the routes serve', async () => {
+  const { xml } = await buildSitemap({ baseUrl: BASE }, {
+    ...emptyDeps(),
+    listPublicCharacters: ok([{ id: 'char-1', name: 'Nadia', updated_at: '2026-05-01T00:00:00.000Z' }]),
+    listPublicMissions: ok([{ id: 'mission-1', updated_at: '2026-05-02T00:00:00.000Z' }]),
+    listPublicClasses: ok([{ id: 'class-1', name: 'Vanguard', updated_at: '2026-05-03T00:00:00.000Z' }]),
+    listPublicPages: ok([{ slug: 'changelog-advent-v1-v2', updated_at: '2026-05-04T00:00:00.000Z' }]),
+    listPublicProfiles: ok([{ name: 'dtorres' }])
+  });
+
+  expect(locs(xml)).toEqual([
+    ...STATIC_PATHS.map(path => `${BASE}${path}`),
+    `${BASE}/pages/changelog-advent-v1-v2`,
+    `${BASE}/classes/class-1/Vanguard`,
+    `${BASE}/characters/char-1/Nadia`,
+    `${BASE}/missions/mission-1`,
+    `${BASE}/profile/view/dtorres`
+  ]);
+});
+
+test('a trailing slash on the base URL does not double up', async () => {
+  const { xml } = await buildSitemap({ baseUrl: `${BASE}/` }, emptyDeps());
+
+  expect(locs(xml)).toContain(`${BASE}/`);
+  expect(xml).not.toContain('//privacy');
+});
+
+test('names are URL-encoded and XML-escaped', async () => {
+  const { xml } = await buildSitemap({ baseUrl: BASE }, {
+    ...emptyDeps(),
+    listPublicCharacters: ok([{ id: 'char-1', name: 'Nadia & "Rook" <the Kid>', updated_at: null }]),
+    listPublicProfiles: ok([{ name: 'a b/c' }])
+  });
+
+  const doc = parse(xml);
+  expect(doc.getElementsByTagName('parsererror').length).toBe(0);
+
+  // encodeURIComponent turns & into %26, so the escaped document carries no
+  // raw markup characters from user data at all.
+  expect(xml).toContain(`${BASE}/characters/char-1/Nadia%20%26%20%22Rook%22%20%3Cthe%20Kid%3E`);
+  expect(xml).toContain(`${BASE}/profile/view/a%20b%2Fc`);
+});
+
+test('rows with no usable URL segment are dropped', async () => {
+  const { xml } = await buildSitemap({ baseUrl: BASE }, {
+    ...emptyDeps(),
+    // A blank name is fine for characters and classes -- the routes make the
+    // name segment optional -- but a page needs its slug and a profile is
+    // looked up by name, so those rows have no reachable URL.
+    listPublicCharacters: ok([{ id: 'char-1', name: '   ', updated_at: null }]),
+    listPublicPages: ok([{ slug: null, updated_at: null }, { slug: 'real', updated_at: null }]),
+    listPublicProfiles: ok([{ name: '' }])
+  });
+
+  const urls = locs(xml);
+  expect(urls).toContain(`${BASE}/characters/char-1`);
+  expect(urls).toContain(`${BASE}/pages/real`);
+  expect(urls.some(url => url.includes('/profile/view/'))).toBe(false);
+  expect(urls.length).toBe(STATIC_PATHS.length + 2);
+});
+
+test('lastmod is emitted as a W3C datetime, and omitted when unusable', async () => {
+  const { xml } = await buildSitemap({ baseUrl: BASE }, {
+    ...emptyDeps(),
+    listPublicMissions: ok([
+      { id: 'good', updated_at: '2026-05-02T03:04:05+00:00' },
+      { id: 'bad', updated_at: 'not a date' },
+      { id: 'missing', updated_at: null }
+    ])
+  });
+
+  expect(xml).toContain('<loc>https://agent-resources.vip/missions/good</loc>\n    <lastmod>2026-05-02T03:04:05.000Z</lastmod>');
+  expect(xml).toContain('<loc>https://agent-resources.vip/missions/bad</loc>\n  </url>');
+  expect(xml).toContain('<loc>https://agent-resources.vip/missions/missing</loc>\n  </url>');
+  expect([...xml.matchAll(/<lastmod>/g)].length).toBe(1);
+});
+
+test('toLastmod rejects unparseable input rather than emitting it', () => {
+  expect(toLastmod('2026-05-02T03:04:05Z')).toBe('2026-05-02T03:04:05.000Z');
+  expect(toLastmod('not a date')).toBe(null);
+  expect(toLastmod(null)).toBe(null);
+  expect(toLastmod('')).toBe(null);
+});
+
+test('a failing section degrades to empty and is reported', async () => {
+  const { xml, failures } = await buildSitemap({ baseUrl: BASE }, {
+    ...emptyDeps(),
+    listPublicCharacters: fails('characters table exploded'),
+    listPublicMissions: throws('connection reset'),
+    listPublicPages: ok([{ slug: 'still-here', updated_at: null }])
+  });
+
+  expect(failures.sort()).toEqual(['characters', 'missions']);
+  // The sections that worked still ship.
+  expect(locs(xml)).toContain(`${BASE}/pages/still-here`);
+  expect(parse(xml).getElementsByTagName('parsererror').length).toBe(0);
+});
+
+test('each section asks for its documented cap', async () => {
+  const asked = {};
+  const record = (label) => async ({ limit }) => {
+    asked[label] = limit;
+    return { data: [], error: null };
+  };
+
+  await buildSitemap({ baseUrl: BASE }, {
+    listPublicCharacters: record('characters'),
+    listPublicMissions: record('missions'),
+    listPublicClasses: record('classes'),
+    listPublicPages: record('pages'),
+    listPublicProfiles: record('profiles')
+  });
+
+  expect(asked).toEqual(LIMITS);
+  // The caps have to leave room for a single valid sitemap (50,000 URLs).
+  const total = Object.values(LIMITS).reduce((sum, value) => sum + value, 0);
+  expect(total + STATIC_PATHS.length).toBeLessThanOrEqual(50000);
+});
+
+test('a complete document is cached; a degraded one is not', async () => {
+  let calls = 0;
+  const counting = () => ({
+    ...emptyDeps(),
+    listPublicMissions: async () => {
+      calls += 1;
+      return { data: [{ id: `mission-${calls}`, updated_at: null }], error: null };
+    }
+  });
+
+  const first = await getSitemapXml({ baseUrl: BASE }, counting());
+  const second = await getSitemapXml({ baseUrl: BASE }, counting());
+
+  expect(calls).toBe(1);
+  expect(second.cached).toBe(true);
+  expect(second.xml).toBe(first.xml);
+
+  // A different origin is a different document and must not reuse the cache.
+  const other = await getSitemapXml({ baseUrl: 'http://localhost:3000' }, counting());
+  expect(calls).toBe(2);
+  expect(other.cached).toBe(false);
+  expect(other.xml).toContain('http://localhost:3000/');
+
+  clearSitemapCache();
+
+  let degradedCalls = 0;
+  const degraded = () => ({
+    ...emptyDeps(),
+    listPublicClasses: async () => {
+      degradedCalls += 1;
+      return { data: null, error: new Error('down') };
+    }
+  });
+
+  await getSitemapXml({ baseUrl: BASE }, degraded());
+  const retry = await getSitemapXml({ baseUrl: BASE }, degraded());
+
+  expect(degradedCalls).toBe(2);
+  expect(retry.cached).toBe(false);
+  expect(retry.failures).toEqual(['classes']);
+});
+
+test('renderSitemap produces one <url> per entry', () => {
+  const xml = renderSitemap([
+    { loc: 'https://example.test/a', lastmod: '2026-01-01T00:00:00.000Z' },
+    { loc: 'https://example.test/b' }
+  ]);
+
+  const doc = parse(xml);
+  expect(doc.getElementsByTagName('parsererror').length).toBe(0);
+  expect(doc.getElementsByTagName('url').length).toBe(2);
+  expect(doc.getElementsByTagName('lastmod').length).toBe(1);
+});

--- a/test/robots-txt.test.js
+++ b/test/robots-txt.test.js
@@ -1,20 +1,10 @@
-// test/robots-txt.test.js
+// public/robots.txt is a static file, so there is no handler to test -- but
+// getting it wrong is invisible until pages drop out of (or into) search
+// results. Checks that it is reachable and that its anchored/wildcard patterns
+// classify real paths correctly.
 //
-// public/robots.txt is a plain file served by the express.static mount in
-// app.js, so there is no route handler to test -- but the file itself is easy
-// to get subtly wrong in a way nobody notices until pages quietly drop out of
-// (or into) search results. Two things are worth pinning down:
-//
-//   1. It is actually reachable at /robots.txt. Crawlers only look there;
-//      a file that stops being served is indistinguishable from no rules.
-//   2. The rules classify paths the way we mean them to. The anchored and
-//      wildcard patterns are the fiddly part: "Disallow: /characters$" must
-//      keep the gated index out while leaving /characters/:id crawlable, and
-//      "Allow: /profile/view/" must win over "Disallow: /profile/".
-//
-// The matcher below implements the subset of the robots.txt spec our file
-// uses -- '*' wildcards, '$' end-anchors, and longest-match-wins between
-// Allow and Disallow -- which is what Googlebot and Bingbot both do.
+// The matcher implements the subset of the spec the file uses -- '*', '$', and
+// longest-match-wins between Allow and Disallow -- as Googlebot and Bingbot do.
 const { test, expect, beforeAll, afterAll } = require('bun:test');
 const express = require('express');
 const path = require('path');
@@ -93,14 +83,13 @@ test('serves a wildcard group that does not blanket-block the site', () => {
   const rules = parseRules(body);
 
   expect(rules.length).toBeGreaterThan(0);
-  // "Disallow: /" would deindex everything -- the one catastrophic typo here.
+  // The one catastrophic typo here: it would deindex everything.
   expect(rules.some(rule => !rule.allow && rule.pattern === '/')).toBe(false);
   expect(isAllowed(rules, '/')).toBe(true);
 });
 
-// A Sitemap line is host-global, not part of any user-agent group, and the
-// spec requires it to be absolute -- a relative path is silently ignored,
-// which looks exactly like having no sitemap at all.
+// A relative Sitemap line is silently ignored, which looks exactly like having
+// no sitemap at all.
 test('points crawlers at an absolute sitemap URL', () => {
   const sitemaps = body
     .split('\n')
@@ -130,8 +119,7 @@ test.each([
   ['/profile/view/nadia', true],
   ['/party', true],
 
-  // Sign-in gated indexes: blocked, without taking their detail pages with
-  // them (covered by the crawlable cases above).
+  // Gated indexes, blocked without taking their detail pages with them.
   ['/characters', false],
   ['/missions', false],
   ['/lfg', false],

--- a/test/robots-txt.test.js
+++ b/test/robots-txt.test.js
@@ -1,0 +1,152 @@
+// test/robots-txt.test.js
+//
+// public/robots.txt is a plain file served by the express.static mount in
+// app.js, so there is no route handler to test -- but the file itself is easy
+// to get subtly wrong in a way nobody notices until pages quietly drop out of
+// (or into) search results. Two things are worth pinning down:
+//
+//   1. It is actually reachable at /robots.txt. Crawlers only look there;
+//      a file that stops being served is indistinguishable from no rules.
+//   2. The rules classify paths the way we mean them to. The anchored and
+//      wildcard patterns are the fiddly part: "Disallow: /characters$" must
+//      keep the gated index out while leaving /characters/:id crawlable, and
+//      "Allow: /profile/view/" must win over "Disallow: /profile/".
+//
+// The matcher below implements the subset of the robots.txt spec our file
+// uses -- '*' wildcards, '$' end-anchors, and longest-match-wins between
+// Allow and Disallow -- which is what Googlebot and Bingbot both do.
+const { test, expect, beforeAll, afterAll } = require('bun:test');
+const express = require('express');
+const path = require('path');
+const { startHttpServer, stopHttpServer } = require('./helpers/http-server');
+
+let server;
+let baseUrl;
+let body;
+
+beforeAll(async () => {
+  const app = express();
+  // Mounted exactly as app.js:35 mounts it.
+  app.use(express.static(path.join(__dirname, '..', 'public')));
+  ({ server, baseUrl } = await startHttpServer(app));
+
+  const res = await fetch(`${baseUrl}/robots.txt`);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('text/plain');
+  body = await res.text();
+});
+
+afterAll(async () => {
+  await stopHttpServer(server);
+});
+
+// Rules for the wildcard user-agent, in file order.
+const parseRules = (text) => {
+  const rules = [];
+  let inWildcardGroup = false;
+
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.replace(/#.*$/, '').trim();
+    if (!line) continue;
+
+    const [field, ...rest] = line.split(':');
+    const value = rest.join(':').trim();
+    const name = field.trim().toLowerCase();
+
+    if (name === 'user-agent') {
+      inWildcardGroup = value === '*';
+    } else if (inWildcardGroup && (name === 'allow' || name === 'disallow')) {
+      rules.push({ allow: name === 'allow', pattern: value });
+    }
+  }
+
+  return rules;
+};
+
+const toRegExp = (pattern) => {
+  const anchored = pattern.endsWith('$');
+  const source = (anchored ? pattern.slice(0, -1) : pattern)
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*');
+  return new RegExp(`^${source}${anchored ? '$' : ''}`);
+};
+
+// Longest matching pattern wins; Allow wins ties. An empty Disallow value
+// means "allow everything" and never matches.
+const isAllowed = (rules, url) => {
+  let winner = null;
+
+  for (const rule of rules) {
+    if (!rule.pattern) continue;
+    if (!toRegExp(rule.pattern).test(url)) continue;
+    if (!winner
+      || rule.pattern.length > winner.pattern.length
+      || (rule.pattern.length === winner.pattern.length && rule.allow)) {
+      winner = rule;
+    }
+  }
+
+  return winner ? winner.allow : true;
+};
+
+test('serves a wildcard group that does not blanket-block the site', () => {
+  const rules = parseRules(body);
+
+  expect(rules.length).toBeGreaterThan(0);
+  // "Disallow: /" would deindex everything -- the one catastrophic typo here.
+  expect(rules.some(rule => !rule.allow && rule.pattern === '/')).toBe(false);
+  expect(isAllowed(rules, '/')).toBe(true);
+});
+
+test.each([
+  // Public content stays crawlable.
+  ['/', true],
+  ['/news', true],
+  ['/privacy', true],
+  ['/terms', true],
+  ['/contact', true],
+  ['/classes', true],
+  ['/classes/abc-123/pyrokinetic', true],
+  ['/characters/abc-123/nadia', true],
+  ['/missions/abc-123', true],
+  ['/lfg/abc-123', true],
+  ['/library', true],
+  ['/pages/some-slug', true],
+  ['/profile/view/nadia', true],
+  ['/party', true],
+
+  // Sign-in gated indexes: blocked, without taking their detail pages with
+  // them (covered by the crawlable cases above).
+  ['/characters', false],
+  ['/missions', false],
+  ['/lfg', false],
+  ['/profile', false],
+  ['/classes/my', false],
+
+  // Per-user, admin, and machine endpoints.
+  ['/auth/check', false],
+  ['/api/agent/me', false],
+  ['/link/bot', false],
+  ['/profile/edit', false],
+  ['/profile/agent-tokens', false],
+  ['/lfg/tab/my-posts', false],
+  ['/badges/manage', false],
+  ['/nav/manage', false],
+  ['/pages/manage', false],
+  ['/library/unlocks', false],
+
+  // Forms, exports, search endpoints, and HTMX fragments.
+  ['/characters/new', false],
+  ['/characters/wizard', false],
+  ['/characters/abc-123/edit', false],
+  ['/characters/abc-123/export', false],
+  ['/characters/class-gear', false],
+  ['/characters/s', false],
+  ['/missions/search', false],
+  ['/missions/s', false],
+  ['/party/s', false],
+  ['/party/panel', false],
+  ['/lfg/abc-123/join', false]
+])('%s is %s to crawlers', (url, allowed) => {
+  expect(isAllowed(parseRules(body), url)).toBe(allowed);
+});

--- a/test/robots-txt.test.js
+++ b/test/robots-txt.test.js
@@ -98,6 +98,21 @@ test('serves a wildcard group that does not blanket-block the site', () => {
   expect(isAllowed(rules, '/')).toBe(true);
 });
 
+// A Sitemap line is host-global, not part of any user-agent group, and the
+// spec requires it to be absolute -- a relative path is silently ignored,
+// which looks exactly like having no sitemap at all.
+test('points crawlers at an absolute sitemap URL', () => {
+  const sitemaps = body
+    .split('\n')
+    .map(line => line.replace(/#.*$/, '').trim())
+    .filter(line => /^sitemap:/i.test(line))
+    .map(line => line.slice(line.indexOf(':') + 1).trim());
+
+  expect(sitemaps.length).toBe(1);
+  expect(() => new URL(sitemaps[0])).not.toThrow();
+  expect(new URL(sitemaps[0]).pathname).toBe('/sitemap.xml');
+});
+
 test.each([
   // Public content stays crawlable.
   ['/', true],


### PR DESCRIPTION
## Summary

Implements XML sitemap generation and robots.txt rules to improve search engine crawlability. The sitemap dynamically lists all public content (characters, missions, classes, pages, profiles) with proper URL encoding and XML escaping. robots.txt gates crawlers away from auth-protected and admin endpoints while allowing access to public content. Both documents handle degraded states gracefully: the sitemap serves partial results if a data source fails, and robots.txt is a static file with absolute sitemap URL.

## Changes

**New files:**
- `services/sitemap/build.js` - Sitemap generation service with 15-minute caching for complete documents, short-lived caching (60s) for degraded ones
- `services/sitemap/build.test.js` - Comprehensive tests covering URL formatting, XML escaping, error handling, and caching behavior
- `models/sitemap.js` - Database queries for public content with pagination support
- `routes/sitemap.js` - Express route serving `/sitemap.xml` with origin detection (SITE_URL or request-derived)
- `public/robots.txt` - Crawler rules allowing public content, blocking auth-gated indexes and admin areas
- `test/robots-txt.test.js` - Tests verifying robots.txt rules and absolute sitemap URL
- `routes/sitemap.test.js` - Integration tests for the sitemap route, origin resolution, and cache headers

**Modified files:**
- `app.js` - Mount sitemap route
- `scripts/run-tests.mjs` - Add sitemap route tests to HTTP test suite
- `.env.example` - Document SITE_URL configuration
- `README.md` - Document SITE_URL setup

## Key design decisions

- **Graceful degradation**: If one data source fails (e.g., missions table unreachable), the sitemap still serves URLs from other sections and reports failures so the route can skip caching
- **Proper escaping**: User-provided names and slugs are URL-encoded then XML-escaped to prevent malformed documents
- **Caching strategy**: Complete sitemaps cached for 15 minutes; degraded ones cached for 60 seconds to allow quick recovery
- **Origin handling**: SITE_URL takes precedence (production), falls back to request scheme/host (dev), respects X-Forwarded-Proto (proxy)
- **Pagination**: Database queries page through results (1000 rows at a time) up to per-section caps that sum to 40,000 URLs, leaving headroom within the 50,000-URL sitemap limit

## Validation

- [x] `bun run check`
- [x] `bun run test`
- [x] `bun run test:http` (new routes/sitemap.test.js and test/robots-txt.test.js)
- [x] No database writes or migrations

## Database and risk

- [x] No migration required
- [x] No authorization or sensitive data concerns (sitemap lists only public content already visible to anonymous users)

https://claude.ai/code/session_017q5ktgMVQ6SPZ3UZJUag9Y